### PR TITLE
add functions to change R prompt when renv is active

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -26,6 +26,7 @@ renv_load_libpaths <- function(manifest) {
   Sys.setenv(R_LIBS_USER = paste(libpaths, collapse = .Platform$path.sep))
   .libPaths(libpaths)
 
+
 }
 
 renv_load_repos <- function(manifest) {
@@ -91,7 +92,15 @@ renv_load_finish <- function() {
   fmt <- "%s environment '%s' loaded. Using library paths:"
   messagef(fmt, if (local) "Local virtual" else "Virtual", basename(renv))
   message(paste("-", shQuote(paths), collapse = "\n"))
+}
 
+renv_load_prompt <- function(manifest) {
+  renv <- manifest$Environment$Environment
+  options(prompt = sprintf("%s > ", basename(renv)))
+}
+
+renv_reset_prompt <- function() {
+  options(prompt = "> ")
 }
 
 renv_load_project <- function(project) {
@@ -99,3 +108,5 @@ renv_load_project <- function(project) {
   renv_state$local(as.logical(activate$Local))
   activate$Environment
 }
+
+

--- a/R/renv.R
+++ b/R/renv.R
@@ -127,6 +127,7 @@ activate <- function(name = NULL, project = NULL, local = NULL) {
   # set library paths now so that they're properly restored in new sessions
   manifest <- renv_manifest_load(project)
   renv_load_libpaths(manifest)
+  renv_load_prompt(manifest)
 
   reason <- sprintf("Virtual environment '%s' activated", name)
   renv_request_restart(reason)
@@ -152,7 +153,7 @@ deactivate <- function(project = NULL) {
   name <- activate$Environment
   fmt <- "* Deactivating %s environment '%s' ..."
   vmessagef(fmt, if (renv_state$local()) "local virtual" else "virtual", name)
-
+  renv_reset_prompt()
   renv_request_restart("Virtual environment deactivated")
 }
 
@@ -188,7 +189,7 @@ load <- function(project = NULL) {
   renv_load_libpaths(spec)
   renv_load_repos(spec)
   renv_load_python(spec)
-
+  renv_load_prompt(spec)
   renv_load_finish()
 
   invisible(renv)


### PR DESCRIPTION
If an renv called "test" is activated, the R prompt is set to:

```
test >
```

If the  renv environment is deactivated, the R prompt is set back to:

```
>
```

Currently, this the existing prompt option is clobbered; this could perhaps be changed if we think it matters ... e.g. by saving the existing prompt to an environment variable and restoring the saved value instead of the default. I wanted to get feedback on the idea before doing that work. 