### PR TITLE
Updated renv_snapshot_validate_dependencies() to ensure that a logical result is returned

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments for R
-Version: 0.4.0-23
+Version: 0.4.0-24
 Author: Kevin Ushey
 Maintainer: Kevin Ushey <kevin@rstudio.com>
 Description: Use 'renv' to create and manage project-local R dependencies.

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -219,7 +219,7 @@ renv_snapshot_validate_dependencies <- function(project, lockfile, library, conf
   request  <- bad$Requested
 
   fmt <- "- %s requires %s, but %s will be snapshotted"
-  warning(sprintf(fmt, format(package), format(requires), format(request)))
+  warningf(fmt, format(package), format(requires), format(request))
 
   return(FALSE)
 }

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -219,7 +219,7 @@ renv_snapshot_validate_dependencies <- function(project, lockfile, library, conf
   request  <- bad$Requested
 
   fmt <- "- %s requires %s, but %s will be snapshotted"
-  sprintf(fmt, format(package), format(requires), format(request))
+  warning(sprintf(fmt, format(package), format(requires), format(request)))
 
   return(FALSE)
 }

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -221,6 +221,7 @@ renv_snapshot_validate_dependencies <- function(project, lockfile, library, conf
   fmt <- "- %s requires %s, but %s will be snapshotted"
   sprintf(fmt, format(package), format(requires), format(request))
 
+  return(FALSE)
 }
 
 renv_snapshot_validate_sources <- function(project, lockfile, library, confirm) {


### PR DESCRIPTION
Currently, `renv_snapshot_validate_dependencies()` can return either a logical, or a character array, if some problem is encountered.

The later results in a problem with [renv_snapshot_validate()](https://github.com/rstudio/renv/blob/master/R/snapshot.R#L133), however, when it attempts to evaluate the expression:

```r
  renv_snapshot_validate_dependencies(project, lockfile, library, confirm) &&
    renv_snapshot_validate_sources(project, lockfile, library, confirm)
```

With this change, any 'bad' packages detected will result in `renv_snapshot_validate_dependencies()` returning `FALSE`.