### PR TITLE
Add support for falling back to the default user cache if the envars-…

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -4,8 +4,8 @@ renv_cache_version <- function() {
   "v4"
 }
 
-renv_cache_package_path <- function(record, writable=FALSE) {
-
+renv_cache_package_path <- function(record, writable = FALSE) {
+  
   # validate required fields -- if any are missing, we can't use the cache
   required <- c("Package", "Version")
   missing <- renv_vector_diff(required, names(record))
@@ -28,7 +28,7 @@ renv_cache_package_path <- function(record, writable=FALSE) {
 
   # if the record doesn't have a hash, check to see if we can still locate a
   # compatible package version within the cache
-  root <- with(record, renv_paths_cache(Package, Version, version = version,writable = writable))
+  root <- with(record, renv_paths_cache(Package, Version, version = version, writable = writable))
   hashes <- list.files(root, full.names = TRUE)
   packages <- list.files(hashes, full.names = TRUE)
 

--- a/R/cache.R
+++ b/R/cache.R
@@ -4,7 +4,7 @@ renv_cache_version <- function() {
   "v4"
 }
 
-renv_cache_package_path <- function(record) {
+renv_cache_package_path <- function(record, writable=FALSE) {
 
   # validate required fields -- if any are missing, we can't use the cache
   required <- c("Package", "Version")
@@ -14,7 +14,7 @@ renv_cache_package_path <- function(record) {
 
   # if we have a hash, use it directly
   if (!is.null(record$Hash)) {
-    path <- with(record, renv_paths_cache(Package, Version, Hash, Package))
+    path <- with(record, renv_paths_cache(Package, Version, Hash, Package, writable = writable))
     return(path)
   }
 
@@ -28,7 +28,7 @@ renv_cache_package_path <- function(record) {
 
   # if the record doesn't have a hash, check to see if we can still locate a
   # compatible package version within the cache
-  root <- with(record, renv_paths_cache(Package, Version, version = version))
+  root <- with(record, renv_paths_cache(Package, Version, version = version,writable = writable))
   hashes <- list.files(root, full.names = TRUE)
   packages <- list.files(hashes, full.names = TRUE)
 
@@ -90,7 +90,7 @@ renv_cache_synchronize <- function(record, linkable = FALSE) {
   record$Hash <- record$Hash %||% renv_hash_description(path)
 
   # construct cache entry
-  cache <- renv_cache_package_path(record)
+  cache <- renv_cache_package_path(record, writable = TRUE)
   if (!nzchar(cache))
     return(FALSE)
 

--- a/R/install.R
+++ b/R/install.R
@@ -126,12 +126,8 @@ renv_install_impl <- function(record, project) {
   # figure out whether we can use the cache during install
   library <- renv_global_get("install.library") %||% renv_libpaths_default()
   linkable <-
-    settings$use.cache(project = project) && (
-      identical(library, renv_paths_library(project = project)) ||
-        # Support for packaged renv under inst
-        # Remove inst sub-folder from path
-      identical(sub("inst/","",library), renv_paths_library(project = project))
-    )
+    settings$use.cache(project = project) &&
+    identical(library, renv_paths_library(project = project))
 
   linker <- if (linkable) renv_file_link else renv_file_copy
 
@@ -144,11 +140,6 @@ renv_install_impl <- function(record, project) {
 
     # check for cache entry and install if there
     cache <- renv_cache_package_path(record)
-    if (file.exists(cache))
-      return(renv_install_package_cache(record, cache, linker))
-
-    # check for cache entry in the default location and install if there
-    cache <- renv_cache_package_path(record, writable = TRUE)
     if (file.exists(cache))
       return(renv_install_package_cache(record, cache, linker))
 

--- a/R/install.R
+++ b/R/install.R
@@ -142,6 +142,11 @@ renv_install_impl <- function(record, project) {
     cache <- renv_cache_package_path(record)
     if (file.exists(cache))
       return(renv_install_package_cache(record, cache, linker))
+    
+    # check for cache entry in the default location and install if there
+    cache <- renv_cache_package_path(record, writable = TRUE)
+    if (file.exists(cache))
+      return(renv_install_package_cache(record, cache, linker))
 
   }
 

--- a/R/paths.R
+++ b/R/paths.R
@@ -5,7 +5,7 @@ renv_prefix_platform <- function(version = NULL) {
   file.path(prefix, R.version$platform)
 }
 
-renv_paths_common <- function(name, prefixes = NULL, ...) {
+renv_paths_common <- function(name, prefixes = NULL,...,writable = FALSE) {
   # check for single absolute path supplied by user
   # TODO: handle multiple?
   end <- file.path(...)
@@ -14,8 +14,16 @@ renv_paths_common <- function(name, prefixes = NULL, ...) {
 
   # compute root path
   envvar <- paste("RENV_PATHS", toupper(name), sep = "_")
-  root <- Sys.getenv(envvar, unset = renv_paths_root(name))
-
+  # test if configured path is writable
+  root <- Sys.getenv(envvar)
+  if(root == ""){
+    root <- renv_paths_root(name)
+  }else{
+    if(writable && !assertthat::is.writeable(root)){
+      warning(paste0(root," folder not writable, use default ",name))
+      root <- renv_paths_root(name)
+    }
+  }
   # form rest of path
   prefixed <- if (length(prefixes))
     file.path(root, paste(prefixes, collapse = "/"))

--- a/R/paths.R
+++ b/R/paths.R
@@ -19,7 +19,8 @@ renv_paths_common <- function(name, prefixes = NULL,...,writable = FALSE) {
   if(root == ""){
     root <- renv_paths_root(name)
   }else{
-    if(writable && !assertthat::is.writeable(root)){
+    if(writable &&
+       file.access(root, mode = 2) != 0) {
       warning(paste0(root," folder not writable, use default ",name))
       root <- renv_paths_root(name)
     }

--- a/R/purge.R
+++ b/R/purge.R
@@ -56,7 +56,7 @@ renv_purge_impl <- function(package,
   }
 
   # get root cache path entry for package
-  paths <- renv_paths_cache(package)
+  paths <- renv_paths_cache(package,writable = TRUE)
   if (!file.exists(paths))
     return(bail())
 


### PR DESCRIPTION
…defined cache is not writable by the user. 

In our organization we have set a central and global cache for renv which is only writable by admins. The cache is defined to be the default for all users using the variable _RENV_PATHS_CACHE_.

These changes allow the developers to use their local cache when a package version is not already installed in the global cache.

I haven't extensively tested it but it works with the main functions, install/purge/restore/...


