### PR TITLE
fix issue when renv is a sym link pointing to folder within inst/ (wh…

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -126,8 +126,12 @@ renv_install_impl <- function(record, project) {
   # figure out whether we can use the cache during install
   library <- renv_global_get("install.library") %||% renv_libpaths_default()
   linkable <-
-    settings$use.cache(project = project) &&
-    identical(library, renv_paths_library(project = project))
+    settings$use.cache(project = project) && (
+      identical(library, renv_paths_library(project = project)) ||
+      # this enables renv in installed package
+      # Remove inst sub-folder from path
+      identical(sub("inst/","",library), renv_paths_library(project = project))
+    )
 
   linker <- if (linkable) renv_file_link else renv_file_copy
 
@@ -135,7 +139,7 @@ renv_install_impl <- function(record, project) {
     settings$use.cache(project = project) &&
     renv_record_cacheable(record) &&
     !renv_restore_rebuild_required(record)
-
+  
   if (cacheable) {
 
     # check for cache entry and install if there


### PR DESCRIPTION
…ich preserve renv when installing package)

To allow the use of renv within an installed package (especially useful for package with shiny apps),  I put _renv_ and _renv.lock_ under _inst/_ and add sym links to them in the root of the project. After installing the project, I just need to call _renv::restore()_ to have the dependencies installed (linked from the cache) within the installed package.

This change fixes a problem when you are developing the package (no problem after package installation).  The project was not detected as **linkable** because _library_ variable has the _inst/_ in the path and _renv_paths_library()_ not which makes the test fail.

