### PR TITLE
Fix typo

### DIFF
--- a/vignettes/docker.Rmd
+++ b/vignettes/docker.Rmd
@@ -69,7 +69,7 @@ way to accomplish this is with the `remotes` package. For example:
 
 ```
 ENV RENV_VERSION 0.5.0-25
-RUN R -e 'install.packages("remotes", repos = c(CRAN = "https://cloud.r-project.org"))
+RUN R -e 'install.packages("remotes", repos = c(CRAN = "https://cloud.r-project.org"))'
 RUN R -e 'remotes::install_github("rstudio/renv@${RENV_VERSION}")'
 ```
 


### PR DESCRIPTION
If do not close the parentheses, we will get the following error.

```
/bin/sh: 1: Syntax error: Unterminated quoted string
ERROR: Service 'rstudio' failed to build: The command '/bin/sh -c R -e 'install.packages("remotes", repos = c(CRAN = "https://cloud.r-project.org"))' returned a non-zero code: 2
```

Avoid errors by closing parentheses.

