### PR TITLE
Docker requires enclosing double-quotes to expand env vars in strings

### DIFF
--- a/vignettes/docker.Rmd
+++ b/vignettes/docker.Rmd
@@ -69,8 +69,8 @@ way to accomplish this is with the `remotes` package. For example:
 
 ```
 ENV RENV_VERSION 0.5.0-25
-RUN R -e 'install.packages("remotes", repos = c(CRAN = "https://cloud.r-project.org"))'
-RUN R -e 'remotes::install_github("rstudio/renv@${RENV_VERSION}")'
+RUN R -e "install.packages('remotes', repos = c(CRAN = 'https://cloud.r-project.org'))"
+RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"
 ```
 
 Now, `renv` can be used to install packages on the image. If you'd like the


### PR DESCRIPTION
Ran into this issue with Docker while attempting to follow the vignette. The `RENV_VERSION` specified with a Docker `ENV` statement will not expand inside the string passed to `RUN R -e` unless the string is enclosed in double-quotes (whereas the example used single quotes). I've changed both the `RUN R...` invocations in 71/72 to use enclosing double-quotes accordingly for consistency, though the problem is only with the `remotes::install_github()` line when actually run.

Cf. [this Docker/Moby issue](https://github.com/moby/moby/issues/9288) referencing this behavior:

> "To expand environment variables you need to use double quotes in RUN commands."

Thanks for the great package!