### PR TITLE
Feature/discover import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.9.2-27
+Version: 0.9.2-28
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio", role = c("cph"))

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -817,7 +817,7 @@ renv_dependencies_discover_r_import <- function(node, envir) {
     return(FALSE)
 
   # match a call to any function with a '.from' argument
-  prototype <- function(.from = "", ...) {}
+  prototype <- function(.from, ...) {}
   matched <- catch(match.call(prototype, node, expand.dots = FALSE))
   if (inherits(matched, "error"))
     return(FALSE)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -606,7 +606,8 @@ renv_dependencies_discover_r <- function(path = NULL, text = NULL) {
     renv_dependencies_discover_r_require_namespace,
     renv_dependencies_discover_r_colon,
     renv_dependencies_discover_r_pacman,
-    renv_dependencies_discover_r_modules
+    renv_dependencies_discover_r_modules,
+    renv_dependencies_discover_r_import
   )
 
   discoveries <- new.env(parent = emptyenv())
@@ -807,6 +808,30 @@ renv_dependencies_discover_r_modules <- function(node, envir) {
   envir[[as.character(package)]] <- TRUE
 
   TRUE
+}
+
+renv_dependencies_discover_r_import <- function(node, envir) {
+
+  node <- renv_call_expect(node, "import", c("from", "here", "into"))
+  if (is.null(node))
+    return(FALSE)
+
+  # match a call to any function with a '.from' argument
+  prototype <- function(.from = "", ...) {}
+  matched <- catch(match.call(prototype, node, expand.dots = FALSE))
+  if (inherits(matched, "error"))
+    return(FALSE)
+
+  # the '.from' argument is the package name, either a character vector of length one or a symbol
+  if ((is.character(matched$.from) && length(matched$.from) == 1)
+      || is.symbol(matched$.from))
+  {
+    envir[[as.character(matched$.from)]] <- TRUE
+    return(TRUE)
+  }
+
+  FALSE
+
 }
 
 renv_dependencies_list <- function(source,

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -816,8 +816,15 @@ renv_dependencies_discover_r_import <- function(node, envir) {
   if (is.null(node))
     return(FALSE)
 
-  # match a call to any function with a '.from' argument
-  prototype <- function(.from, ...) {}
+  # attempt to match the call
+  call_name <- as.character(node[[1L]])
+  if (call_name == "from") {
+    # a call to import::from must name the package and at least one object to import
+    prototype <- function(.from, object, ...) {}
+  } else {
+    # a call to import::here or import::into must name the .from argument
+    prototype <- function(..., .from) {}
+  }
   matched <- catch(match.call(prototype, node, expand.dots = FALSE))
   if (inherits(matched, "error"))
     return(FALSE)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -819,10 +819,10 @@ renv_dependencies_discover_r_import <- function(node, envir) {
   # attempt to match the call
   call_name <- as.character(node[[1L]])
   if (call_name == "from") {
-    # a call to import::from must name the package and at least one object to import
-    prototype <- function(.from, object, ...) {}
+    # a call to import::from must name the package as the first argument or as `.from`
+    prototype <- function(.from, ...) {}
   } else {
-    # a call to import::here or import::into must name the .from argument
+    # a call to import::here or import::into must provide the `.from` argument
     prototype <- function(..., .from) {}
   }
   matched <- catch(match.call(prototype, node, expand.dots = FALSE))

--- a/tests/testthat/resources/import.R
+++ b/tests/testthat/resources/import.R
@@ -1,0 +1,21 @@
+# Capture packages (a, b, ...), not functions or other objects (f1, f2, ...)
+# Do not capture packages in invalid calls (x1, x2, ...)
+
+# valid uses of import::from
+import::from(a, f1, f2, f3)
+import::from(f1, .from = b)
+
+# valid uses of import::here
+import::here(f1, f2, f3, .from = c)
+# invalid uses of import::here – should not infer a dependency
+import::here(f1, x2)  # no .from argument
+import::here(f1, f2, f3, x3)  # as above
+import::here(f1) # no package is specified
+
+# valid uses of import::into
+import::into(f1, f2, f3, .into = "imports::pkg", .from = d)
+import::into("imports::pkg", f1, f2, .from = e)
+# invalid uses of import::into
+import::into(f1, f2, x4, .into = "imports::pkg")  # no .from argument
+import::into(f1, x5)  # no .from or .into
+import::into(f1)  # no package specified at all

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -61,6 +61,12 @@ test_that("pacman::p_load() usages are understood", {
   expect_setequal(packages, letters[1:length(packages)])
 })
 
+test_that("import:: usages are understood", {
+  deps <- dependencies("resources/import.R")
+  packages <- setdiff(deps$Package, "import")
+  expect_setequal(packages, letters[1:length(packages)])
+})
+
 test_that("renv warns when large number of files found", {
 
   renv_tests_scope()


### PR DESCRIPTION
Been using renv and really liking it so far. I noticed that it doesn't have support for the `import` package (https://github.com/smbache/import) when discovering dependencies. I've put together a quick PR to enable that. Let me know if this is useful and I can write some tests too.