### PR TITLE
find website dependency in site yml field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # renv 0.9.0 (UNRELEASED)
 
+* `renv::dependencies()` can now parse R package dependencies used as custom
+  site generator in an Rmd yaml header. (#269, @cderv)
+
 * `renv` no longer sources the user profile (normally located at `~/.Rprofile`)
   by default. If you desire this behavior, you can opt-in by setting
   `RENV_CONFIG_USER_PROFILE = TRUE`; e.g. within your project or user

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -396,6 +396,15 @@ renv_dependencies_discover_rmd_yaml_header <- function(path) {
       deps$push(splat[[1]])
   }
 
+  # check for custom site generator function from another package
+  output <- yaml$site %||% ""
+
+  if (is_string(output)) {
+    splat <- strsplit(output, ":{2,3}")[[1]]
+    if (length(splat) == 2)
+      deps$push(splat[[1]])
+  }
+
   packages <- as.character(deps$data())
   renv_dependencies_list(path, packages)
 
@@ -764,7 +773,7 @@ renv_dependencies_discover_r_modules <- function(node, envir) {
   if (empty(package))
     return(FALSE)
 
-  # package could be symbols or character so call as.character 
+  # package could be symbols or character so call as.character
   # to be safe then mark packages as known
   envir[[as.character(package)]] <- TRUE
 

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -170,3 +170,17 @@ test_that("packages referenced by modules::import() are discovered", {
   expect_setequal(deps$Package, c("A", "B", "C", "D"))
 
 })
+
+test_that("Rmarkdown custom site generator is found as dependency", {
+  renv_tests_scope()
+  writeLines(
+    c("---", "site: blogdown:::blogdown_site", "---"),
+    con = "index.Rmd")
+  deps <- dependencies()
+  expect_true("blogdown" %in% deps$Package)
+  writeLines(
+    c("---", "site: bookdown::bookdown_site", "---"),
+    con = "index.Rmd")
+  deps <- dependencies()
+  expect_true("bookdown" %in% deps$Package)
+})


### PR DESCRIPTION
This fixes #269 by adding support for the `site` yaml field for `renv::dependencies`. 
This include test about finding non-exported function `blogdown:::blogdown_site` and exported function `bookdown::bookdown_site`

Technically you can pass a list with functions to site field but I am not sure anyone uses it. 
You can also add the yaml header in `index.md` file but I am not sure renv knows how to handle them. 
Anyway I think there could be very few people using renv and these non standard way so I left that out. 