### PR TITLE
Continue if 4xx returned during HEAD request for URL download

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -116,7 +116,12 @@ renv_download_impl <- function(url, destfile, type = NULL, request = "GET", head
     renv_download_default
   )
 
-  catch(downloader(url, destfile, type, request, headers))
+  exit_code = catch(downloader(url, destfile, type, request, headers))
+
+  if (request == "HEAD" && exit_code == 22)
+    unlink(destfile, recursive = TRUE, force = TRUE)
+
+  exit_code
 
 }
 


### PR DESCRIPTION
When retrieving a package using Source == URL, some packages will fail with "Error: download failed [file was truncated]." The root cause is a 403 forbidden returned by the initial HEAD request to get the file size. This in turn happens because some sites, including GitHub's service on AWS, don't allow HEAD requests.

Because other failure modes are already handled in the code path, the proposed change here simply treats a 4xx error as a failed HEAD fetch (no output returned). This causes the renv::restore() command to emit a warning about the 403 status, but still successfully install the package.

See this same issue in a different software tool at https://github.com/cavaliercoder/grab/issues/43

renv.lock contents to reproduce:
```
{
  "R": {
    "Version": "3.6.3",
    "Repositories": [
      {
        "Name": "CRAN",
        "URL": "https://cloud.r-project.org"
      }
    ]
  },
  "Packages": {
    "JGR": {
      "Package": "JGR",
      "Version": "1.9-1",
      "Source": "URL",
      "RemoteType": "url",
      "RemoteUrl": "https://github.com/markush81/JGR/releases/download/1.9-1/JGR_1.9-1.tar.gz"
    },
    "JavaGD": {
      "Package": "JavaGD",
      "Version": "0.6-1.1",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "95c317e22a41a5e64fd9fcbaa898e53a"
    },
    "rJava": {
      "Package": "rJava",
      "Version": "0.9-12",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "21b20702f0e8e171a81a5d9d75f2b2fd"
    },
    "renv": {
      "Package": "renv",
      "Version": "0.9.3",
      "Source": "Repository",
      "Repository": "CRAN",
      "Hash": "c1a367437d8a8a44bec4b9d4974cb20c"
    }
  }
}
```