### PR TITLE
allow modules::import outside module/amodule

### DIFF
--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -177,10 +177,15 @@ test_that("packages referenced by modules::import() are discovered", {
     import("e")
     import(f)
 
+    # NOTE: fully scoped modules::import calls should
+    # be added to dependencies
+
+    modules::import("G")
+    modules::import(H)
   })
 
   deps <- dependencies(file)
-  expect_setequal(deps$Package, c("A", "B", "C", "D"))
+  expect_setequal(deps$Package, c("A", "B", "C", "D", "G", "H", "modules"))
 
 })
 


### PR DESCRIPTION
Currently `modules::import` is only recognized as a dependency declaration within a `module::module` or `module::amodule` call. This misses dependencies within files used as modules, e.g., `m <- modules::use("myFileModule.R")`, where `myFileModule.R` contains top-level `modules::import` statements. 

I frequently do this b/c a file with top-level import statements can both be used as a module and be used as an input to `source()`, which make it more "portable" to those not using modules. 

I can't think of a case where `modules::import`would be called without the intention of declaring a dependency, so it seems to makes sense to remove the requirement that modules::import appear within a `module` expression...