### PR TITLE
Fix regex for detecting RSPM URL

### DIFF
--- a/R/rspm.R
+++ b/R/rspm.R
@@ -38,7 +38,7 @@ renv_rspm_transform_impl <- function(url) {
   #
   # in particular, there should be at least two trailing
   # alphanumeric path components
-  pattern <- "/[^/]+/[^/]+/$"
+  pattern <- "/[^/]+/[^/]+/"
   if (!grepl(pattern, url))
     return(url)
 

--- a/R/rspm.R
+++ b/R/rspm.R
@@ -38,7 +38,7 @@ renv_rspm_transform_impl <- function(url) {
   #
   # in particular, there should be at least two trailing
   # alphanumeric path components
-  pattern <- "/[^/]+/[^/]+/*$"
+  pattern <- "/[^/]+/[^/]+/$"
   if (!grepl(pattern, url))
     return(url)
 


### PR DESCRIPTION
This reduces load time in a project with a secondary CRAN repo from 4 to 1 seconds.