### PR TITLE
Use system2 over system in renv_python_virtualenv_create

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.12.0-5
+Version: 0.12.0-6
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio", role = c("cph"))

--- a/R/python-virtualenv.R
+++ b/R/python-virtualenv.R
@@ -49,11 +49,10 @@ renv_python_virtualenv_create <- function(python, path) {
 
   version <- renv_python_version(python)
   module <- if (numeric_version(version) > "3.2") "venv" else "virtualenv"
-
-  fmt <- "%s -m %s %s 2>&1"
   python <- renv_path_normalize(python)
-  cmd <- sprintf(fmt, shQuote(python), module, shQuote(path.expand(path)))
-  output <- system(cmd, intern = TRUE)
+
+  output <- system2(python, args = c("-m", module, path.expand(path)))
+  
   status <- attr(output, "status") %||% 0L
 
   if (status != 0L || !file.exists(path)) {

--- a/R/python-virtualenv.R
+++ b/R/python-virtualenv.R
@@ -51,7 +51,7 @@ renv_python_virtualenv_create <- function(python, path) {
   module <- if (numeric_version(version) > "3.2") "venv" else "virtualenv"
   python <- renv_path_normalize(python)
 
-  output <- system2(python, args = c("-m", module, path.expand(path)))
+  output <- system2(python, args = c("-m", module, shQuote(path.expand(path))))
   
   status <- attr(output, "status") %||% 0L
 


### PR DESCRIPTION
## Issue  

I routinely use both Linux and Win for projects and prefer virtualenv over Conda. Restoring venv on Linux is fine, but on Win 10 I always seem to run into issues creating the venv during activation:  

```
* Creating virtual environment 'renv-python-3.8.3' ... Error: [WinError 123] The filename, directory name, or volume label syntax is incorrect: 'C:\\Users\\xxxx\\yyyyy\\2>&1'
Error: failed to create virtual environment
In addition: Warning message:
In system(cmd, intern = TRUE) :
  running command '"C:/Program Files/Python38/python.exe" -m venv "C:/Users/xxxx/yyyyy/renv/python/virtualenvs/renv-python-3.8.3" 2>&1' had status 1
Traceback (most recent calls last):
17: source("renv/activate.R")
16: withVisible(eval(ei, envir))
15: eval(ei, envir)
14: eval(ei, envir)
13: local(...) at activate.R#2
12: eval.parent(substitute(eval(quote(expr), envir)))
11: eval(expr, p)
10: eval(expr, p)
 9: eval(quote(...), new.env())
 8: eval(quote(...), new.env())
 7: if (renv_bootstrap_load(project, libpath, version))
      return(TRUE) at activate.R#325
 6: renv::load(project) at activate.R#309
 5: renv_load_python(project, lockfile$Python)
 4: renv_load_python_env(fields, renv_use_python_virtualenv)
 3: loader(project = project, version = version, name = name)
 2: renv_python_virtualenv_create(python, path)
 1: stop(paste(msg, collapse = "\n"), call. = FALSE)
```

This seems to boil down to Windows not playing nice with the path constructed (or perhaps the quotes).  

[python-virtualenv.R#L53](https://github.com/rstudio/renv/blob/master/R/python-virtualenv.R#L53)  

```r
  fmt <- "%s -m %s %s 2>&1"
  python <- renv_path_normalize(python)
  cmd <- sprintf(fmt, shQuote(python), module, shQuote(path.expand(path)))
  output <- system(cmd, intern = TRUE)
```

## Solution  

Instead of constructing the venv command in `renv_python_virtualenv_create`  with `sprintf()` and using `system()`, I'd suggest using `system2()` and passing the module and path as arguments, which is more platform-agnostic and perhaps more robust.  

This has resolved all issues on my local system and passed local tests.  