### PR TITLE
Increase bootstrap reliability by not filtering out extra cran url

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 * Fixed an issue where package installation could fail if the `configure.vars`
   option was set to be a named character, rather than a named list. (#609)
 
+* Increase bootstrap reliability by always trying an extra CRAN URL.
+
 # renv 0.12.5
 
 * Fixed an issue where `renv` would fail to bootstrap. (#608)

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -35,7 +35,7 @@ renv_bootstrap_repos <- function() {
   repos[repos == "@CRAN@"] <- "https://cloud.r-project.org"
 
   # add in renv.bootstrap.repos if set
-  default <- c(CRAN = "https://cloud.r-project.org")
+  default <- c(EXTRA_CRAN = "https://cloud.r-project.org")
   extra <- getOption("renv.bootstrap.repos", default = default)
   repos <- c(repos, extra)
 

--- a/inst/resources/activate.R
+++ b/inst/resources/activate.R
@@ -73,7 +73,7 @@ local({
     repos[repos == "@CRAN@"] <- "https://cloud.r-project.org"
   
     # add in renv.bootstrap.repos if set
-    default <- c(CRAN = "https://cloud.r-project.org")
+    default <- c(EXTRA_CRAN = "https://cloud.r-project.org")
     extra <- getOption("renv.bootstrap.repos", default = default)
     repos <- c(repos, extra)
   


### PR DESCRIPTION
Rename default extra cran url key to ensure it is not filtered out by the
repo URL deduplication code. It is thus always there as fallback in cases
where the cran url points to a server which is not available, outdated or
broken.