### PR TITLE
introduce notion of custom renv profiles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.12.5-27
+Version: 0.12.5-28
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 
 # renv 0.13.0 (UNRELEASED)
 
+* `renv` now has support for custom project profiles. Profiles can be used to
+  activate different sets of project libraries + lockfiles for different workflows
+  in a given project. See `vignette("profiles", package = "renv")` for more
+  details.
+  
 * Fixed an issue where attempts to initialize an `renv` project in a path
   containing non-ASCII characters could fail on Windows. (#629)
 

--- a/R/actions.R
+++ b/R/actions.R
@@ -3,12 +3,13 @@ actions <- function(action = c("snapshot", "restore"),
                     ...,
                     project = NULL,
                     library = NULL,
-                    lockfile = file.path(project, "renv.lock"),
+                    lockfile = NULL,
                     type = settings$snapshot.type(project = project),
                     clean = FALSE)
 {
-  action  <- match.arg(action)
-  project <- renv_project_resolve(project)
+  action   <- match.arg(action)
+  project  <- renv_project_resolve(project)
+  lockfile <- lockfile %||% renv_lockfile_path(project = project)
 
   renv_scope_lock(project = project)
 

--- a/R/activate.R
+++ b/R/activate.R
@@ -21,7 +21,7 @@
 #' renv::activate("~/projects/analysis")
 #'
 #' }
-activate <- function(project = NULL) {
+activate <- function(project = NULL, profile = NULL) {
 
   renv_consent_check()
   renv_scope_error_handler()
@@ -31,6 +31,7 @@ activate <- function(project = NULL) {
 
   renv_activate_impl(
     project = project,
+    profile = profile,
     version = NULL,
     restart = FALSE,
     quiet   = FALSE
@@ -40,13 +41,25 @@ activate <- function(project = NULL) {
 
 }
 
-renv_activate_impl <- function(project, version, restart, quiet) {
-
+renv_activate_impl <- function(project,
+                               profile,
+                               version,
+                               restart,
+                               quiet)
+{
   # prepare renv infrastructure
-  renv_infrastructure_write(project, version)
+  renv_infrastructure_write(
+    project = project,
+    profile = profile,
+    version = version
+  )
 
   # try to load the project
   load(project, quiet = quiet)
+
+  # ensure renv is imbued into the new library path if necessary
+  if (!renv_tests_running())
+    renv_imbue_self(project)
 
   # restart session if requested
   if (restart)

--- a/R/activate.R
+++ b/R/activate.R
@@ -47,6 +47,9 @@ renv_activate_impl <- function(project,
                                restart,
                                quiet)
 {
+  # activate requested profile
+  renv_profile_set(profile)
+
   # prepare renv infrastructure
   renv_infrastructure_write(
     project = project,

--- a/R/activate.R
+++ b/R/activate.R
@@ -29,6 +29,8 @@ activate <- function(project = NULL, profile = NULL) {
   project <- renv_project_resolve(project)
   renv_scope_lock(project = project)
 
+  renv_profile_set(profile)
+
   renv_activate_impl(
     project = project,
     profile = profile,
@@ -47,9 +49,6 @@ renv_activate_impl <- function(project,
                                restart,
                                quiet)
 {
-  # activate requested profile
-  renv_profile_set(profile)
-
   # prepare renv infrastructure
   renv_infrastructure_write(
     project = project,

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -411,10 +411,8 @@ renv_bootstrap_profile_load <- function(project) {
 renv_bootstrap_profile_prefix <- function() {
 
   profile <- renv_bootstrap_profile_get()
-  if (is.na(profile))
-    return(character())
-
-  file.path("renv/profiles", profile)
+  if (!is.na(profile) && nzchar(profile))
+    return(file.path("renv/profiles", profile))
 
 }
 

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -323,7 +323,8 @@ renv_bootstrap_library_root <- function(project) {
     return(file.path(path, name))
   }
 
-  file.path(project, "renv/library")
+  prefix <- renv_bootstrap_profile_prefix()
+  paste(c(project, prefix, "renv/library"), collapse = "/")
 
 }
 
@@ -379,4 +380,48 @@ renv_bootstrap_load <- function(project, libpath, version) {
 
   TRUE
 
+}
+
+renv_bootstrap_profile_load <- function(project) {
+
+  # if RENV_PROFILE is already set, just use that
+  profile <- Sys.getenv("RENV_PROFILE", unset = NA)
+  if (!is.na(profile) && nzchar(profile))
+    return(profile)
+
+  # check for a profile file (nothing to do if it doesn't exist)
+  path <- file.path(project, "renv/profile")
+  if (!file.exists(path))
+    return(NULL)
+
+  # read the profile, and set it if it exists
+  contents <- readLines(path, warn = FALSE)
+  if (length(contents) == 0L)
+    return(NULL)
+
+  # set RENV_PROFILE
+  profile <- contents[[1L]]
+  if (nzchar(profile))
+    Sys.setenv(RENV_PROFILE = profile)
+
+  profile
+
+}
+
+renv_bootstrap_profile_prefix <- function() {
+
+  profile <- renv_bootstrap_profile_get()
+  if (is.na(profile))
+    return(character())
+
+  file.path("renv/profiles", profile)
+
+}
+
+renv_bootstrap_profile_get <- function() {
+  Sys.getenv("RENV_PROFILE", unset = NA)
+}
+
+renv_bootstrap_profile_set <- function(profile) {
+  Sys.setenv(RENV_PROFILE = profile)
 }

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -409,17 +409,29 @@ renv_bootstrap_profile_load <- function(project) {
 }
 
 renv_bootstrap_profile_prefix <- function() {
-
   profile <- renv_bootstrap_profile_get()
-  if (!is.na(profile) && nzchar(profile))
+  if (!is.null(profile))
     return(file.path("renv/profiles", profile))
-
 }
 
 renv_bootstrap_profile_get <- function() {
-  Sys.getenv("RENV_PROFILE", unset = NA)
+  profile <- Sys.getenv("RENV_PROFILE", unset = "")
+  renv_bootstrap_profile_normalize(profile)
 }
 
 renv_bootstrap_profile_set <- function(profile) {
-  Sys.setenv(RENV_PROFILE = profile)
+  profile <- renv_profile_normalize(profile)
+  if (is.null(profile))
+    Sys.unsetenv("RENV_PROFILE")
+  else
+    Sys.setenv(RENV_PROFILE = profile)
+}
+
+renv_bootstrap_profile_normalize <- function(profile) {
+
+  if (is.null(profile) || profile %in% c("", "default"))
+    return(NULL)
+
+  profile
+
 }

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -420,7 +420,7 @@ renv_bootstrap_profile_get <- function() {
 }
 
 renv_bootstrap_profile_set <- function(profile) {
-  profile <- renv_profile_normalize(profile)
+  profile <- renv_bootstrap_profile_normalize(profile)
   if (is.null(profile))
     Sys.unsetenv("RENV_PROFILE")
   else

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -390,7 +390,7 @@ renv_bootstrap_profile_load <- function(project) {
     return(profile)
 
   # check for a profile file (nothing to do if it doesn't exist)
-  path <- file.path(project, "renv/profile")
+  path <- file.path(project, "renv/local/profile")
   if (!file.exists(path))
     return(NULL)
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -430,7 +430,7 @@ renv_dependencies_discover_description <- function(path, fields = NULL) {
 
     # collect profile-specific dependencies as well
     profile <- renv_profile_get()
-    field <- if (!is.na(profile))
+    field <- if (length(profile))
       sprintf("Config/renv/profiles/%s/dependencies", profile)
 
     fields <- c(fields, "Suggests", field)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -247,7 +247,7 @@ renv_dependencies_find_extra <- function(root) {
 
   # collect deps
   path <- file.path(root, prefix)
-  renv_dependencies_find_impl(path, root)
+  renv_dependencies_find_impl(path, root, 0)
 
 }
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -427,8 +427,15 @@ renv_dependencies_discover_description <- function(path, fields = NULL) {
   state <- renv_dependencies_state()
   type <- "unknown"
   if (identical(file.path(state$root, "DESCRIPTION"), path)) {
-    fields <- c(fields, "Suggests")
+
+    # collect profile-specific dependencies as well
+    profile <- renv_profile_get()
+    field <- if (!is.na(profile))
+      sprintf("Config/renv/profiles/%s/dependencies", profile)
+
+    fields <- c(fields, "Suggests", field)
     type <- renv_description_type(desc = dcf)
+
   }
 
   data <- lapply(fields, function(field) {

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -156,7 +156,7 @@ renv_diagnostics_packages_sources <- function(lockfile, all) {
 
 renv_diagnostics_packages_lockfile <- function(project) {
 
-  lockpath <- file.path(project, "renv.lock")
+  lockpath <- renv_lockfile_path(project = project)
   if (!file.exists(lockpath)) {
     vwritef("This project has not yet been snapshotted: 'renv.lock' does not exist.")
     return(list())

--- a/R/embed.R
+++ b/R/embed.R
@@ -13,6 +13,10 @@
 #' @inheritParams renv-params
 #'
 #' @param path The path to an \R or R Markdown script.
+#'
+#' @param lockfile The path to an `renv` lockfile. When `NULL` (the default),
+#'   the project lockfile will be read (if any); otherwise, a new lockfile
+#'   will be generated from the current library paths.
 embed <- function(path = NULL,
                   ...,
                   lockfile = NULL,

--- a/R/history.R
+++ b/R/history.R
@@ -74,9 +74,10 @@ revert <- function(commit = "HEAD", ..., project = NULL) {
   owd <- setwd(project)
   on.exit(setwd(owd), add = TRUE)
 
-  system2("git", c("checkout", commit, "--", "renv.lock"))
-  system2("git", c("reset", "HEAD", "renv.lock"), stdout = FALSE, stderr = FALSE)
-  system2("git", c("diff", "--", "renv.lock"))
+  lockpath <- renv_lockfile_path(project = project)
+  system2("git", c("checkout", commit, "--", shQuote(lockpath)))
+  system2("git", c("reset", "HEAD", shQuote(lockpath)), stdout = FALSE, stderr = FALSE)
+  system2("git", c("diff", "--", shQuote(lockpath)))
 
   vwritef("* renv.lock from commit %s has been checked out.", commit)
   invisible(commit)

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -1,14 +1,31 @@
 
 # tools for writing / removing renv-related infrastructure
-renv_infrastructure_write <- function(project = NULL, version = NULL) {
+renv_infrastructure_write <- function(project = NULL,
+                                      profile = NULL,
+                                      version = NULL)
+{
   project <- renv_project_resolve(project)
 
+  renv_infrastructure_write_profile(project, profile = profile)
   renv_infrastructure_write_rprofile(project)
   renv_infrastructure_write_rbuildignore(project)
   renv_infrastructure_write_gitignore(project)
   renv_infrastructure_write_activate(project, version = version)
 }
 
+renv_infrastructure_write_profile <- function(project, profile = NULL) {
+
+  path <- file.path(project, "renv/profile")
+  ensure_parent_directory(path)
+
+  if (is.null(profile))
+    unlink(path)
+  else
+    writeLines(profile, con = path)
+
+  invisible(path)
+
+}
 
 renv_infrastructure_write_rprofile <- function(project) {
 

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -18,6 +18,7 @@ renv_infrastructure_write_profile <- function(project, profile = NULL) {
   path <- file.path(project, "renv/profile")
   ensure_parent_directory(path)
 
+  profile <- renv_profile_normalize(profile)
   if (is.null(profile))
     unlink(path)
   else

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -15,7 +15,7 @@ renv_infrastructure_write <- function(project = NULL,
 
 renv_infrastructure_write_profile <- function(project, profile = NULL) {
 
-  path <- file.path(project, "renv/profile")
+  path <- file.path(project, "renv/local/profile")
   ensure_parent_directory(path)
 
   profile <- renv_profile_normalize(profile)
@@ -64,7 +64,7 @@ renv_infrastructure_write_gitignore <- function(project) {
   stk <- if (settings$vcs.ignore.library()) add else remove
   stk$push("library/")
 
-  add$push("lock/", "python/", "staging/")
+  add$push("local/", "lock/", "python/", "staging/")
 
   renv_infrastructure_write_entry_impl(
     add    = as.character(add$data()),

--- a/R/init.R
+++ b/R/init.R
@@ -77,6 +77,7 @@
 #' @example examples/examples-init.R
 init <- function(project = NULL,
                  ...,
+                 profile  = NULL,
                  settings = NULL,
                  bare     = FALSE,
                  force    = FALSE,
@@ -100,12 +101,9 @@ init <- function(project = NULL,
   # be quiet in RStudio projects (as we will normally restart automatically)
   quiet <- !is.null(getOption("restart"))
 
-  # for bare inits, just active the project
-  if (bare) {
-    version <- renv_package_version("renv")
-    status <- renv_activate_impl(project, version, restart, quiet)
-    return(invisible(status))
-  }
+  # for bare inits, just activate the project
+  if (bare)
+    return(renv_init_fini(project, profile, version, restart, quiet))
 
   # form path to lockfile, library
   library  <- renv_paths_library(project = project)
@@ -134,8 +132,22 @@ init <- function(project = NULL,
   }
 
   # activate the newly-hydrated project
+  renv_init_fini(project, profile, version, restart, quiet)
+
+}
+
+renv_init_fini <- function(project, profile, version, restart, quiet) {
+
   version <- renv_package_version("renv")
-  status <- renv_activate_impl(project, version, restart, quiet)
+
+  renv_activate_impl(
+    project = project,
+    profile = profile,
+    version = version,
+    restart = restart,
+    quiet   = quiet
+  )
+
   invisible(project)
 
 }

--- a/R/load.R
+++ b/R/load.R
@@ -58,11 +58,12 @@ load <- function(project = getwd(), quiet = FALSE) {
   renv_load_path(project)
   renv_load_shims(project)
   renv_load_renviron(project)
+  renv_load_profile(project)
   renv_load_settings(project)
   renv_load_project(project)
   renv_load_sandbox(project)
   renv_load_libpaths(project)
-  renv_load_profile(project)
+  renv_load_rprofile(project)
   renv_load_cache(project)
 
   lockfile <- renv_lockfile_load(project)
@@ -182,9 +183,16 @@ renv_load_renviron <- function(project) {
 
 }
 
+renv_load_profile <- function(project) {
+
+  renv_bootstrap_profile_load(project = project)
+
+}
+
 renv_load_settings <- function(project) {
 
-  settings <- file.path(project, "renv/settings.R")
+  components <- c(project, renv_profile_prefix(), "renv/settings.R")
+  settings <- paste(components, collapse = "/")
   if (!file.exists(settings))
     return(FALSE)
 
@@ -223,7 +231,7 @@ renv_load_project <- function(project) {
 
 }
 
-renv_load_profile <- function(project = NULL) {
+renv_load_rprofile <- function(project = NULL) {
 
   project <- renv_project_resolve(project)
 
@@ -235,13 +243,13 @@ renv_load_profile <- function(project = NULL) {
 
   profile <- Sys.getenv("R_PROFILE_USER", unset = "~/.Rprofile")
   if (file.exists(profile))
-    renv_load_profile_impl(profile)
+    renv_load_rprofile_impl(profile)
 
   TRUE
 
 }
 
-renv_load_profile_impl <- function(profile) {
+renv_load_rprofile_impl <- function(profile) {
 
   status <- catch(eval(parse(profile), envir = globalenv()))
   if (!inherits(status, "error"))
@@ -407,7 +415,16 @@ renv_load_report_project <- function(project) {
     renv_session_quiet()
   )
 
-  if (!quiet) {
+  if (quiet)
+    return()
+
+  profile <- renv_profile_get()
+  version <- renv_package_version("renv")
+
+  if (!is.na(profile)) {
+    fmt <- "* (%s) Project '%s' loaded. [renv %s]"
+    vwritef(fmt, profile, aliased_path(project), version)
+  } else {
     fmt <- "* Project '%s' loaded. [renv %s]"
     vwritef(fmt, aliased_path(project), renv_package_version("renv"))
   }
@@ -430,7 +447,8 @@ renv_load_report_updates <- function(project) {
 # nocov start
 renv_load_report_updates_impl <- function(project) {
 
-  if (!file.exists(file.path(project, "renv.lock")))
+  lockpath <- renv_lockfile_path(project = project)
+  if (!file.exists(lockpath))
     return(FALSE)
 
   status <- update(project = project, check = TRUE)

--- a/R/load.R
+++ b/R/load.R
@@ -279,7 +279,8 @@ renv_load_sandbox <- function(project) {
 renv_load_python <- function(project, fields) {
 
   # set a default reticulate Python environment path
-  envpath <- file.path(project, "renv/python/r-reticulate")
+  components <- c(project, renv_profile_prefix(), "renv/python/r-reticulate")
+  envpath <- paste(components, collapse = "/")
   Sys.setenv(RETICULATE_MINICONDA_PYTHON_ENVPATH = envpath)
 
   # nothing more to do if no lockfile fields set

--- a/R/load.R
+++ b/R/load.R
@@ -422,7 +422,7 @@ renv_load_report_project <- function(project) {
   profile <- renv_profile_get()
   version <- renv_package_version("renv")
 
-  if (!is.na(profile)) {
+  if (length(profile)) {
     fmt <- "* (%s) Project '%s' loaded. [renv %s]"
     vwritef(fmt, profile, aliased_path(project), version)
   } else {

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -102,11 +102,12 @@ renv_lockfile_fini_bioconductor <- function(lockfile) {
 }
 
 renv_lockfile_path <- function(project) {
-  file.path(project, "renv.lock")
+  renv_paths_lockfile(project = project)
 }
 
 renv_lockfile_save <- function(lockfile, project) {
-  renv_lockfile_write(lockfile, file = renv_lockfile_path(project))
+  file <- renv_lockfile_path(project)
+  renv_lockfile_write(lockfile, file = file)
 }
 
 renv_lockfile_load <- function(project) {

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -174,7 +174,7 @@ renv_migrate_packrat_lockfile <- function(project) {
   lockfile <- renv_lockfile_fini(lockfile)
 
   # write the lockfile
-  lockpath <- file.path(project, "renv.lock")
+  lockpath <- renv_lockfile_path(project = project)
   renv_lockfile_write(lockfile, file = lockpath)
 
 }

--- a/R/paths.R
+++ b/R/paths.R
@@ -42,6 +42,18 @@ renv_paths_library <- function(..., project = NULL) {
   file.path(root, renv_prefix_platform(), ...) %||% ""
 }
 
+renv_paths_lockfile <- function(project = NULL) {
+  project <- renv_project_resolve(project)
+  components <- c(project, renv_profile_prefix(), "renv.lock")
+  paste(components, collapse = "/")
+}
+
+renv_paths_settings <- function(project = NULL) {
+  project <- renv_project_resolve(project)
+  components <- c(project, renv_profile_prefix(), "renv/settings.dcf")
+  paste(components, collapse = "/")
+}
+
 renv_paths_local <- function(...) {
   renv_paths_common("local", c(), ...)
 }
@@ -292,7 +304,9 @@ renv_paths_init <- function() {
 #' # get the path to the project library
 #' path <- renv::paths$library()
 paths <- list(
-  root    = renv_paths_root,
-  library = renv_paths_library,
-  cache   = renv_paths_cache
+  root     = renv_paths_root,
+  library  = renv_paths_library,
+  lockfile = renv_paths_lockfile,
+  settings = renv_paths_settings,
+  cache    = renv_paths_cache
 )

--- a/R/profile.R
+++ b/R/profile.R
@@ -1,0 +1,12 @@
+
+renv_profile_prefix <- function() {
+  renv_bootstrap_profile_prefix()
+}
+
+renv_profile_get <- function() {
+  renv_bootstrap_profile_get()
+}
+
+renv_profile_set <- function(profile) {
+  renv_bootstrap_profile_set(profile)
+}

--- a/R/profile.R
+++ b/R/profile.R
@@ -10,3 +10,7 @@ renv_profile_get <- function() {
 renv_profile_set <- function(profile) {
   renv_bootstrap_profile_set(profile)
 }
+
+renv_profile_normalize <- function(profile) {
+  renv_bootstrap_profile_normalize(profile)
+}

--- a/R/python.R
+++ b/R/python.R
@@ -191,7 +191,8 @@ renv_python_envpath <- function(project, type, version) {
     stopf("unrecognized environment type '%s'", type)
   )
 
-  file.path(project, suffix)
+  components <- c(project, renv_profile_prefix(), suffix)
+  paste(components, collapse = "/")
 
 }
 

--- a/R/record.R
+++ b/R/record.R
@@ -25,7 +25,7 @@
 #' @example examples/examples-record.R
 #' @export
 record <- function(records,
-                   lockfile = file.path(project, "renv.lock"),
+                   lockfile = NULL,
                    project  = NULL)
 {
   renv_scope_error_handler()

--- a/R/roxygen.R
+++ b/R/roxygen.R
@@ -24,6 +24,10 @@
 #'   boolean (indicating that all installed packages should be rebuilt), or a
 #'   vector of package names indicating which packages should be rebuilt.
 #'
+#' @param profile The profile to be activated. When `NULL`, the default
+#'   profile is activated instead. See `vignette("profiles", package = "renv")`
+#'   for more information.
+#'
 #' @return The project directory, invisibly. Note that this function is normally
 #'   called for its side effects.
 #'

--- a/R/settings.R
+++ b/R/settings.R
@@ -158,7 +158,7 @@ renv_settings_merge <- function(settings, merge) {
 }
 
 renv_settings_path <- function(project) {
-  file.path(project, "renv/settings.dcf")
+  renv_paths_settings(project = project)
 }
 
 

--- a/R/snapshot-auto.R
+++ b/R/snapshot-auto.R
@@ -10,7 +10,7 @@ renv_snapshot_auto <- function(project) {
   if (inherits(status, "error"))
     return(FALSE)
 
-  lockfile <- file.path(project, "renv.lock")
+  lockfile <- renv_lockfile_path(project = project)
   vwritef("* Automatic snapshot has updated '%s'.", aliased_path(lockfile))
   TRUE
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -96,7 +96,7 @@
 snapshot <- function(project  = NULL,
                      ...,
                      library  = NULL,
-                     lockfile = file.path(project, "renv.lock"),
+                     lockfile = paths$lockfile(project = project),
                      type     = settings$snapshot.type(project = project),
                      packages = NULL,
                      prompt   = interactive(),

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -36,8 +36,8 @@
 #'
 #' \item{`"explicit"`}{
 #' Only capture packages which are explicitly listed in the project
-#' `DESCRIPTION` file. This workflow is recommended for users who wish to more
-#' explicitly manage a project's \R package dependencies.
+#' `DESCRIPTION` file. This workflow is recommended for users who wish to
+#' manage their project's \R package dependencies directly.
 #' }
 #'
 #' \item{`"custom"`}{

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -53,7 +53,11 @@
 #'
 #' By default, `"implicit"`-style snapshots are used. The snapshot type can be
 #' configured on a project-specific basis using the `renv` project [settings]
-#' mechanism.
+#' mechanism. For example, to use `"explicit"` snapshots in a project:
+#'
+#' ```
+#' renv::settings$snapshot.type("explicit")
+#' ````
 #'
 #' When the `packages` argument is set, `type` is ignored, and instead only the
 #' requested set of packages, and their recursive dependencies, will be written
@@ -70,8 +74,7 @@
 #'   directly instead.
 #'
 #' @param type The type of snapshot to perform. See **Snapshot Type** for
-#'   more details. When `NULL` (the default), an "implicit"-style snapshot
-#'   is performed.
+#'   more details.
 #'
 #' @param packages A vector of packages to be included in the lockfile. When
 #'   `NULL` (the default), all packages relevant for the type of snapshot being

--- a/R/tests.R
+++ b/R/tests.R
@@ -280,6 +280,7 @@ renv_tests_init <- function() {
   if (renv_tests_running())
     return()
 
+  Sys.unsetenv("RENV_PROFILE")
   Sys.unsetenv("RENV_PATHS_LIBRARY")
   Sys.unsetenv("RENV_PATHS_LIBRARY_ROOT")
   Sys.unsetenv("RENV_CONFIG_CACHE_ENABLED")
@@ -287,6 +288,7 @@ renv_tests_init <- function() {
   Sys.unsetenv("RENV_PYTHON")
   Sys.unsetenv("RETICULATE_PYTHON")
   Sys.unsetenv("RETICULATE_PYTHON_ENV")
+  Sys.unsetenv("RETICULATE_PYTHON_FALLBACK")
 
   renv_tests_init_workarounds()
   renv_tests_init_working_dir()

--- a/inst/resources/activate.R
+++ b/inst/resources/activate.R
@@ -361,7 +361,8 @@ local({
       return(file.path(path, name))
     }
   
-    file.path(project, "renv/library")
+    prefix <- renv_bootstrap_profile_prefix()
+    paste(c(project, prefix, "renv/library"), collapse = "/")
   
   }
   
@@ -418,6 +419,53 @@ local({
     TRUE
   
   }
+  
+  renv_bootstrap_profile_load <- function(project) {
+  
+    # if RENV_PROFILE is already set, just use that
+    profile <- Sys.getenv("RENV_PROFILE", unset = NA)
+    if (!is.na(profile) && nzchar(profile))
+      return(profile)
+  
+    # check for a profile file (nothing to do if it doesn't exist)
+    path <- file.path(project, "renv/profile")
+    if (!file.exists(path))
+      return(NULL)
+  
+    # read the profile, and set it if it exists
+    contents <- readLines(path, warn = FALSE)
+    if (length(contents) == 0L)
+      return(NULL)
+  
+    # set RENV_PROFILE
+    profile <- contents[[1L]]
+    if (nzchar(profile))
+      Sys.setenv(RENV_PROFILE = profile)
+  
+    profile
+  
+  }
+  
+  renv_bootstrap_profile_prefix <- function() {
+  
+    profile <- renv_bootstrap_profile_get()
+    if (is.na(profile))
+      return(character())
+  
+    file.path("renv/profiles", profile)
+  
+  }
+  
+  renv_bootstrap_profile_get <- function() {
+    Sys.getenv("RENV_PROFILE", unset = NA)
+  }
+  
+  renv_bootstrap_profile_set <- function(profile) {
+    Sys.setenv(RENV_PROFILE = profile)
+  }
+
+  # load the renv profile, if any
+  renv_bootstrap_profile_load(project)
 
   # construct path to library root
   root <- renv_bootstrap_library_root(project)

--- a/inst/resources/activate.R
+++ b/inst/resources/activate.R
@@ -449,10 +449,8 @@ local({
   renv_bootstrap_profile_prefix <- function() {
   
     profile <- renv_bootstrap_profile_get()
-    if (is.na(profile))
-      return(character())
-  
-    file.path("renv/profiles", profile)
+    if (!is.na(profile) && nzchar(profile))
+      return(file.path("renv/profiles", profile))
   
   }
   

--- a/inst/resources/activate.R
+++ b/inst/resources/activate.R
@@ -447,19 +447,27 @@ local({
   }
   
   renv_bootstrap_profile_prefix <- function() {
-  
     profile <- renv_bootstrap_profile_get()
-    if (!is.na(profile) && nzchar(profile))
+    if (!is.null(profile))
       return(file.path("renv/profiles", profile))
-  
   }
   
   renv_bootstrap_profile_get <- function() {
-    Sys.getenv("RENV_PROFILE", unset = NA)
+    profile <- Sys.getenv("RENV_PROFILE", unset = "")
+    renv_bootstrap_profile_normalize(profile)
   }
   
   renv_bootstrap_profile_set <- function(profile) {
     Sys.setenv(RENV_PROFILE = profile)
+  }
+  
+  renv_bootstrap_profile_normalize <- function(profile) {
+  
+    if (is.null(profile) || profile %in% c("", "default"))
+      return(NULL)
+  
+    profile
+  
   }
 
   # load the renv profile, if any

--- a/inst/resources/activate.R
+++ b/inst/resources/activate.R
@@ -428,7 +428,7 @@ local({
       return(profile)
   
     # check for a profile file (nothing to do if it doesn't exist)
-    path <- file.path(project, "renv/profile")
+    path <- file.path(project, "renv/local/profile")
     if (!file.exists(path))
       return(NULL)
   
@@ -458,7 +458,11 @@ local({
   }
   
   renv_bootstrap_profile_set <- function(profile) {
-    Sys.setenv(RENV_PROFILE = profile)
+    profile <- renv_bootstrap_profile_normalize(profile)
+    if (is.null(profile))
+      Sys.unsetenv("RENV_PROFILE")
+    else
+      Sys.setenv(RENV_PROFILE = profile)
   }
   
   renv_bootstrap_profile_normalize <- function(profile) {

--- a/man/activate.Rd
+++ b/man/activate.Rd
@@ -4,12 +4,16 @@
 \alias{activate}
 \title{Activate a Project}
 \usage{
-activate(project = NULL)
+activate(project = NULL, profile = NULL)
 }
 \arguments{
 \item{project}{The project directory. If \code{NULL}, then the active project will
 be used. If no project is currently active, then the current working
 directory is used instead.}
+
+\item{profile}{The profile to be activated. When \code{NULL}, the default
+profile is activated instead. See \code{vignette("profiles", package = "renv")}
+for more information.}
 }
 \value{
 The project directory, invisibly. Note that this function is normally

--- a/man/embed.Rd
+++ b/man/embed.Rd
@@ -12,6 +12,10 @@ embed(path = NULL, ..., lockfile = NULL, project = NULL)
 \item{...}{Unused arguments, reserved for future expansion. If any arguments
 are matched to \code{...}, \code{renv} will signal an error.}
 
+\item{lockfile}{The path to an \code{renv} lockfile. When \code{NULL} (the default),
+the project lockfile will be read (if any); otherwise, a new lockfile
+will be generated from the current library paths.}
+
 \item{project}{The project directory. If \code{NULL}, then the active project will
 be used. If no project is currently active, then the current working
 directory is used instead.}

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -7,6 +7,7 @@
 init(
   project = NULL,
   ...,
+  profile = NULL,
   settings = NULL,
   bare = FALSE,
   force = FALSE,
@@ -19,6 +20,10 @@ changed to match the requested project directory.}
 
 \item{...}{Unused arguments, reserved for future expansion. If any arguments
 are matched to \code{...}, \code{renv} will signal an error.}
+
+\item{profile}{The profile to be activated. When \code{NULL}, the default
+profile is activated instead. See \code{vignette("profiles", package = "renv")}
+for more information.}
 
 \item{settings}{A list of \link{settings} to be used with the newly-initialized
 project.}

--- a/man/paths.Rd
+++ b/man/paths.Rd
@@ -5,7 +5,7 @@
 \alias{paths}
 \title{Path Customization}
 \format{
-An object of class \code{list} of length 3.
+An object of class \code{list} of length 5.
 }
 \usage{
 paths

--- a/man/record.Rd
+++ b/man/record.Rd
@@ -4,7 +4,7 @@
 \alias{record}
 \title{Update Package Records in a Lockfile}
 \usage{
-record(records, lockfile = file.path(project, "renv.lock"), project = NULL)
+record(records, lockfile = NULL, project = NULL)
 }
 \arguments{
 \item{records}{A list of named records, mapping package names to a definition

--- a/man/snapshot.Rd
+++ b/man/snapshot.Rd
@@ -8,7 +8,7 @@ snapshot(
   project = NULL,
   ...,
   library = NULL,
-  lockfile = file.path(project, "renv.lock"),
+  lockfile = paths$lockfile(project = project),
   type = settings$snapshot.type(project = project),
   packages = NULL,
   prompt = interactive(),

--- a/man/snapshot.Rd
+++ b/man/snapshot.Rd
@@ -33,8 +33,7 @@ project directory. When \code{NULL}, the lockfile (as an \R object) is returned
 directly instead.}
 
 \item{type}{The type of snapshot to perform. See \strong{Snapshot Type} for
-more details. When \code{NULL} (the default), an "implicit"-style snapshot
-is performed.}
+more details.}
 
 \item{packages}{A vector of packages to be included in the lockfile. When
 \code{NULL} (the default), all packages relevant for the type of snapshot being
@@ -110,7 +109,8 @@ in the lockfile.
 
 By default, \code{"implicit"}-style snapshots are used. The snapshot type can be
 configured on a project-specific basis using the \code{renv} project \link{settings}
-mechanism.
+mechanism. For example, to use \code{"explicit"} snapshots in a project:\preformatted{renv::settings$snapshot.type("explicit")
+}
 
 When the \code{packages} argument is set, \code{type} is ignored, and instead only the
 requested set of packages, and their recursive dependencies, will be written

--- a/man/snapshot.Rd
+++ b/man/snapshot.Rd
@@ -92,8 +92,8 @@ by writing e.g. \verb{library(<package>)} into a file called \code{dependencies.
 
 \item{\code{"explicit"}}{
 Only capture packages which are explicitly listed in the project
-\code{DESCRIPTION} file. This workflow is recommended for users who wish to more
-explicitly manage a project's \R package dependencies.
+\code{DESCRIPTION} file. This workflow is recommended for users who wish to
+manage their project's \R package dependencies directly.
 }
 
 \item{\code{"custom"}}{

--- a/templates/template-activate.R
+++ b/templates/template-activate.R
@@ -38,6 +38,9 @@ local({
 
   # load bootstrap tools ${BOOTSTRAP}
 
+  # load the renv profile, if any
+  renv_bootstrap_profile_load(project)
+
   # construct path to library root
   root <- renv_bootstrap_library_root(project)
 

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -282,3 +282,16 @@ test_that("empty / missing labels are handled", {
   deps <- dependencies("resources/empty-label.Rmd", progress = FALSE)
   expect_true(all(c("A", "B") %in% deps$Package))
 })
+
+test_that("only dependencies in a top-level DESCRIPTION file are used", {
+  renv_tests_scope()
+
+  dir.create("a")
+  writeLines("Depends: toast", con = "DESCRIPTION")
+  writeLines("Depends: oatmeal", con = "a/DESCRIPTION")
+
+  deps <- dependencies(quiet = TRUE)
+  expect_true("toast" %in% deps$Package)
+  expect_false("oatmeal" %in% deps$Package)
+
+})

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -26,5 +26,5 @@ test_that("errors when sourcing user profile are reported", {
   profile <- renv_tempfile_path("renv-profile-", fileext = ".R")
   writeLines("stop(1)", con = profile)
   renv_scope_envvars(R_PROFILE_USER = profile)
-  expect_warning(renv_load_profile(getwd()))
+  expect_warning(renv_load_rprofile(getwd()))
 })

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -1,0 +1,35 @@
+
+context("Profile")
+
+test_that("a profile changes the default library / lockfile path", {
+
+  renv_tests_scope()
+  renv_scope_envvars(RENV_PROFILE = "testing")
+
+  project <- getwd()
+  init()
+
+  # NOTE: renv/profile should not be written here as we've only forced
+  # activation via an environment variable and not explicitly via API
+  profile <- file.path(project, "renv/profile")
+  expect_false(file.exists(profile))
+
+  # however, other paths should resolve relative to the active profile
+  prefix <- "renv/profiles/testing"
+
+  expect_equal(
+    paths$lockfile(project = project),
+    file.path(project, prefix, "renv.lock")
+  )
+
+  expect_equal(
+    paths$library(project = project),
+    file.path(project, prefix, "renv/library", renv_prefix_platform())
+  )
+
+  expect_equal(
+    paths$settings(project = project),
+    file.path(project, prefix, "renv/settings.dcf")
+  )
+
+})

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -58,3 +58,19 @@ test_that("profile-specific dependencies can be written", {
   expect_false("toast" %in% deps$Package)
 
 })
+
+test_that("profile-specific dependencies can be declared in DESCRIPTION", {
+  renv_tests_scope()
+
+  renv_scope_envvars(RENV_PROFILE = "testing")
+  init()
+
+  writeLines(
+    "Config/renv/profiles/testing/dependencies: toast",
+    con = "DESCRIPTION"
+  )
+
+  deps <- dependencies()
+  expect_true("toast" %in% deps$Package)
+
+})

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -33,3 +33,28 @@ test_that("a profile changes the default library / lockfile path", {
   )
 
 })
+
+test_that("profile-specific dependencies can be written", {
+
+  renv_tests_scope()
+
+  # initialize project with 'testing' profile
+  renv_scope_envvars(RENV_PROFILE = "testing")
+  init()
+
+  # have this profile depend on 'toast'
+  path <- file.path(getwd(), renv_profile_prefix(), "deps.R")
+  writeLines("library(toast)", con = path)
+
+  # validate the dependency is included
+  deps <- dependencies(quiet = TRUE)
+  expect_true("toast" %in% deps$Package)
+
+  # switch to other profile
+  Sys.setenv(RENV_PROFILE = "other")
+
+  # 'toast' is no longe required
+  deps <- dependencies(quiet = TRUE)
+  expect_false("toast" %in% deps$Package)
+
+})

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -11,7 +11,7 @@ test_that("a profile changes the default library / lockfile path", {
 
   # NOTE: renv/profile should not be written here as we've only forced
   # activation via an environment variable and not explicitly via API
-  profile <- file.path(project, "renv/profile")
+  profile <- file.path(project, "renv/local/profile")
   expect_false(file.exists(profile))
 
   # however, other paths should resolve relative to the active profile

--- a/vignettes/profiles.Rmd
+++ b/vignettes/profiles.Rmd
@@ -1,0 +1,66 @@
+---
+title: "Custom Profiles"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Custom Profiles}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+
+## Introduction
+
+Starting with `renv 0.13.0`, it is possible to activate and switch between
+different profiles associated with a project. A profile can be thought of as
+a different mode in which a project is used. For example:
+
+- A "development" profile might be used when developing and testing a project,
+- A "production" profile might be used for production deployments,
+- A "shiny" profile might be used when running the Shiny application.
+
+At its heart, activating or using a particular profile implies using a different
+set of paths for the project library and lockfile. With this, it is possible
+to associate different packages, and different dependencies, with different
+workflows in a single project using `renv`.
+
+
+## Usage
+
+By default, `renv` projects use the "default" profile, which implies that
+library and lockfile paths are set in the typical way. To activate a particular
+profile, use:
+
+```
+renv::activate(profile = "dev")
+```
+
+This creates a profile called `"dev"`, and sets it as the default for the
+project, so that newly-launched R sessions will operate using the `"dev"`
+profile. After setting this and re-launching R, you should see that the
+default library and lockfile paths are resolved within the `renv/profiles/dev`
+folder from the project root.
+
+Alternatively, if you want to activate a particular profile for an R session
+without setting it as the default, you can use:
+
+```
+Sys.setenv(RENV_PROFILE = "dev")
+```
+
+and `renv` will automatically use that profile as appropriate when computing
+library and lockfile paths. Similarly, from the command line, you might
+enforce the use of a particular profile in an `renv` project with:
+
+```
+export RENV_PROFILE=dev
+```
+
+With that set, `renv` would default to using the `"dev"` profile for any
+newly-launched R sessions within `renv` projects.

--- a/vignettes/profiles.Rmd
+++ b/vignettes/profiles.Rmd
@@ -1,14 +1,15 @@
 ---
-title: "Custom Profiles"
+title: "Project Profiles"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Custom Profiles}
+  %\VignetteIndexEntry{Project Profiles}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
+  eval = FALSE,
   collapse = TRUE,
   comment = "#>"
 )
@@ -48,7 +49,7 @@ default library and lockfile paths are resolved within the `renv/profiles/dev`
 folder from the project root.
 
 Alternatively, if you want to activate a particular profile for an R session
-without setting it as the default, you can use:
+without setting it as the default for new R sessions, you can use:
 
 ```
 Sys.setenv(RENV_PROFILE = "dev")
@@ -64,3 +65,35 @@ export RENV_PROFILE=dev
 
 With that set, `renv` would default to using the `"dev"` profile for any
 newly-launched R sessions within `renv` projects.
+
+To activate the "default" profile used by a project, use:
+
+```
+renv::activate(profile = NULL)
+```
+
+
+## Managing Profile-specific Dependencies
+
+Profile-specific package dependencies can be declared within the project's
+top-level `DESCRIPTION` file. For example, to declare a set of dependencies
+for a profile called "shiny":
+
+```
+Config/renv/profiles/shiny/dependencies: shiny, tidyverse
+```
+
+The dependencies in this field can be specified in a format similar to that of
+the `Depends` and `Imports` fields of a regular `DESCRIPTION` file. These
+dependencies will be included in addition to the default set of dependencies
+normally discovered in the project. If you'd prefer that only the packages
+enumerated in this field are used, you can opt-in to using `"explicit"`
+snapshots, and leave the `Imports`, `Depends` and `Suggests` fields blank:
+
+```{r}
+renv::settings$snapshot.type("explicit")
+```
+
+When set, only the dependencies listed in the project `DESCRIPTION` file will
+be used when the lockfile is generated. See `?renv::snapshot` for more details.
+


### PR DESCRIPTION
This PR makes it possible to bind a set of disparate "profiles" with a particular `renv` project. Essentially, profiles are a way of associating different sets of libraries / lockfiles with a particular project, keyed for a particular workflow. See the vignette for more details.

Closes https://github.com/rstudio/renv/issues/253.