### PR TITLE
Unignored check for file size in case of zip/tar archive during pkg installation

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -43,15 +43,6 @@ download <- function(url, destfile, type = NULL, quiet = FALSE, headers = NULL) 
   # on Windows, try using our local curl binary if available
   renv_scope_downloader()
 
-  # if this file is a zipfile or tarball, rather than attempting
-  # to download headers etc. to validate the file is okay, just
-  # check that the archive appears not to be damaged
-  status <- renv_download_check_archive(destfile)
-  if (identical(status, TRUE)) {
-    vwritef("\tOK [file is up to date]")
-    return(destfile)
-  }
-
   # if the file already exists, compare its size with
   # the server's reported size for that file
   info <- file.info(destfile, extra_cols = FALSE)


### PR DESCRIPTION
resolves #504 


Once this PR is merged, one should be able to reinstall a package in case the package size changed in the remote repository.

This scenario can happen for example when a user uses a version identifier like 99.99.99.9000 as a snapshot placeholder, where snapshot means a development version that should reinstalled always when renv::install is called

Another reason for this fix is a scenario where a downloaded package is invalid from somehow reason (network failure, packet loss) and a user needs to reinstall it.