### PR TITLE
Support multiple caches

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -114,6 +114,19 @@ renv_cache_synchronize <- function(record, linkable = FALSE) {
 
   # construct cache entry
   cache <- renv_cache_find(record)
+
+  copied <- FALSE
+  for (cachePath in cache) {
+    copied <- renv_cache_synchronize_inner(cachePath, record, linkable, path)
+    if (copied)
+      return(TRUE)
+  }
+  return(FALSE)
+
+}
+
+renv_cache_synchronize_inner <- function(cache, record, linkable, path) {
+
   if (!nzchar(cache))
     return(FALSE)
 

--- a/R/paths.R
+++ b/R/paths.R
@@ -17,8 +17,10 @@ renv_paths_common <- function(name, prefixes = NULL, ...) {
     Sys.getenv(envvar, unset = NA) %NA%
     renv_paths_root(name)
 
-  if (identical(name, "cache") && grepl(";", root, fixed = TRUE))
-    root <- strsplit(root, ";", fixed = TRUE)[[1]]
+  # check if the cache consists of multiple paths, if yes then split the paths
+  # this allows mixing read-only and read+write cache directories. See also https://github.com/rstudio/renv/issues/628
+  if (identical(name, "cache") && grepl("[:;]", root))
+    root <- strsplit(root, "[:;]")[[1]]
 
   # form rest of path
   prefixed <- if (length(prefixes))

--- a/R/paths.R
+++ b/R/paths.R
@@ -17,6 +17,9 @@ renv_paths_common <- function(name, prefixes = NULL, ...) {
     Sys.getenv(envvar, unset = NA) %NA%
     renv_paths_root(name)
 
+  if (identical(name, "cache") && grepl(";", root, fixed = TRUE))
+    root <- strsplit(root, ";", fixed = TRUE)[[1]]
+
   # form rest of path
   prefixed <- if (length(prefixes))
     file.path(root, paste(prefixes, collapse = "/"))

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -1,6 +1,47 @@
 
 context("Cache")
 
+# test_that("multiple cache directories are used", {
+#   skip_on_cran()
+#
+#   # use a temporary cache for this test as we're going
+#   # to mutate and invalidate it
+#   tempcache1 <- tempfile("renv-tempcache-")
+#   ensure_directory(tempcache1)
+#   tempcache2 <- tempfile("renv-tempcache-")
+#   ensure_directory(tempcache2)
+#   browser()
+#   on.exit({
+#     unlink(tempcache1, recursive = TRUE)
+#     unlink(tempcache2, recursive = TRUE)
+#   }, add = TRUE)
+#   renv_scope_envvars(RENV_PATHS_CACHE = paste(tempcache1, tempcache2, sep = ";"))
+#
+#   # initialize project
+#   renv_tests_scope("breakfast")
+#   renv::init()
+#
+#   # find packages in the cache
+#   cache <- renv_cache_list()
+#
+#   # diagnostics for missing DESCRIPTION
+#   bread <- renv_cache_list(packages = "bread")
+#   descpath <- file.path(bread, "DESCRIPTION")
+#   unlink(descpath)
+#
+#   # diagnostics for bad hash
+#   breakfast <- renv_cache_list(packages = "breakfast")
+#   descpath <- file.path(breakfast, "DESCRIPTION")
+#   desc <- renv_description_read(descpath)
+#   desc$Version <- "2.0.0"
+#   renv_dcf_write(desc, file = descpath)
+#
+#   # check problems explicitly
+#   problems <- renv_cache_diagnose(verbose = FALSE)
+#   expect_true(nrow(problems) == 2)
+#
+# })
+
 test_that("issues within the cache are reported", {
   skip_on_cran()
 

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -1,47 +1,6 @@
 
 context("Cache")
 
-# test_that("multiple cache directories are used", {
-#   skip_on_cran()
-#
-#   # use a temporary cache for this test as we're going
-#   # to mutate and invalidate it
-#   tempcache1 <- tempfile("renv-tempcache-")
-#   ensure_directory(tempcache1)
-#   tempcache2 <- tempfile("renv-tempcache-")
-#   ensure_directory(tempcache2)
-#   browser()
-#   on.exit({
-#     unlink(tempcache1, recursive = TRUE)
-#     unlink(tempcache2, recursive = TRUE)
-#   }, add = TRUE)
-#   renv_scope_envvars(RENV_PATHS_CACHE = paste(tempcache1, tempcache2, sep = ";"))
-#
-#   # initialize project
-#   renv_tests_scope("breakfast")
-#   renv::init()
-#
-#   # find packages in the cache
-#   cache <- renv_cache_list()
-#
-#   # diagnostics for missing DESCRIPTION
-#   bread <- renv_cache_list(packages = "bread")
-#   descpath <- file.path(bread, "DESCRIPTION")
-#   unlink(descpath)
-#
-#   # diagnostics for bad hash
-#   breakfast <- renv_cache_list(packages = "breakfast")
-#   descpath <- file.path(breakfast, "DESCRIPTION")
-#   desc <- renv_description_read(descpath)
-#   desc$Version <- "2.0.0"
-#   renv_dcf_write(desc, file = descpath)
-#
-#   # check problems explicitly
-#   problems <- renv_cache_diagnose(verbose = FALSE)
-#   expect_true(nrow(problems) == 2)
-#
-# })
-
 test_that("issues within the cache are reported", {
   skip_on_cran()
 
@@ -183,5 +142,71 @@ test_that("corrupt Meta/package.rds is detected", {
   expect_true(nrow(diagnostics) == 1)
   expect_true(diagnostics$Package == "bread")
   expect_true(diagnostics$Version == "1.0.0")
+
+})
+
+test_that("multiple cache directories are used", {
+  skip_on_cran()
+  skip_on_os("windows") # setting folder permissions is a bit more complex on windows
+
+  chmod <- function(path, mode = c("read", "read+write")) {
+    mode <- match.arg(mode)
+    path <- normalizePath(path)
+    stopifnot(file.exists(path))
+    # '5' (read and execute) is the minimum permission that will work.
+    # With '4' (read only) things like dir() don't work anymore.
+    numbers <- if (mode == "read") "555" else "777"
+    system(sprintf("chmod %s %s", numbers, path))
+  }
+
+  # use multiple temporary caches for this test
+  tempcache1 <- tempfile("renv-tempcache-")
+  ensure_directory(tempcache1)
+  tempcache2 <- tempfile("renv-tempcache-")
+  ensure_directory(tempcache2)
+
+  on.exit({
+    unlink(tempcache1, recursive = TRUE)
+    unlink(tempcache2, recursive = TRUE)
+  }, add = TRUE)
+
+  # add both packages to the cache
+  renv_scope_envvars(RENV_PATHS_CACHE = paste(tempcache1, tempcache2, sep = ";"))
+
+  # initialize project
+  renv_tests_scope()
+  renv::init()
+
+  # there should be two paths in the cache
+  expect_length(renv::paths$cache(), 2L)
+
+  # install bread to first cache path
+  renv::install("bread")
+
+  # test that there is one package (bread) and it is installed in the first cache
+  cache <- renv_cache_list()
+  expect_length(cache, 1L)
+  expect_true(startsWith(cache[basename(cache) == "bread"], tempcache1))
+
+  # make the first cache read only
+  chmod(renv::paths$cache()[1L], "read")
+
+  # install oatmeal to second cache path
+  renv::install("oatmeal")
+
+  # test that there are 2 packages and the latest package (oatmeal) is installed in the second cache
+  cache <- renv_cache_list()
+  expect_length(cache, 2L)
+  expect_true(startsWith(cache[basename(cache) == "oatmeal"], tempcache2))
+
+  # make the first cache read+write again, should now install into the first cache again
+  chmod(renv::paths$cache()[1L], "read+write")
+
+  renv::install("toast")
+
+  # test that there are 3 packages and the latest package (toast) is installed in the first cache
+  cache <- renv_cache_list()
+  expect_length(cache, 3L)
+  expect_true(startsWith(cache[basename(cache) == "toast"], tempcache1))
 
 })


### PR DESCRIPTION
Fixes https://github.com/rstudio/renv/issues/628 and adds a unit test. I've emailed the contributor agreement.

An example that uses multiple caches:
```r
mkdir <- function(path) {
  if (!dir.exists(path))
    dir.create(path, recursive = TRUE)
  else TRUE
}

chmod <- function(path, mode = c("read", "read+write")) {
  path <- normalizePath(path)
  mode <- match.arg(mode)
  stopifnot(file.exists(path))
  # I think '5' (read and execute) is the minimum that will work.
  # With '4' (read only) things like dir() don't work anymore.
  numbers <- if (mode == "read") "577" else "777"
  system(sprintf("chmod %s %s", numbers, path))
}

cacheDir1 <- "~/.local/share/renvTest/cache1"
cacheDir2 <- "~/.local/share/renvTest/cache2"

# use a ; to distinguish between multiple caches
Sys.setenv("RENV_PATHS_CACHE" = paste(cacheDir1, cacheDir2, sep = ";"))
Sys.getenv("RENV_PATHS_CACHE")

# two paths
renv::paths$cache()

sapply(renv::paths$cache(), unlink, recursive = TRUE)
sapply(renv::paths$cache(), mkdir)

# installed into first path
renv::install("crayon")

sapply(renv::paths$cache(), dir)

chmod(renv::paths$cache()[1], "read")

# installed into second path
renv::install("R.methodsS3")

sapply(renv::paths$cache(), dir)

# remove symlink to crayon and R.methodsS3
file.remove(file.path(renv::paths$library(), c("crayon", "R.methodsS3")))

sapply(renv::paths$cache(), chmod, "read")

# both caches are read-only but linking still works
renv::install("crayon")
renv::install("R.methodsS3")

# new package is installed in the local folder
renv::install("R.oo")

# R.oo is not in the cache but in the local folder
sapply(renv::paths$cache(), dir)
"R.oo" %in% sapply(renv::paths$library(), dir)
```
Note that there is already quite some stuff in place that just 'works' with multiple caches because the code accepts vectorized input. This goes for the changes in `paths.R` but also when copying from the cache. I'm happy to look into more edge cases (cache 1 contains version A of a package while cache 2 contains version B) but I thought this is an okay start.

Comments and feedback are welcome!
