### PR TITLE
Fix detection of caches with hashes

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -26,6 +26,14 @@ renv_cache_find <- function(record) {
   # if we have a hash, use it directly
   if (!is.null(record$Hash)) {
     path <- with(record, renv_paths_cache(Package, Version, Hash, Package))
+
+    # if there are multiple caches, return the first existing one.
+    # if no paths exist, return the first cache
+    if (length(path) > 1L) {
+      existing_paths <- which(dir.exists(path))
+      path <- path[if (length(existing_paths) == 0) 1L else existing_paths[1L]]
+    }
+
     return(path)
   }
 

--- a/R/cache.R
+++ b/R/cache.R
@@ -31,7 +31,8 @@ renv_cache_find <- function(record) {
     # if no paths exist, return the first cache
     if (length(path) > 1L) {
       existing_paths <- which(dir.exists(path))
-      path <- path[if (length(existing_paths) == 0) 1L else existing_paths[1L]]
+      if (length(existing_paths) > 0)
+        path <- path[existing_paths[1L]]
     }
 
     return(path)


### PR DESCRIPTION
So we played around a bit with multiple caches and unfortunately, it looks like my previous PR (#653) introduced a bug. This PR hopefully solves that. The problem is that some callers of `renv_cache_find` really expect a single string but this code
```r
if (!is.null(record$Hash)) {
  path <- with(record, renv_paths_cache(Package, Version, Hash, Package))
  return(path)
}
```
always returns multiple strings if there are multiple caches. This mainly occurs when calling `renv::restore`, or when passing a record to `renv::install`.

Below some example code that does not retrieve an installed package from the cache but instead downloads it anew. We also encountered situations where for some packages an error was thrown, but I think the many warnings speak for themselves. 
```r
mkdir <- function(path) {
  if (!dir.exists(path))
    dir.create(path, recursive = TRUE)
  else TRUE
}

cacheDir1 <- "~/.local/share/renvTest/cache1"
cacheDir2 <- "~/.local/share/renvTest/cache2"

Sys.setenv("RENV_PATHS_CACHE" = paste(cacheDir1, cacheDir2, sep = ";"))
Sys.getenv("RENV_PATHS_CACHE")

sapply(renv::paths$cache(), unlink, recursive = TRUE)
unlink(file.path(renv::paths$library(), "crayon"))
sapply(renv::paths$cache(), mkdir)

# install crayon
renv::install("crayon@1.4.1")

# record copied from renv.lock, usually called within renv::restore()
record <- list(crayon = list(
  "Package"    = "crayon",
  "Version"    = "1.4.1",
  "Source"     = "Repository",
  "Repository" = "CRAN",
  "Hash"       = "e75525c55c70e5f4f78c9960a4b402e9"
))
# * Querying repositories for available source packages ... Done!
# Retrieving 'https://cran.rstudio.com/src/contrib/crayon_1.4.1.tar.gz' ...
# 	OK [file is up to date]
# Installing crayon [1.4.1] ...
# 	OK [built from source]
# Copying crayon [1.4.1] into the cache ...
# 	OK [copied 21 files in 0.0059 seconds]

# skipping this step causes an error on master, also with a single cache
unlink(file.path(renv::paths$library(), "crayon"))

renv::install(record) # goes wrong on master:
# Retrieving 'https://cran.rstudio.com/src/contrib/crayon_1.4.1.tar.gz' ...
# 	OK [file is up to date]
# Installing crayon [1.4.1] ...
# 	OK [built from source]
# Copying crayon [1.4.1] into the cache ...
# 	OK [copied 21 files in 0.025 seconds]
# Warning messages:
# 1: In if (!file.exists(descpath)) return("unknown") :
#   the condition has length > 1 and only the first element will be used
# 2: In envir[[path]] : wrong arguments for subsetting an environment
# more warnings
```

Comments/ feedback are welcome! I already send a Contributor License Agreement last time, but let me know if I need to send another one.