### PR TITLE
fix a typo in the local-sources vignette

### DIFF
--- a/vignettes/local-sources.Rmd
+++ b/vignettes/local-sources.Rmd
@@ -50,7 +50,7 @@ To directly install a package from these local sources, you must specify the pac
 version or provide the full path to the tarball:
 
 - `renv::install("<package>@<version>")`
-- `renv::install("<project>/renv/local/<package>_<version>.tar.gz`
+- `renv::install("<project>/renv/local/<package>_<version>.tar.gz")`
 
 Note that packages placed in one of these local sources will override any
 default source recorded in the lockfile. For example, if `skeleton 1.0.0` was


### PR DESCRIPTION
Thanks for this nice package.  This PR fixes a typo in the `vignette/local-sources.Rmd`.