### PR TITLE
added missing documentation entry for 'vcs.ignore.local'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.13.2-6
+Version: 0.13.2-7
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio", role = c("cph"))

--- a/R/settings.R
+++ b/R/settings.R
@@ -305,6 +305,12 @@ renv_settings_impl <- function(name, validate, default, update) {
 #'
 #' }
 #'
+#' \item{\code{vcs.ignore.local}}{
+#'
+#'   Set whether `renv` project-specific local sources are excluded from version control.
+#'
+#' }
+#'
 #' }
 #'
 #' @section Defaults:

--- a/man/settings.Rd
+++ b/man/settings.Rd
@@ -82,6 +82,12 @@ Set whether the \code{renv} project library is excluded from version control.
 
 }
 
+\item{\code{vcs.ignore.local}}{
+
+Set whether \code{renv} project-specific local sources are excluded from version control.
+
+}
+
 }
 }
 


### PR DESCRIPTION
Added missing documentation in `?renv::settings` (see #696).