### PR TITLE
Keep only library path subfolders that are valid R package names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.13.2-12
+Version: 0.13.2-14
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio", role = c("cph"))

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -529,9 +529,10 @@ renv_snapshot_r_packages_impl <- function(library = NULL,
   ignored <- renv_project_ignored_packages(project = project)
   paths <- paths[!basename(paths) %in% ignored]
 
-  # ignore '_cache' folder explicitly (written by 'pak')
-  paths <- paths[!basename(paths) %in% "_cache"]
-
+  # remove paths that are not valid package names
+  pattern <- sprintf("^%s$", .standard_regexps()$valid_package_name)
+  paths <- paths[grep(pattern, basename(paths))]
+  
   # validate the remaining set of packages
   valid <- renv_snapshot_r_library_diagnose(library, paths)
 


### PR DESCRIPTION
I noticed that **renv** can complaints if you have non-package subfolders in your library path, e.g.

```r
Project '~/test' loaded. [renv 0.13.2]
The following package(s) are missing their DESCRIPTION files:

    _foobar [/home/hb/test/renv/library/R-4.0/x86_64-pc-linux-gnu/_foobar]

These may be left over from a prior, failed installation attempt.
Consider removing or re-installing these packages.
```

This PR fixes that by ignoring folders that cannot be packages. This also removes the need for hardcoded filters, such as the one used to drop subfolders named `_cache`.