### PR TITLE
Removes the path->shortpath normalizePath hack when R version >= 4.0.0

### DIFF
--- a/R/path.R
+++ b/R/path.R
@@ -45,6 +45,11 @@ renv_path_normalize_win32 <- function(path,
                                       winslash = "/",
                                       mustWork = FALSE)
 {
+
+  # see the NOTE above, this workaround is only necessary for R < 4 and it complicates things unnecessarily
+  if (getRversion() >= "4.0.0")
+    return(normalizePath(path, winslash, mustWork))
+
   # get encoding for this set of paths
   enc <- Encoding(path)
 


### PR DESCRIPTION
I sadly enough cannot give an easily reproducible example of the problems we ran into.

But using this hack that is apparently only necessary on R<4 causes our application (with embedded R) to choke windows somehow. And if the hack isn't necessary anyhow than we prefer not using it at all.