### PR TITLE
stop detecting --quiet and -q

### DIFF
--- a/R/session.R
+++ b/R/session.R
@@ -7,7 +7,7 @@ renv_session_quiet <- function() {
   if (!is.na(index))
     args <- head(args, n = index - 1L)
 
-  quiet <- c("-s", "-q", "--slave", "--no-echo", "--quiet", "--silent")
+  quiet <- c("-s", "--slave", "--no-echo")
   any(quiet %in% args)
 
 }


### PR DESCRIPTION
Because they just mean to suppress the startup message
```
  -q, --quiet           Don't print startup message
  --silent              Same as --quiet
```
Not sure if it is the best way to handle #733, but this is a solution.