### PR TITLE
Fix box::use() declarations with trailing comma

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # renv 0.14.0 (UNRELEASED)
 
+* Fixed crash during dependency discovery when encountering `box::use()`
+  declarations that use a trailing comma (@klmr)
+
 * `renv::clean()` no longer attempts to clean the system library by default.
   (#737)
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1085,6 +1085,11 @@ renv_dependencies_discover_r_box <- function(node, stack, envir) {
 
 renv_dependencies_discover_r_box_impl <- function(node, stack, envir) {
 
+  # Trailing comma causes empty nodes
+  if (identical(node, quote(expr = ))) {
+    return(FALSE)
+  }
+
   # if the node is just a symbol, then it's the name of a package
   if (is.symbol(node)) {
     package <- as.character(node)

--- a/tests/testthat/resources/box.R
+++ b/tests/testthat/resources/box.R
@@ -2,5 +2,5 @@ box::use(
     A,
     b = B,
     C[...],
-    D[c, d]
+    D[c, d],
 )


### PR DESCRIPTION
As of ‘box’ v1.0.1, the `box::use()` declaration allows trailing commas. This PR adds support for this syntax to the ‘renv’ dependency discovery. Without this PR, presence of such a trailing comma causes a crash during dependency discovery.

The PR also adds a test case which runs successfully with the change. However, some of the other tests (in `test-actions.R` and `test-migrate.R`) reproducibly fail on my system (regardless of these code changes), probably due to mismatching configuration.