### PR TITLE
Check for .Rprofile in home directory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.13.2-59
+Version: 0.13.2-60
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio", role = c("cph"))

--- a/R/load.R
+++ b/R/load.R
@@ -260,7 +260,11 @@ renv_load_rprofile <- function(project = NULL) {
 
   renv_scope_libpaths()
 
-  profile <- Sys.getenv("R_PROFILE_USER", unset = "~/.Rprofile")
+  profile <- Sys.getenv("R_PROFILE_USER")
+
+  if (!file.exists(profile))
+    profile <- file.path(Sys.getenv("HOME"), ".Rprofile")
+
   if (file.exists(profile))
     renv_load_rprofile_impl(profile)
 
@@ -546,4 +550,3 @@ renv_load_invoke <- function(callback) {
     callback()
 
 }
-


### PR DESCRIPTION
The following line does not work when `R_PROFILE_USER` is set to `""`, which it apparently is on my installation (Fedora 34).

https://github.com/rstudio/renv/blob/bfc791ba80ea7f8e5669538a9ba0552008ad2e14/R/load.R#L263

This means that renv doesn't find my profile (in `~/.Rprofile`) when I set `RENV_CONFIG_USER_PROFILE=TRUE`.

With this pull request, the function now explicitly checks the home folder for the file. I removed the input to `unset`, but maybe it could've stayed.