### PR TITLE
Add dependency discovery support for utility scripts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # renv 0.14.0 (UNRELEASED)
 
+* Added dependency discovery support for R utility scripts identified by a
+  shebang line instead of a file extension. (#801; @klmr)
+
 * Fixed an issue where `renv::install("<package>", type = "both")` would attempt
   to install the package from sources, even if the current system did not have
   the requisite build tools available. (#800)
@@ -54,7 +57,7 @@
 
 * Fixed crash during dependency discovery when encountering `box::use()`
   declarations that use a trailing comma, and no longer treat `.` and `..` as
-  package names (@klmr)
+  package names. (@klmr)
 
 * `renv::clean()` no longer attempts to clean the system library by default.
   (#737)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -249,25 +249,13 @@ renv_dependencies_callback <- function(path) {
 }
 
 is_r_executable <- function(path) {
+  # don't check executability via `file.access` since this is implemented
+  # differently on Windows, and would thus lead to different dependencies being
+  # discovered across platforms
   if (nzchar(fileext(path)))
     return(FALSE)
 
-  grepl("\\b(R|r|Rscript)\\b", get_shebang_command(path))
-}
-
-get_shebang_command <- function(path) {
-  con <- file(path, open = "rb")
-  on.exit(close(con), add = TRUE)
-
-  signature <- charToRaw("#!")
-  first_two_bytes <- readBin(con, what = "raw", n = length(signature))
-  looks_like_script <- identical(first_two_bytes, signature)
-
-  # skip binary files with potentially very long first "lines"
-  if (looks_like_script)
-    readLines(con, n = 1L, warn = FALSE)
-  else
-    ""
+  grepl("\\b(R|r|Rscript)\\b", renv_file_shebang(path))
 }
 
 renv_dependencies_find_extra <- function(root) {

--- a/R/files.R
+++ b/R/files.R
@@ -491,3 +491,18 @@ renv_file_read <- function(path) {
   contents <- readLines(path, warn = FALSE, encoding = "UTF-8")
   paste(contents, collapse = "\n")
 }
+
+renv_file_shebang <- function(path) {
+  con <- file(path, open = "rb")
+  on.exit(close(con), add = TRUE)
+
+  signature <- charToRaw("#!")
+  first_two_bytes <- readBin(con, what = "raw", n = length(signature))
+  looks_like_script <- identical(first_two_bytes, signature)
+
+  # skip binary files with potentially very long first "lines"
+  if (looks_like_script)
+    readLines(con, n = 1L, warn = FALSE)
+  else
+    ""
+}

--- a/tests/testthat/resources/utility
+++ b/tests/testthat/resources/utility
@@ -1,0 +1,8 @@
+#!/usr/bin/env Rscript
+
+library(A)
+
+B::C()
+
+
+# vim: ft=r

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -342,3 +342,9 @@ test_that("bslib dependencies are discovered", {
   deps <- dependencies("resources/bslib.Rmd", progress = FALSE)
   expect_true("bslib" %in% deps$Package)
 })
+
+test_that("utility script dependencies are discovered", {
+  deps <- dependencies("resources/utility", progress = FALSE)
+  expect_false(is.null(deps))
+  expect_setequal(deps$Package, c("A", "B"))
+})


### PR DESCRIPTION
Implements #801 

If a file has no file extension, this PR adds code that opens the file in binary mode and reads the first two bytes; if these bytes are equal to `#!`, it continues to read the first line and checks whether it contains the word `R`, `r` or `RScript`. If so, this file is treated as an R script file.

For now this PR does *not* check whether the file is executable, since file executability is not a cross-platform property, which would thus lead to different results of `renv::dependencies()` across platforms (in particular, `file.access` does not consider file mode flags on Windows; instead, it tests for specific file extensions).

I’m unsure whether the helper function location (in `R/dependencies.R`) is correct within the project’s scope: maybe they should instead go into `R/utils.R`?