### PR TITLE
Avoid partial matching on chunk options that start with `exercise`

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -627,7 +627,7 @@ renv_dependencies_discover_chunks_ignore <- function(chunk) {
     return(TRUE)
 
   # skip learnr exercises
-  if (truthy(chunk$params$exercise, default = FALSE))
+  if (truthy(chunk$params[["exercise"]], default = FALSE))
     return(TRUE)
 
   # skip chunks whose labels end in '-display'


### PR DESCRIPTION
Replaces `$` list subsetting for `exercise` knitr chunk option with `[[` to avoid partial matching on other `exercise*` chunk options, e.g. `exercise.eval`.