### PR TITLE
allow renv ignores to be set via option

### DIFF
--- a/R/renvignore.R
+++ b/R/renvignore.R
@@ -45,6 +45,11 @@ renv_renvignore_pattern <- function(path = getwd(), root = path) {
   include <- unlist(extract(patterns, "include"))
   exclude <- unlist(extract(patterns, "exclude"))
 
+  # allow for inclusion / exclusion via option
+  # (primarily intended for internal use with packrat)
+  include <- c(include, renv_renvignore_pattern_extra("include", root))
+  exclude <- c(exclude, renv_renvignore_pattern_extra("exclude", root))
+
   # ignore hidden directories by default
   exclude <- c("/[.][^/]*/$", exclude)
 
@@ -161,5 +166,25 @@ renv_renvignore_exec <- function(path, root, children) {
 
   # return vector of excludes
   excludes
+
+}
+
+renv_renvignore_pattern_extra <- function(key, root) {
+
+  # check for value from option
+  optname <- paste("renv.renvignore", key, sep = ".")
+  patterns <- getOption(optname)
+  if (is.null(patterns))
+    return(NULL)
+
+  # should we use the pattern as-is?
+  asis <- attr(patterns, "asis", exact = TRUE)
+  if (identical(asis, TRUE))
+    return(patterns)
+
+  # otherwise, process it as an .renvignore-style ignore
+  root <- attr(patterns, "root", exact = TRUE) %||% root
+  patterns <- renv_renvignore_parse(patterns, root)
+  patterns[[key]]
 
 }

--- a/tests/testthat/test-renvignore.R
+++ b/tests/testthat/test-renvignore.R
@@ -123,3 +123,24 @@ test_that(".renvignore can be used to ignore all but certain files", {
   expect_false("oatmeal" %in% deps$Package)
 
 })
+
+test_that("ignores can be set via option if required", {
+
+  renv_tests_scope()
+
+  dir.create("data")
+  writeLines("library(A)", con = "data/script.R")
+
+  dir.create("inst")
+  writeLines("library(B)", con = "inst/script.R")
+
+  dir.create("ok")
+  writeLines("library(C)", con = "ok/script.R")
+
+  exclude <- structure(c("/data/", "/inst/"), asis = TRUE)
+  options(renv.renvignore.exclude = exclude)
+
+  deps <- dependencies(progress = FALSE)
+  expect_setequal(deps$Package, "C")
+
+})


### PR DESCRIPTION
Closes https://github.com/rstudio/renv/issues/863.

This PR allows one to set `.renvignore`-style ignores for `renv` via the option `renv.renvignore.exclude`. These can either be `.gitignore`-style ignores, or (if the `asis` attribute is set to `TRUE`) PCREs which match against the full file path. (Directories will have a trailing `/` appended to the path.)

The option is primarily intended for internal consumption, so I haven't documented any explicit interface here.

I think the usage for Packrat here would be something like:

```
# get ignores
ignores <- packrat::opts$ignored.directories()

# post-process ignore in some appropriate way

# tell renv to use the pattern as-is
attr(ignores, "asis", TRUE) <- TRUE

# set the option
options(renv.renvignore.exclude = ignores)
```

Let me know if this seems sane.