### PR TITLE
Don't write to global cache when cache is disabled

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -253,7 +253,7 @@ renv_load_project <- function(project) {
     projlist <- readLines(projects, warn = FALSE, encoding = "UTF-8")
 
   # if the project is already recorded or cache disabled, nothing to do
-  if (project %in% projlist || !renv::config$cache.enabled())
+  if (project %in% projlist && renv::config$cache.enabled())
     return(TRUE)
 
   # otherwise, update the project list

--- a/R/load.R
+++ b/R/load.R
@@ -252,8 +252,8 @@ renv_load_project <- function(project) {
   if (file.exists(projects))
     projlist <- readLines(projects, warn = FALSE, encoding = "UTF-8")
 
-  # if the project is already recorded, nothing to do
-  if (project %in% projlist)
+  # if the project is already recorded or cache disabled, nothing to do
+  if (project %in% projlist || !renv::config$cache.enabled())
     return(TRUE)
 
   # otherwise, update the project list

--- a/R/load.R
+++ b/R/load.R
@@ -253,7 +253,7 @@ renv_load_project <- function(project) {
     projlist <- readLines(projects, warn = FALSE, encoding = "UTF-8")
 
   # if the project is already recorded or cache disabled, nothing to do
-  if (project %in% projlist && renv::config$cache.enabled())
+  if (project %in% projlist || !renv::config$cache.enabled())
     return(TRUE)
 
   # otherwise, update the project list


### PR DESCRIPTION
Closes #837. In particular it solves weird concurrency problems with pre-commit.ci