### PR TITLE
Handling url remotes from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.14.0-66
+Version: 0.14.0-67
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio, PBC", role = c("cph"))

--- a/tests/testthat/test-remotes.R
+++ b/tests/testthat/test-remotes.R
@@ -66,6 +66,13 @@ test_that("we can parse a variety of remotes", {
   expect_equal(record$RemoteUrl, "https://github.com/kevinushey/renv.git1.git")
   expect_equal(record$RemoteRef, "main")
 
+  # url
+  record <- renv_remotes_resolve("url::https://github.com/kevinushey/renv.git1/archive/refs/heads/main.zip")
+  expect_equal(record$Package, "renv.git1")
+  expect_equal(record$Version, "0.0.0.9000")
+  expect_equal(record$RemoteUrl, "https://github.com/kevinushey/renv.git1/archive/refs/heads/main.zip")
+  expect_equal(record$Source, "URL")
+
   # # git - ssh
   # # this test appears to fail on CI (ssh access to GitHub disallowed?)
   # record <- renv_remotes_resolve("git::git@github.com:kevinushey/renv.git1.git@main")


### PR DESCRIPTION
The main reason where standard url check not working is `Remotes` section in `DESCRIPTION` file where spec contains `url::`.
```
Remotes: 
  url::https://github.com/kevinushey/renv.git1/archive/refs/heads/main.zip
```

It also possible to solve this in simple way by replace in spec. [[1]](https://github.com/galachad/renv/tree/handling-ulr-simple)
```
# check for URLs
spec <- sub("^url::", "", spec)
```