### PR TITLE
Bugfix/description encoding and bioc installer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.14.0-133
+Version: 0.14.0-134
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio, PBC", role = c("cph"))

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -95,3 +95,13 @@ renv_bioconductor_repos_biocinstaller <- function(version) {
   version <- version %||% BiocInstaller$biocVersion()
   BiocInstaller$biocinstallRepos(version = version)
 }
+
+renv_bioconductor_installer_package <- function(project = NULL){
+  bioc_version <- renv_bioconductor_version(project)
+  old <- `if`(
+    is.null(bioc_version),
+    getRversion() < "3.5.0",
+    bioc_version < "3.8"
+  )
+  "BiocInstaller" if old else "BiocManager"
+}

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -103,5 +103,5 @@ renv_bioconductor_installer_package <- function(project = NULL){
     getRversion() < "3.5.0",
     bioc_version < "3.8"
   )
-  "BiocInstaller" if old else "BiocManager"
+  `if`(old, "BiocInstaller", "BiocManager")
 }

--- a/R/dcf.R
+++ b/R/dcf.R
@@ -5,8 +5,25 @@
 # - always keeps whitespace
 renv_dcf_read <- function(file, text = NULL, ...) {
 
+  encoding <- "UTF-8"
+
+  if(is.null(text)){
+    path <- `if`(
+      inherits(file, "connection"),
+      unlist(summary(file))["description"],
+      file
+    )
+    raw_contents <- readBin(path, "raw", file.size(path))
+    enc_offset <- grepRaw("Encoding:", raw_contents)
+    if(length(enc_offset)){
+      line_length <- grepRaw("\n", tail(raw_contents, -enc_offset))
+      raw_enc <- head(tail(raw_contents, -enc_offset - 9L), line_length - 10L)
+      encoding <- rawToChar(raw_enc)
+    }
+  }
+
   # read the file
-  contents <- text %||% renv_file_read(file)
+  contents <- text %||% renv_file_read(file, encoding = encoding)
 
   # look for tags
   pattern <- "(?:^|\n)[^\\s][^:\n]*:"

--- a/R/files.R
+++ b/R/files.R
@@ -505,8 +505,12 @@ renv_file_find <- function(path, predicate) {
 
 }
 
-renv_file_read <- function(path) {
-  contents <- readLines(path, warn = FALSE, encoding = "UTF-8")
+renv_file_read <- function(path, encoding = "UTF-8") {
+  contents <- readLines(path, warn = FALSE, encoding = encoding)
+
+  if(encoding != 'UTF-8')
+    contents <- iconv(contents, from = encoding, to = "UTF-8")
+
   paste(contents, collapse = "\n")
 }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -888,7 +888,7 @@ renv_snapshot_filter_packages <- function(project, records, packages) {
 
 }
 
-renv_add_bioc_packages <- (packages, records, project = NULL){
+renv_add_bioc_packages <- function(packages, records, project = NULL){
   # add in bioconductor infrastructure packages
   # if any other bioconductor packages detected
   sources <- extract_chr(packages, "Source")

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -303,7 +303,7 @@ renv_snapshot_validate_bioconductor <- function(project, lockfile, libpaths) {
     return(ok)
 
   # check for BiocManager or BiocInstaller
-  package <- if (getRversion() >= "3.5.0") "BiocManager" else "BiocInstaller"
+  package <- renv_bioconductor_installer_package(project)
   if (!package %in% names(records)) {
 
     text <- c(
@@ -853,15 +853,7 @@ renv_snapshot_filter_impl <- function(project, records, source) {
   paths <- renv_package_dependencies(used, project = project)
   all <- as.character(names(paths))
   kept <- keep(records, all)
-
-  # add in bioconductor infrastructure packages
-  # if any other bioconductor packages detected
-  sources <- extract_chr(kept, "Source")
-  if ("Bioconductor" %in% sources) {
-    packages <- c("BiocManager", "BiocInstaller", "BiocVersion")
-    for (package in packages)
-      kept[[package]] <- records[[package]]
-  }
+  kept <- renv_add_bioc_packages(kept, records, project)
 
   kept
 
@@ -890,17 +882,26 @@ renv_snapshot_filter_packages <- function(project, records, packages) {
   paths <- renv_package_dependencies(packages, project = project)
   all <- as.character(names(paths))
   kept <- keep(records, all)
-
-  # add in bioconductor infrastructure packages
-  # if any other bioconductor packages detected
-  sources <- extract_chr(kept, "Source")
-  if ("Bioconductor" %in% sources) {
-    packages <- c("BiocManager", "BiocInstaller", "BiocVersion")
-    for (package in packages)
-      kept[[package]] <- records[[package]]
-  }
+  kept <- renv_add_bioc_packages(kept, records, project)
 
   kept
+
+}
+
+renv_add_bioc_packages <- (packages, records, project = NULL){
+  # add in bioconductor infrastructure packages
+  # if any other bioconductor packages detected
+  sources <- extract_chr(packages, "Source")
+  if ("Bioconductor" %in% sources) {
+    bioc_packages <- c(
+      "BiocVersion",
+      renv_bioconductor_installer_package(project = project)
+    )
+    for (package in bioc_packages)
+      packages[[package]] <- records[[package]]
+  }
+
+  packages
 
 }
 


### PR DESCRIPTION
- Fixed: `snapshot` failed if any package with non UTF-8 encoding `DESCRIPTION` file was installed in any library (an example for such a package: `sfsmisc`)
- Fixed: `renv_lockfile_create` run with a warning if an old `BiocInstaller` installation happened to present in any of the libraries, because `renv_snapshot_filter` added `BiocInstaller` to the lockfile with its `Version` being `NULL`