### PR TITLE
Bugfix/find bioc installer package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.14.0-133
+Version: 0.14.0-134
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio, PBC", role = c("cph"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.14.0-134
+Version: 0.14.0-138
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio, PBC", role = c("cph"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.14.0-138
+Version: 0.14.0-139
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio, PBC", role = c("cph"))

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -100,7 +100,7 @@ renv_bioconductor_installer_package <- function(project = NULL) {
 
   bioc_version <- renv_bioconductor_version(project)
 
-  if(is.null(bioc_version)){
+  if (is.null(bioc_version)) {
     old <- utils::compareVersion(getRversion(), "3.5.0") < 0L
   } else {
     old <- utils::compareVersion(bioc_version, "3.8") < 0L

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -110,7 +110,7 @@ renv_bioconductor_installer_package <- function(project = NULL) {
 
 }
 
-renv_bioconductor_packages <- function(packages, records, project = NULL){
+renv_bioconductor_packages <- function(packages, records, project = NULL) {
   # add in bioconductor infrastructure packages
   # if any other bioconductor packages detected
   sources <- extract_chr(packages, "Source")

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -95,3 +95,13 @@ renv_bioconductor_repos_biocinstaller <- function(version) {
   version <- version %||% BiocInstaller$biocVersion()
   BiocInstaller$biocinstallRepos(version = version)
 }
+
+renv_bioconductor_installer_package <- function(project = NULL){
+  bioc_version <- renv_bioconductor_version(project)
+  old <- `if`(
+    is.null(bioc_version),
+    getRversion() < "3.5.0",
+    bioc_version < "3.8"
+  )
+  "BiocInstaller" if old else "BiocManager"
+}

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -106,6 +106,6 @@ renv_bioconductor_installer_package <- function(project = NULL) {
     old <- utils::compareVersion(bioc_version, "3.8") < 0L
   }
 
-  if(old) "BiocInstaller" else "BiocManager"
+  if (old) "BiocInstaller" else "BiocManager"
 
 }

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -96,7 +96,7 @@ renv_bioconductor_repos_biocinstaller <- function(version) {
   BiocInstaller$biocinstallRepos(version = version)
 }
 
-renv_bioconductor_installer_package <- function(project = NULL){
+renv_bioconductor_installer_package <- function(project = NULL) {
 
   bioc_version <- renv_bioconductor_version(project)
 

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -103,5 +103,5 @@ renv_bioconductor_installer_package <- function(project = NULL){
     getRversion() < "3.5.0",
     bioc_version < "3.8"
   )
-  "BiocInstaller" if old else "BiocManager"
+  `if`(old, "BiocInstaller", "BiocManager")
 }

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -109,3 +109,20 @@ renv_bioconductor_installer_package <- function(project = NULL) {
   if (old) "BiocInstaller" else "BiocManager"
 
 }
+
+renv_bioconductor_packages <- function(packages, records, project = NULL){
+  # add in bioconductor infrastructure packages
+  # if any other bioconductor packages detected
+  sources <- extract_chr(packages, "Source")
+  if ("Bioconductor" %in% sources) {
+    bioc_packages <- c(
+      "BiocVersion",
+      renv_bioconductor_installer_package(project = project)
+    )
+    for (package in bioc_packages)
+      packages[[package]] <- records[[package]]
+  }
+
+  packages
+
+}

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -31,7 +31,7 @@ renv_bioconductor_init_biocinstaller <- function() {
 
 }
 
-renv_bioconductor_version <- function(project) {
+renv_bioconductor_version <- function(project = NULL) {
 
   # check and see if we have an override via option
   version <- getOption("renv.bioconductor.version")
@@ -97,11 +97,15 @@ renv_bioconductor_repos_biocinstaller <- function(version) {
 }
 
 renv_bioconductor_installer_package <- function(project = NULL){
+
   bioc_version <- renv_bioconductor_version(project)
-  old <- `if`(
-    is.null(bioc_version),
-    getRversion() < "3.5.0",
-    bioc_version < "3.8"
-  )
-  `if`(old, "BiocInstaller", "BiocManager")
+
+  if(is.null(bioc_version)){
+    old <- utils::compareVersion(getRversion(), "3.5.0") < 0L
+  } else {
+    old <- utils::compareVersion(bioc_version, "3.8") < 0L
+  }
+
+  if(old) "BiocInstaller" else "BiocManager"
+
 }

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -888,7 +888,7 @@ renv_snapshot_filter_packages <- function(project, records, packages) {
 
 }
 
-renv_add_bioc_packages <- (packages, records, project = NULL){
+renv_add_bioc_packages <- function(packages, records, project = NULL){
   # add in bioconductor infrastructure packages
   # if any other bioconductor packages detected
   sources <- extract_chr(packages, "Source")

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -303,7 +303,7 @@ renv_snapshot_validate_bioconductor <- function(project, lockfile, libpaths) {
     return(ok)
 
   # check for BiocManager or BiocInstaller
-  package <- if (getRversion() >= "3.5.0") "BiocManager" else "BiocInstaller"
+  package <- renv_bioconductor_installer_package(project)
   if (!package %in% names(records)) {
 
     text <- c(
@@ -853,15 +853,7 @@ renv_snapshot_filter_impl <- function(project, records, source) {
   paths <- renv_package_dependencies(used, project = project)
   all <- as.character(names(paths))
   kept <- keep(records, all)
-
-  # add in bioconductor infrastructure packages
-  # if any other bioconductor packages detected
-  sources <- extract_chr(kept, "Source")
-  if ("Bioconductor" %in% sources) {
-    packages <- c("BiocManager", "BiocInstaller", "BiocVersion")
-    for (package in packages)
-      kept[[package]] <- records[[package]]
-  }
+  kept <- renv_add_bioc_packages(kept, records, project)
 
   kept
 
@@ -890,17 +882,26 @@ renv_snapshot_filter_packages <- function(project, records, packages) {
   paths <- renv_package_dependencies(packages, project = project)
   all <- as.character(names(paths))
   kept <- keep(records, all)
-
-  # add in bioconductor infrastructure packages
-  # if any other bioconductor packages detected
-  sources <- extract_chr(kept, "Source")
-  if ("Bioconductor" %in% sources) {
-    packages <- c("BiocManager", "BiocInstaller", "BiocVersion")
-    for (package in packages)
-      kept[[package]] <- records[[package]]
-  }
+  kept <- renv_add_bioc_packages(kept, records, project)
 
   kept
+
+}
+
+renv_add_bioc_packages <- (packages, records, project = NULL){
+  # add in bioconductor infrastructure packages
+  # if any other bioconductor packages detected
+  sources <- extract_chr(packages, "Source")
+  if ("Bioconductor" %in% sources) {
+    bioc_packages <- c(
+      "BiocVersion",
+      renv_bioconductor_installer_package(project = project)
+    )
+    for (package in bioc_packages)
+      packages[[package]] <- records[[package]]
+  }
+
+  packages
 
 }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -888,23 +888,6 @@ renv_snapshot_filter_packages <- function(project, records, packages) {
 
 }
 
-renv_add_bioc_packages <- function(packages, records, project = NULL){
-  # add in bioconductor infrastructure packages
-  # if any other bioconductor packages detected
-  sources <- extract_chr(packages, "Source")
-  if ("Bioconductor" %in% sources) {
-    bioc_packages <- c(
-      "BiocVersion",
-      renv_bioconductor_installer_package(project = project)
-    )
-    for (package in bioc_packages)
-      packages[[package]] <- records[[package]]
-  }
-
-  packages
-
-}
-
 renv_snapshot_filter_custom <- function(project, records) {
 
   option <- "renv.snapshot.filter"


### PR DESCRIPTION
Fixed: `renv_lockfile_create` run with a warning if an old `BiocInstaller` installation happened to present in any of the libraries, because `renv_snapshot_filter` added `BiocInstaller` to the lockfile with its `Version` being `NULL`