### PR TITLE
document `RENV_PATHS_LOCKFILE`

### DIFF
--- a/R/paths.R
+++ b/R/paths.R
@@ -278,7 +278,8 @@ renv_paths_root_default_tempdir <- function() {
 #' \code{RENV_PATHS_LIBRARY}         \tab The path to the project library. \cr
 #' \code{RENV_PATHS_LIBRARY_ROOT}    \tab The parent path for project libraries. \cr
 #' \code{RENV_PATHS_LIBRARY_STAGING} \tab The parent path used for staged package installs. \cr
-#' \code{RENV_PATHS_CELLAR}          \tab The cellar, containing local package binaries and sources. \cr
+#' \code{RENV_PATHS_LOCKFILE}        \tab The path to the [lockfile][lockfiles]. \cr
+#' \code{RENV_PATHS_CELLAR}          \tab The path to the cellar, containing local package binaries and sources. \cr
 #' \code{RENV_PATHS_SOURCE}          \tab The path containing downloaded package sources. \cr
 #' \code{RENV_PATHS_BINARY}          \tab The path containing downloaded package binaries. \cr
 #' \code{RENV_PATHS_CACHE}           \tab The path containing cached package installations. \cr


### PR DESCRIPTION
`RENV_PATHS_LOCKFILE` was missing for some reason in the corresponding table of env vars.