### PR TITLE
Fix handling of Rtools 4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.15.4-28
+Version: 0.15.4-29
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio, PBC", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,8 @@
 
 * Fixed an issue where `renv` could fail to install packages containing
   multibyte unicode characters in their DESCRIPTION file. (#956)
+  
+* Fixed detection of Rtools 4.2 (#1002)
 
 
 # renv 0.15.4

--- a/R/paths.R
+++ b/R/paths.R
@@ -120,7 +120,7 @@ renv_paths_rtools <- function(...) {
     root <- spec$root
   }
 
-  file.path(spec$root, ...) %||% ""
+  file.path(root, ...) %||% ""
 
 }
 

--- a/R/rtools.R
+++ b/R/rtools.R
@@ -42,10 +42,16 @@ renv_rtools_read <- function(root) {
 
 renv_rtools_version <- function(root) {
 
+
   # detect Rtools40
   mirrors <- file.path(root, "etc/pacman.d/mirrorlist.rtools")
   if (file.exists(mirrors))
     return(numeric_version("4.0"))
+
+  #detect Rtools42
+  mirrors <- file.path(root, "etc/pacman.d/mirrorlist.clang64")
+  if (file.exists(mirrors))
+    return(numeric_version("4.2"))
 
   # detect older Rtools installations
   path <- file.path(root, "VERSION.txt")
@@ -65,7 +71,8 @@ renv_rtools_compatible <- function(spec) {
     return(FALSE)
 
   ranges <- list(
-    "4.0" = c("4.0.0", "9.9.9"),
+    "4.2" = c("4.2.0", "9.9.9"),
+    "4.0" = c("4.0.0", "4.2.0"),
     "3.5" = c("3.3.0", "4.0.0"),
     "3.4" = c("3.3.0", "4.0.0"),
     "3.3" = c("3.2.0", "3.3.0"),
@@ -105,8 +112,10 @@ renv_rtools_envvars <- function(root) {
 
   if (version < "4.0")
     renv_rtools_envvars_default(root)
-  else
+  else if (version < "4.2")
     renv_rtools_envvars_rtools40(root)
+  else
+    renv_rtools_envvars_rtools42(root)
 
 }
 
@@ -128,6 +137,24 @@ renv_rtools_envvars_default <- function(root) {
     "mingw_$(WIN)/bin/",
     sep = "/"
   )
+
+  list(PATH = path, BINPREF = binpref)
+
+}
+
+renv_rtools_envvars_rtools42 <- function(root) {
+
+  # add Rtools utilities to path
+  bin <- normalizePath(
+    file.path(root, "usr/bin"),
+    winslash = "\\",
+    mustWork = FALSE
+  )
+
+  path <- paste(bin, Sys.getenv("PATH"), sep = .Platform$path.sep)
+
+  # set BINPREF
+  binpref <- ""
 
   list(PATH = path, BINPREF = binpref)
 

--- a/renv.Rproj
+++ b/renv.Rproj
@@ -17,6 +17,5 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --no-byte-compile --with-keep.source
 PackageRoxygenize: rd,collate,namespace,vignette


### PR DESCRIPTION
Fixes #1002

- Identify Rtools 4.2 when installed
- Update compatibility to indicate that Rtools 4.2 should be used for R >= 4.2
- Set `BINPREF` to `""` when using Rtools 4.2
- Handle RENV_PATHS_RTOOLS environment variable correctly