### PR TITLE
Support package names that differ from the repository name in GitHub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.15.5-49
+Version: 0.15.5-50
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio, PBC", role = c("cph"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.15.5-48
+Version: 0.15.5-49
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("RStudio, PBC", role = c("cph"))

--- a/R/remotes.R
+++ b/R/remotes.R
@@ -118,8 +118,8 @@ renv_remotes_parse_remote <- function(spec) {
 
   pattern <- paste0(
     "^",
-    "(?:[a-zA-Z.]+=)?",                # optional package name + "="
-    "(?:([^@:]+)(?:@([^:]+))?::)?",    # optional prefix, providing type + host
+    "(?:[0-9a-zA-Z.]+=)?",             # optional package name + "="
+    "(?:([^@:=]+)(?:@([^:]+))?::)?",   # optional prefix, providing type + host
     "([^/#@:]+)",                      # a username
     "(?:/([^@#:]+))?",                 # a repository (allow sub-repositories)
     "(?::([^@#:]+))?",                 # optional subdirectory

--- a/R/remotes.R
+++ b/R/remotes.R
@@ -118,6 +118,7 @@ renv_remotes_parse_remote <- function(spec) {
 
   pattern <- paste0(
     "^",
+    "(?:[a-zA-Z.]+=)?",                # optional package name + "="
     "(?:([^@:]+)(?:@([^:]+))?::)?",    # optional prefix, providing type + host
     "([^/#@:]+)",                      # a username
     "(?:/([^@#:]+))?",                 # a repository (allow sub-repositories)

--- a/tests/testthat/test-remotes.R
+++ b/tests/testthat/test-remotes.R
@@ -216,3 +216,40 @@ test_that("remote specs referencing packages in sub-sub-directories are parsed c
   expect_equal(remote, expected)
 
 })
+
+test_that("custom github package names are supported", {
+
+  spec <- "test.1pkg=user/repo"
+  remote <- renv_remotes_parse(spec)
+
+  expected <- list(
+    spec   = spec,
+    type   = "github",
+    host   = NULL,
+    user   = "user",
+    repo   = "repo",
+    subdir = NULL,
+    pull   = NULL,
+    ref    = NULL
+  )
+
+  expect_equal(remote, expected)
+
+
+  spec <- "test.1pkg=github::user/repo"
+  remote <- renv_remotes_parse(spec)
+
+  expected <- list(
+    spec   = spec,
+    type   = "github",
+    host   = NULL,
+    user   = "user",
+    repo   = "repo",
+    subdir = NULL,
+    pull   = NULL,
+    ref    = NULL
+  )
+
+  expect_equal(remote, expected)
+
+})


### PR DESCRIPTION
PR to fix #1064. I can't get the test suite to run on my laptop, so I haven't been able to fully test.