### PR TITLE
prevent "NULL" user libpaths

### DIFF
--- a/R/libpaths.R
+++ b/R/libpaths.R
@@ -147,7 +147,7 @@ renv_libpaths_user <- function() {
   for (envvar in envvars) {
 
     value <- Sys.getenv(envvar, unset = NA)
-    if (is.na(value) || value == "<NA>" || !nzchar(value))
+    if (is.na(value) || value == "<NA>" || value == "NULL" || !nzchar(value))
       next
 
     parts <- strsplit(value, .Platform$path.sep, fixed = TRUE)[[1]]


### PR DESCRIPTION
In R CMD check for R >= 4.2, the environment variable R_LIBS_USER somehow gets set to the character NULL.

This is a bandaid for this. See https://github.com/rstudio/renv/issues/1161#issuecomment-1461092077