### PR TITLE
Tweaks to CI vignette

### DIFF
--- a/vignettes/ci.Rmd
+++ b/vignettes/ci.Rmd
@@ -14,36 +14,49 @@ knitr::opts_chunk$set(
 )
 ```
 
-When building, deploying, or testing with continuous integration (CI) systems
-(e.g. [GitHub Actions][github-actions], [Travis CI][travis-ci],
-[AppVeyor][appveyor], and others), one often needs to download and install a set
-of R packages before the service can be run. Normally, one will have to download
-and reinstall these packages on each build, which can often be slow --
-especially in environments where binary packages are not available from your R
-package repositories.
+When building, deploying, or testing an renv-using project with continuous 
+integration (CI) systems (e.g. [GitHub Actions][github-actions],
+[GitLab CI][gitlab-ci], and others) you need some way to tell the CI system
+to use renv to restore the same packages that you're using locally.
 
-`renv` can often be helpful in these situations. The general idea is:
+The general idea is:
 
-1. Call `renv::snapshot()` on your local machine, to generate `renv.lock`;
+1. Call `renv::snapshot()` on your local machine to generate `renv.lock`.
 
-2. Call `renv::restore()` on your CI service, to restore the project library
-   from `renv.lock`;
+2. Call `renv::restore()` on your CI service to restore the project library
+   from `renv.lock`.
 
-3. Ensure that the project library, as well as the global `renv` cache, are
-   cached by the CI service.
+3. Cache the project library and global `renv` cache on the CI service.
 
-Normally, `renv` will use the R package repositories as encoded in `renv.lock`
-during restore, and this will override any repositories set in other locations
-(e.g. in `.Rprofile` or `.Rprofile.site`). We'll discuss some strategies for
-providing an alternate R package repository to use during restore below.
-
+Note that this workflow is not generally a good fit for CRAN packages, because 
+CRAN itself runs `R CMD check` using the latest version of all dependencies.
 
 ## GitHub Actions
 
-Here, we describe two common approaches for integrating `renv` with a [GitHub Actions](https://github.com/features/actions) workflow.
+Here, we describe two common approaches for integrating `renv` with a [GitHub Actions](https://github.com/features/actions) workflow:
 
+* Use the `r-lib/setup-renv` action.
 * Use GitHub's built-in cache action together with existing `renv` functionality;
-* Use the `setup-renv` action maintained by the `r-lib` organization.
+
+### Using r-lib/actions/setup-renv
+
+The r-lib organization offers some actions for R users, and among them a [`setup-renv`][r-lib-actions-renv] action is provided for projects using `renv`. To use this action, you can add the following steps to your workflow: 
+
+```yaml
+steps:
+- uses: actions/checkout@v3
+- uses: r-lib/actions/setup-r@v2
+- uses: r-lib/actions/setup-renv@v2
+```
+
+Using these steps will automatically perform the following actions:
+
+* `renv` will be installed, via `install.packages("renv")`,
+* `renv` will be configured to use the GitHub cache,
+* If provided via a `with: profile:` key, that `renv` profile will be activated,
+* The project will be restored via `renv::restore()`.
+
+After this, any steps using R will use the active `renv` project by default.
 
 ### Using the GitHub Actions Cache with renv
 
@@ -77,77 +90,6 @@ steps:
 
 See also the [example][github-actions-renv] on GitHub actions.
 
-### Using r-lib/actions/setup-renv
-
-The `r-lib` organization offers some actions for R users, and among them a [`setup-renv`][r-lib-actions-renv] action is provided for projects using `renv`. To use this action, you can add the following steps to your workflow: 
-
-```yaml
-steps:
-- uses: actions/checkout@v3
-- uses: r-lib/actions/setup-r@v2
-- uses: r-lib/actions/setup-renv@v2
-```
-
-Using these steps, the following actions will then be performed in your workflow:
-
-* `renv` will be installed, via `install.packages("renv")`,
-* `renv` will be configured to use the GitHub cache,
-* If provided via a `with: profile:` key, that `renv` profile will be activated,
-* The project will be restored via `renv::restore()`.
-
-After this, any steps using R will use the active `renv` project by default.
-
-## Travis CI
-
-On Travis CI, one can add the following entries to `.travis.yml` to accomplish
-the above:
-
-```
-cache:
-  directories:
-  - $HOME/.local/share/renv
-  - $TRAVIS_BUILD_DIR/renv/library
-
-install:
-  - Rscript -e "if (!requireNamespace('renv', quietly = TRUE)) install.packages('renv')"
-  - Rscript -e "renv::restore()"
-  
-script:
-  - Rscript -e '<your-build-action>'
-```
-
-Note that we provide both `install` and `script` steps, as we want to
-override the default behaviors provided by Travis for R (which might
-attempt to install different version of R packages than what is currently
-encoded in `renv.lock`). See
-https://docs.travis-ci.com/user/languages/r/#customizing-the-travis-build-steps
-for more details.
-
-It's also possible to override the package repository used during restore by
-setting the `RENV_CONFIG_REPOS_OVERRIDE` environment variable. For example:
-
-```
-env:
-  global:
-    - RENV_CONFIG_REPOS_OVERRIDE=<cran>
-```
-
-replacing `<cran>` with your desired R package repository. This can also be
-accomplished in a similar way by setting:
-
-```
-options(renv.config.repos.override = <...>)
-```
-
-but it is generally more ergonomic to set the associated environment variable.
-(See `?config` for more details.) This can be useful if you'd like to, for
-example, enforce the usage of a [MRAN](https://mran.microsoft.com) checkpoint
-during restore, or another similarly-equipped repository.
-
-See <https://docs.travis-ci.com/user/caching> for more details on how Travis
-manages caching.
-
-
 ## GitLab CI
 
 The following template can be used as a base when using `renv` with
@@ -173,9 +115,7 @@ before_script:
 ```
 
 
-[appveyor]: https://www.appveyor.com/
 [gitlab-ci]: https://about.gitlab.com/features/continuous-integration/
 [github-actions]: https://github.com/features/actions
 [github-actions-renv]: https://github.com/actions/cache/blob/main/examples.md#r---renv
 [r-lib-actions-renv]: https://github.com/r-lib/actions/tree/v2-branch/setup-renv
-[travis-ci]: https://www.travis-ci.com/


### PR DESCRIPTION
* Make it more clear why you'd want to use renv on CI, and why it's not a good idea for CRAN packages
* Flip order of renv approaches (since IMO r-lib/setup-renv is easiest for most people)
* Remove travis, since few people in the R community are using it any more.