### PR TITLE
Build & deploy pkgdown site automatically

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,48 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,3 +20,4 @@ Encoding: UTF-8
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
+Config/Needs/website: tidyverse/tidytemplate

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -81,6 +81,7 @@ reference:
   - graph
   - renv-package
   - renv_lockfile_from_manifest
+  - sandbox
 
 articles:
 
@@ -109,7 +110,9 @@ articles:
     contents: [profiles]
 
 template:
+  package: tidytemplate
   bootstrap: 5
+
   includes:
     in_header: |
       <!-- Google Tag Manager -->


### PR DESCRIPTION
I also used the tidytemplate template, which despite the name, is something we use for many non-tidyverse Posit packages. It's a pretty minor variation from the default, but I do think it looks little cleaner.