### PR TITLE
Refactor prompting

### DIFF
--- a/R/clean.R
+++ b/R/clean.R
@@ -130,7 +130,7 @@ renv_clean_library_tempdirs <- function(project, prompt) {
     return(ntd())
 
   # nocov start
-  if (prompt || renv_verbose()) {
+  if (renv_verbose(prompt)) {
 
     renv_pretty_print(
       bad,
@@ -138,7 +138,7 @@ renv_clean_library_tempdirs <- function(project, prompt) {
       wrap = FALSE
     )
 
-    if (prompt && !proceed())
+    if (!proceed(prompt))
       return(FALSE)
 
   }
@@ -180,7 +180,7 @@ renv_clean_system_library <- function(project, prompt) {
     return(ntd())
 
   # nocov start
-  if (prompt || renv_verbose()) {
+  if (renv_verbose(prompt)) {
 
     renv_pretty_print(
       packages,
@@ -192,7 +192,7 @@ renv_clean_system_library <- function(project, prompt) {
       )
     )
 
-    if (prompt && !proceed())
+    if (!proceed(prompt))
       return(FALSE)
 
   }
@@ -227,7 +227,7 @@ renv_clean_unused_packages <- function(project, prompt) {
     return(ntd())
 
   # nocov start
-  if (prompt || renv_verbose()) {
+  if (renv_verbose(prompt)) {
 
     renv_pretty_print(
       removable,
@@ -238,7 +238,7 @@ renv_clean_unused_packages <- function(project, prompt) {
       "These packages will be removed."
     )
 
-    if (prompt && !proceed())
+    if (!proceed(prompt))
       return(FALSE)
 
   }
@@ -272,7 +272,7 @@ renv_clean_package_locks <- function(project, prompt) {
     return(ntd())
 
   # nocov start
-  if (prompt || renv_verbose()) {
+  if (renv_verbose(prompt)) {
 
     renv_pretty_print(
       basename(old),
@@ -281,7 +281,7 @@ renv_clean_package_locks <- function(project, prompt) {
       wrap = FALSE
     )
 
-    if (prompt && !proceed())
+    if (!proceed(prompt))
       return(FALSE)
 
   }
@@ -316,7 +316,7 @@ renv_clean_cache <- function(project, prompt) {
       wrap = FALSE
     )
 
-    if (prompt && !proceed())
+    if (!proceed(prompt))
       return(FALSE)
 
     writeLines(projlist[!missing], projects, useBytes = TRUE)
@@ -344,7 +344,7 @@ renv_clean_cache <- function(project, prompt) {
   if (empty(diff))
     return(ntd())
 
-  if (prompt || renv_verbose()) {
+  if (renv_verbose(prompt)) {
 
     renv_pretty_print(
       renv_cache_format_path(diff),
@@ -353,7 +353,7 @@ renv_clean_cache <- function(project, prompt) {
       wrap = FALSE
     )
 
-    if (prompt && !proceed())
+    if (!proceed(prompt))
       return(FALSE)
 
   }

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -469,10 +469,7 @@ renv_dependencies_discover_preflight <- function(paths, errors) {
   if (identical(errors, "reported"))
     return(TRUE)
 
-  if (interactive() && !proceed()) {
-    renv_report_user_cancel()
-    invokeRestart("abort")
-  }
+  check_can_proceed()
 
   TRUE
 
@@ -1697,7 +1694,7 @@ renv_dependencies_error_handler <- function(message, errors) {
 
   function(condition) {
 
-    if (identical(errors, "fatal") || interactive() && !proceed()) {
+    if (identical(errors, "fatal") || !proceed()) {
 
       condition <- structure(
         list(message = message, call = NULL, traceback = FALSE),

--- a/R/extsoft.R
+++ b/R/extsoft.R
@@ -29,7 +29,7 @@ renv_extsoft_install <- function(quiet = FALSE) {
     return(TRUE)
   }
 
-  if (interactive()) {
+  if (renv_verbose()) {
 
     renv_pretty_print(
       files,
@@ -37,11 +37,7 @@ renv_extsoft_install <- function(quiet = FALSE) {
       sprintf("Tools will be installed into %s.", renv_path_pretty(extsoft)),
       wrap = FALSE
     )
-
-    if (!proceed()) {
-      renv_report_user_cancel()
-      invokeRestart("abort")
-    }
+    check_can_proceed()
 
   }
 
@@ -137,21 +133,13 @@ renv_extsoft_use <- function(quiet = FALSE) {
   if (identical(original, contents))
     return(TRUE)
 
-  if (interactive()) {
-
-    renv_pretty_print(
-      c(localsoft, libxml, localcpp, locallibs),
-      "The following entries will be added to ~/.R/Makevars:",
-      "These tools will be used when compiling R packages from source.",
-      wrap = FALSE
-    )
-
-    if (!proceed()) {
-      renv_report_user_cancel()
-      invokeRestart("abort")
-    }
-
-  }
+  renv_pretty_print(
+    c(localsoft, libxml, localcpp, locallibs),
+    "The following entries will be added to ~/.R/Makevars:",
+    "These tools will be used when compiling R packages from source.",
+    wrap = FALSE
+  )
+  check_can_proceed()
 
   if (!quiet) vwritef("* '%s' has been updated.", path)
   writeLines(contents, path)

--- a/R/hydrate.R
+++ b/R/hydrate.R
@@ -111,10 +111,7 @@ hydrate <- function(packages = NULL,
   if (report) {
     renv_hydrate_report(packages, na, linkable)
     if (length(packages) || length(na)) {
-      if (prompt && !proceed()) {
-        renv_report_user_cancel()
-        invokeRestart("abort")
-      }
+      check_can_proceed(prompt)
     }
   }
 

--- a/R/install.R
+++ b/R/install.R
@@ -681,7 +681,7 @@ renv_install_preflight_requirements <- function(records) {
     )
   }
 
-  if (interactive() && !proceed())
+  if (!proceed())
     return(FALSE)
 
   TRUE
@@ -796,7 +796,7 @@ renv_install_preflight <- function(project, libpaths, records, prompt) {
   if (ok)
     return(TRUE)
 
-  if (prompt && !proceed())
+  if (!proceed(prompt))
     return(FALSE)
 
   TRUE

--- a/R/purge.R
+++ b/R/purge.R
@@ -99,20 +99,17 @@ renv_purge_impl <- function(package,
   }
 
   # nocov start
-  if (prompt || renv_verbose()) {
+  if (renv_verbose(prompt)) {
 
     renv_pretty_print(
       renv_cache_format_path(paths),
       "The following packages will be purged from the cache:",
       wrap = FALSE
     )
-
-    if (prompt && !proceed()) {
-      renv_report_user_cancel()
-      invokeRestart("abort")
-    }
+    check_can_proceed(prompt)
 
   }
+
   # nocov end
 
   unlink(paths, recursive = TRUE)

--- a/R/python-virtualenv.R
+++ b/R/python-virtualenv.R
@@ -101,11 +101,7 @@ renv_python_virtualenv_snapshot <- function(project, prompt, python) {
     preamble = "The following will be written to requirements.txt:",
     wrap     = FALSE
   )
-
-  if (prompt && !proceed()) {
-    renv_report_user_cancel()
-    invokeRestart("abort")
-  }
+  check_can_proceed(prompt)
 
   writeLines(after, con = path)
 
@@ -137,11 +133,7 @@ renv_python_virtualenv_restore <- function(project, prompt, python) {
     preamble = "The following Python packages will be restored:",
     wrap     = FALSE
   )
-
-  if (prompt && !proceed()) {
-    renv_report_user_cancel()
-    invokeRestart("abort")
-  }
+  check_can_proceed(prompt)
 
   pip_install_requirements(diff, python = python, stream = TRUE)
   TRUE

--- a/R/rebuild.R
+++ b/R/rebuild.R
@@ -74,11 +74,7 @@ rebuild <- function(packages  = NULL,
     "The following package(s) will be reinstalled:"
 
   renv_pretty_print_records(records[packages], preamble)
-
-  if (prompt && !proceed()) {
-    renv_report_user_cancel()
-    invokeRestart("abort")
-  }
+  check_can_proceed(prompt)
 
   # figure out rebuild parameter
   rebuild <- if (recursive) NA else packages

--- a/R/rehash.R
+++ b/R/rehash.R
@@ -47,7 +47,7 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
     return(TRUE)
   }
 
-  if (prompt) {
+  if (renv_verbose(prompt)) {
 
     fmt <- "%s [%s -> %s]"
     packages <- basename(old)[changed]
@@ -59,11 +59,7 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
       sprintf("Packages will be %s to their new locations in the cache.", label),
       wrap = FALSE
     )
-
-    if (prompt && !proceed()) {
-      renv_report_user_cancel()
-      invokeRestart("abort")
-    }
+    check_can_proceed(prompt)
 
   }
 

--- a/R/restore.R
+++ b/R/restore.R
@@ -162,12 +162,9 @@ restore <- function(project  = NULL,
     invokeRestart("abort")
   }
 
-  if (prompt || renv_verbose())
+  if (renv_verbose(prompt)) {
     renv_restore_report_actions(diff, current, lockfile)
-
-  if (prompt && !proceed()) {
-    renv_report_user_cancel()
-    invokeRestart("abort")
+    check_can_proceed(prompt)
   }
 
   # perform the restore

--- a/R/update.R
+++ b/R/update.R
@@ -252,18 +252,14 @@ update <- function(packages = NULL,
   missing <- renv_vector_diff(packages, names(records))
   if (!empty(missing)) {
 
-    if (prompt || renv_verbose()) {
+    if (renv_verbose(prompt)) {
       renv_pretty_print(
         missing,
         "The following package(s) are not currently installed:",
         "The latest available versions of these packages will be installed instead.",
         wrap = FALSE
       )
-    }
-
-    if (prompt && !proceed()) {
-      renv_report_user_cancel()
-      invokeRestart("abort")
+      check_can_proceed(prompt)
     }
 
   }
@@ -351,12 +347,9 @@ update <- function(packages = NULL,
 
   }
 
-  if (prompt || renv_verbose())
+  if (renv_verbose(prompt)) {
     renv_restore_report_actions(diff, old, new)
-
-  if (prompt && !proceed()) {
-    renv_report_user_cancel()
-    invokeRestart("abort")
+    check_can_proceed(prompt)
   }
 
   # perform the install

--- a/R/upgrade.R
+++ b/R/upgrade.R
@@ -66,17 +66,13 @@ renv_upgrade_impl <- function(project, version, reload, prompt) {
     return(TRUE)
   }
 
-  if (prompt || renv_verbose()) {
+  if (renv_verbose(prompt)) {
     renv_pretty_print_records_pair(
       list(renv = old), list(renv = new),
       "A new version of the renv package will be installed:",
       "This project will use the newly-installed version of renv."
     )
-  }
-
-  if (prompt && !proceed()) {
-    renv_report_user_cancel()
-    invokeRestart("abort")
+    check_can_proceed(prompt)
   }
 
   renv_scope_restore(

--- a/R/utils.R
+++ b/R/utils.R
@@ -167,10 +167,20 @@ ask <- function(question, default = FALSE) {
 
 }
 
-proceed <- function(default = FALSE) {
-  ask("Do you want to proceed?", default = default)
+proceed <- function(prompt = interactive(), default = TRUE) {
+  if (prompt) {
+    ask("Do you want to proceed?", default = default)
+  } else {
+    default
+  }
 }
 
+check_can_proceed <- function(prompt = interactive()) {
+  if (!proceed(prompt)) {
+    renv_report_user_cancel()
+    invokeRestart("abort")
+  }
+}
 # nocov end
 
 inject <- function(contents,

--- a/R/verbose.R
+++ b/R/verbose.R
@@ -1,5 +1,5 @@
 
-renv_verbose <- function() {
+renv_verbose <- function(prompt = interactive()) {
 
   verbose <- getOption("renv.verbose")
   if (!is.null(verbose))
@@ -9,6 +9,6 @@ renv_verbose <- function() {
   if (!is.na(verbose))
     return(as.logical(verbose))
 
-  interactive() || !renv_tests_running()
+  prompt || !renv_tests_running()
 
 }


### PR DESCRIPTION
The major user facing is change the default value of `default` for `proceed()` from `FALSE` to `TRUE`, so the interactive default is equivalent to the non-interactive behaviour.

I then refactored `proceed()` to include a `prompt` argument: I think this makes it more clear what happens when `prompt` is `FALSE`.

While updating the code to use the new `proceed()` behaviour I realised that there many repeated calls that aborted if the user said `n` at the prompt. So I introduced a new `check_can_proceed()` function that extracts out the repeated code.

And then while updating the code to use `check_can_proceed()` I realised that (unsurprisingly) most calls to `check_can_proceed()` came up after a message that was gated by a check for `prompt || renv_verbose()`. So I also added a `prompt` argument to `renv_verbose()` because I think this makes the connection between the two functions more clear.

Fixes #1240