### PR TITLE
Refactor project get/set

### DIFF
--- a/R/activate.R
+++ b/R/activate.R
@@ -142,7 +142,7 @@ renv_activate_prompt <- function(action, library, prompt, project) {
     prompt &&
     interactive() &&
     is.null(library) &&
-    !identical(project, Sys.getenv("RENV_PROJECT"))
+    !renv_project_is_active(project)
 
   if (!ask)
     return(FALSE)

--- a/R/autoload.R
+++ b/R/autoload.R
@@ -81,3 +81,24 @@ renv_autoload_impl <- function() {
   TRUE
 
 }
+
+# TODO: this gets really dicey once the user starts configuring where
+# renv places its project-local state ...
+renv_project_find <- function(project = NULL) {
+
+  project <- project %||% getwd()
+
+  anchors <- c("renv.lock", "renv/activate.R")
+  resolved <- renv_file_find(project, function(parent) {
+    for (anchor in anchors)
+      if (file.exists(file.path(parent, anchor)))
+        return(parent)
+  })
+
+  if (is.null(resolved)) {
+    fmt <- "couldn't resolve renv project associated with path %s"
+    stopf(fmt, renv_path_pretty(project))
+  }
+
+  resolved
+}

--- a/R/cite.R
+++ b/R/cite.R
@@ -19,7 +19,7 @@ cite <- function(type = c("plain", "bibtex"),
   renv_scope_error_handler()
   renv_dots_check(...)
 
-  project <- project %||% renv_project()
+  project <- renv_project_resolve(project)
   type <- match.arg(type)
 
   packages <- sort(.packages(all.available = TRUE))

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -214,7 +214,7 @@ renv_dependencies_root <- function(path = getwd()) {
 
   path <- renv_path_normalize(path, winslash = "/", mustWork = TRUE)
 
-  project <- Sys.getenv("RENV_PROJECT", unset = NA)
+  project <- renv_project_get(default = NA)
   if (!is.na(project) && all(renv_path_within(path, project)))
     return(project)
 
@@ -585,7 +585,7 @@ renv_dependencies_discover_description_fields <- function() {
     project <- state$project
 
   # all else fails, use the active project
-  project <- project %||% renv_project()
+  project <- renv_project_resolve(project)
   settings$package.dependency.fields(project = project)
 
 }

--- a/R/install.R
+++ b/R/install.R
@@ -291,7 +291,7 @@ renv_install_staged_library_path_impl <- function() {
 
   # retrieve current project, library path
   staging <- Sys.getenv("RENV_PATHS_LIBRARY_STAGING", unset = NA)
-  project <- Sys.getenv("RENV_PROJECT", unset = NA)
+  project <- renv_project_get(default = NA)
   libpath <- renv_libpaths_active()
 
   # determine root directory for staging

--- a/R/load.R
+++ b/R/load.R
@@ -29,11 +29,7 @@ load <- function(project = NULL, quiet = FALSE) {
 
   renv_scope_error_handler()
 
-  project <- normalizePath(
-    project %||% renv_project_find(project),
-    winslash = "/",
-    mustWork = TRUE
-  )
+  project <- renv_project_resolve(project)
 
   action <- renv_load_action(project)
   if (action[[1L]] == "cancel") {
@@ -64,8 +60,7 @@ load <- function(project = NULL, quiet = FALSE) {
   # then unload the current project and reload the requested one
   switch <-
     !renv_metadata_embedded() &&
-    !is.na(Sys.getenv("RENV_PROJECT", unset = NA)) &&
-    !identical(project, renv_project())
+    !renv_project_is_active(project)
 
   if (switch)
     return(renv_load_switch(project))
@@ -331,7 +326,7 @@ renv_load_project <- function(project) {
 
   # record the active project in this session
   project <- renv_path_normalize(project, winslash = "/")
-  Sys.setenv(RENV_PROJECT = project)
+  renv_project_set(project)
 
   # update project list if enabled
   enabled <- renv_cache_config_enabled(project = project)

--- a/R/modify.R
+++ b/R/modify.R
@@ -38,7 +38,7 @@ renv_modify_impl <- function(project, changes) {
   else
     renv_modify_noninteractive(project, changes)
 
-  if (identical(renv_project(), project))
+  if (renv_project_is_active(project))
     renv_modify_fini(lockfile)
 
 }

--- a/R/snapshot-auto.R
+++ b/R/snapshot-auto.R
@@ -44,7 +44,7 @@ renv_snapshot_auto_enabled <- function(project) {
     return(FALSE)
 
   # only automatically snapshot the current project
-  if (!identical(project, renv_project(default = NULL)))
+  if (!renv_project_is_active(project))
     return(FALSE)
 
   # don't auto-snapshot if the project hasn't been initialized
@@ -99,8 +99,10 @@ renv_snapshot_auto_update <- function(project) {
 
 renv_snapshot_task <- function() {
 
+  project <- renv_project_get(default = NULL)
+
   # check for active renv project
-  if (!renv_project_active())
+  if (is.null(project))
     return()
 
   # see if library state has updated

--- a/R/tests.R
+++ b/R/tests.R
@@ -23,7 +23,7 @@ renv_tests_scope <- function(packages = character(), project = NULL) {
   owd <- setwd(dir)
 
   # set as active project
-  Sys.setenv(RENV_PROJECT = dir)
+  renv_project_set(dir)
 
   # create empty renv directory
   dir.create(file.path(dir, "renv"))
@@ -85,7 +85,7 @@ renv_tests_root_impl <- function(path = getwd()) {
 renv_tests_init_envvars <- function() {
 
   Sys.unsetenv("RENV_PROFILE")
-  Sys.unsetenv("RENV_PROJECT")
+  Sys.unsetenv("RENV_PROJECT") # renv_project_clear()
   Sys.unsetenv("RENV_PATHS_ROOT")
   Sys.unsetenv("RENV_PATHS_LIBRARY")
   Sys.unsetenv("RENV_PATHS_LIBRARY_ROOT")

--- a/R/unload.R
+++ b/R/unload.R
@@ -28,7 +28,7 @@ renv_unload_shims <- function(project) {
 
 renv_unload_project <- function(project) {
   options(renv.project.path = NULL)
-  Sys.unsetenv("RENV_PROJECT")
+  renv_project_clear()
 }
 
 renv_unload_profile <- function(project) {

--- a/R/upgrade.R
+++ b/R/upgrade.R
@@ -54,7 +54,7 @@ renv_upgrade_impl <- function(project, version, reload, prompt) {
   project <- renv_project_resolve(project)
   renv_project_lock(project = project)
 
-  reload <- reload %||% identical(project, renv_project())
+  reload <- reload %||% renv_project_is_active(project)
 
   old <- renv_snapshot_description(package = "renv")
   new <- renv_upgrade_find_record(version)


### PR DESCRIPTION
* Eliminate `renv_project()` in favour of `renv_project_get()`.

* Use `renv_project_resolve()` in `load()`, like all other functions. Move `renv_project_find()` to `autoload.R`, the only place it's now used.

* Use `renv_project_set()`, `renv_project_get()`, and `renv_project_clear()` everywhere, instead of accessing `RENV_PROJECT` env var directly.

*  Implement `renv_project_is_active()` and use where appropriate. Plan is to export as `is_loaded()` to fix #1058.

* I don't understand how `renv_snapshot_task()` worked because, AFAICT, `project` wasn't previously defined.