### PR TITLE
Proceed by default

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -164,7 +164,7 @@ ask <- function(question, default = FALSE) {
 
 }
 
-proceed <- function(default = FALSE) {
+proceed <- function(default = TRUE) {
   ask("Do you want to proceed?", default = default)
 }
 


### PR DESCRIPTION
So we match the behaviour in non-interactive sessions (or when `prompt` has been set to `FALSE`).

Fixes #1240

(Hopefully this PR is easier to review 😆)