### PR TITLE
Create `renv_envvar_path_add()`

### DIFF
--- a/R/envvar.R
+++ b/R/envvar.R
@@ -20,7 +20,7 @@ renv_envvar_clear <- function(key) {
   Sys.unsetenv(key)
 }
 
-renv_envvar_modify <- function(envvar, value, prepend) {
+renv_envvar_path_add <- function(envvar, value, prepend = TRUE) {
 
   old <- Sys.getenv(envvar, unset = "")
   old <- strsplit(old, .Platform$path.sep)[[1]]
@@ -33,12 +33,4 @@ renv_envvar_modify <- function(envvar, value, prepend) {
 
   new
 
-}
-
-renv_envvar_prepend <- function(envvar, value) {
-  renv_envvar_modify(envvar, value, TRUE)
-}
-
-renv_envvar_append <- function(envvar, value) {
-  renv_envvar_modify(envvar, value, FALSE)
 }

--- a/R/load.R
+++ b/R/load.R
@@ -444,14 +444,14 @@ renv_load_python <- function(project, fields) {
 
   # place python + relevant utilities on the PATH
   bindir <- normalizePath(dirname(python), mustWork = FALSE)
-  renv_envvar_prepend("PATH", bindir)
+  renv_envvar_path_add("PATH", bindir)
 
   # on Windows, for conda environments, we may also have a Scripts directory
   # which will need to be pre-pended to the PATH
   if (renv_platform_windows()) {
     scriptsdir <- file.path(bindir, "Scripts")
     if (file.exists(scriptsdir))
-      renv_envvar_prepend("PATH", scriptsdir)
+      renv_envvar_path_add("PATH", scriptsdir)
   }
 
   # for conda environments, we should try to find conda and place the conda
@@ -464,7 +464,7 @@ renv_load_python <- function(project, fields) {
   if (identical(info$type, "conda")) {
     conda <- renv_conda_find(python)
     if (file.exists(conda)) {
-      renv_envvar_prepend("PATH", dirname(conda))
+      renv_envvar_path_add("PATH", dirname(conda))
       Sys.setenv(CONDA_PREFIX = info$root)
     }
   }

--- a/tests/testthat/test-envvar.R
+++ b/tests/testthat/test-envvar.R
@@ -1,22 +1,35 @@
 context("envvar")
 
-test_that("renv_envvar_prepend doesn't duplicate paths", {
+test_that("can add before or after", {
+  path_string <- function(...) {
+    paste(c(...), collapse = .Platform$path.sep)
+  }
+
+  withr::local_envvar(TESTPATH = "a")
+  renv_envvar_path_add("TESTPATH", "b", prepend = TRUE)
+  expect_equal(Sys.getenv("TESTPATH"), path_string(c("b", "a")))
+
+  withr::local_envvar(TESTPATH = "a")
+  renv_envvar_path_add("TESTPATH", "b", prepend = FALSE)
+  expect_equal(Sys.getenv("TESTPATH"), path_string(c("a", "b")))
+})
+
+test_that("renv_envvar_path_modify doesn't duplicate paths", {
   path_string <- function(...) {
     paste(c(...), collapse = .Platform$path.sep)
   }
   withr::local_envvar(TESTPATH = path_string("a", "b", "c"))
 
-  renv_envvar_prepend("TESTPATH", "a")
+  renv_envvar_path_add("TESTPATH", "a")
   expect_equal(Sys.getenv("TESTPATH"), path_string("a", "b", "c"))
 
-  renv_envvar_prepend("TESTPATH", "b")
+  renv_envvar_path_add("TESTPATH", "b")
   expect_equal(Sys.getenv("TESTPATH"), path_string("b", "a", "c"))
 })
 
-test_that("renv_envvar_prepend works if var isn't set", {
+test_that("renv_envvar_path_modify works if var isn't set", {
+  withr::local_envvar(TESTPATH = NA)
 
-  renv_envvar_prepend("TESTPATH", "a")
-  defer(Sys.unsetenv("TESTPATH"))
-
+  renv_envvar_path_add("TESTPATH", "a")
   expect_equal(Sys.getenv("TESTPATH"), "a")
 })


### PR DESCRIPTION
* Replaces `renv_ennvar_modify()` which wasn't a great name since the function is now tightly bound to the `PATH` envvar

* Remove `renv_envvar_prepend()` and `renv_envvar_append()` for similar reasons. (And since "append" isn't used anywhere)

* Test append behaviour just in case it is used in the future