### PR TITLE
Refactor path handling in tests

### DIFF
--- a/R/test.R
+++ b/R/test.R
@@ -6,7 +6,7 @@ test <- function() {
 
   # run tests
   testthat::test_dir(
-    path     = renv_tests_root(),
+    path     = renv_tests_path(),
     reporter = renv_tests_reporter()
   )
 

--- a/R/tests.R
+++ b/R/tests.R
@@ -14,7 +14,7 @@ renv_tests_scope <- function(packages = character(), project = NULL) {
   options(restart = function(...) TRUE)
 
   # save local repositories
-  Sys.setenv(RENV_PATHS_LOCAL = file.path(renv_tests_root(), "local"))
+  Sys.setenv(RENV_PATHS_LOCAL = renv_tests_path("local"))
 
   # move to own test directory
   dir <- project %||% tempfile("renv-test-")
@@ -48,38 +48,14 @@ renv_tests_scope <- function(packages = character(), project = NULL) {
 
 }
 
-renv_tests_root <- function(path = getwd()) {
-  global("tests.root", renv_tests_root_impl(path))
+# Cache absolute path to tests/testthat
+renv_tests_root <- function() {
+  global("tests.root", normalizePath(testthat::test_path(".")))
 }
 
-renv_tests_root_impl <- function(path = getwd()) {
-
-  # if we're working in an RStudio project, we can cheat
-  if (exists(".rs.getProjectDirectory")) {
-    projroot <- get(".rs.getProjectDirectory")
-    return(file.path(projroot(), "tests/testthat"))
-  }
-
-  # construct set of paths we'll hunt through
-  slashes <- gregexpr("(?:/|$)", path, perl = TRUE)[[1]]
-  parts <- substring(path, 1, slashes - 1)
-
-  # begin the search
-  for (part in rev(parts)) {
-
-    # required to find test directory during R CMD check
-    if (file.exists(file.path(part, "testthat.R")))
-      return(file.path(part, "testthat"))
-
-    # required for other general testing
-    anchor <- file.path(part, "DESCRIPTION")
-    if (file.exists(anchor))
-      return(file.path(part, "tests/testthat"))
-
-  }
-
-  stop("could not determine root directory for test files")
-
+renv_tests_path <- function(path = ".") {
+  root <- renv_tests_root()
+  file.path(root, path)
 }
 
 renv_tests_init_envvars <- function() {
@@ -146,9 +122,6 @@ renv_tests_init_options <- function() {
 
 renv_tests_init_repos <- function(repopath = NULL) {
 
-  # find root directory
-  root <- renv_tests_root()
-
   # generate our dummy repository
   repopath <- repopath %||% tempfile("renv-tests-repos-")
   contrib <- file.path(repopath, "src/contrib")
@@ -159,7 +132,7 @@ renv_tests_init_repos <- function(repopath = NULL) {
   on.exit(setwd(owd), add = TRUE)
 
   # copy package stuff to tempdir (because we'll mutate them a bit)
-  source <- file.path(root, "packages")
+  source <- renv_tests_path("packages")
   target <- tempfile("renv-packages-")
   renv_file_copy(source, target)
   setwd(target)
@@ -540,11 +513,6 @@ renv_tests_report <- function(test, elapsed, expectations) {
   # write it out
   cli::cat_bullet(all)
 
-}
-
-renv_tests_path <- function(path) {
-  root <- renv_tests_root()
-  file.path(root, path)
 }
 
 renv_tests_supported <- function() {

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -96,8 +96,7 @@ test_that("local sources are preferred when available", {
   skip_on_cran()
   renv_tests_scope()
 
-  root <- renv_tests_root()
-  renv_scope_envvars(RENV_PATHS_LOCAL = file.path(root, "local"))
+  renv_scope_envvars(RENV_PATHS_LOCAL = renv_tests_path("local"))
 
   record <- renv_available_packages_latest(package = "skeleton", type = "source")
   expect_identical(record$Source, "Cellar")

--- a/tests/testthat/test-bioconductor.R
+++ b/tests/testthat/test-bioconductor.R
@@ -93,7 +93,7 @@ test_that("we can restore a lockfile using multiple Bioconductor releases", {
 
   project <- renv_tests_scope()
 
-  path <- file.path(renv_tests_root(), "resources/bioconductor.lock")
+  path <- renv_tests_path("resources/bioconductor.lock")
   lockfile <- renv_lockfile_read(path)
 
   status <- restore(

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -3,7 +3,7 @@ context("Hash")
 
 test_that("whitespace does not affect hash", {
 
-  descpath <- file.path(renv_tests_root(), "packages/breakfast/DESCRIPTION")
+  descpath <- renv_tests_path("packages/breakfast/DESCRIPTION")
   contents <- readLines(descpath)
   hash <- renv_hash_description(descpath)
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -313,10 +313,9 @@ test_that("install() prefers cellar when available", {
   skip_on_cran()
   renv_tests_scope()
 
-  root <- renv_tests_root()
   locals <- paste(
-    file.path(root, "nowhere"),
-    file.path(root, "local"),
+    renv_tests_path("nowhere"),
+    renv_tests_path("local"),
     sep = ";"
   )
 
@@ -412,10 +411,9 @@ test_that("packages installed from cellar via direct path", {
   skip_on_cran()
   renv_tests_scope("skeleton")
 
-  root <- renv_tests_root()
   locals <- paste(
-    file.path(root, "nowhere"),
-    file.path(root, "local"),
+    frenv_tests_path("nowhere"),
+    frenv_tests_path("local"),
     sep = ";"
   )
 


### PR DESCRIPTION
* Use `renv_tests_path()` in more place.

* Simplify implementation of `renv_tests_root()` using `testthat::test_path()`.