### PR TITLE
Eliminate renv_tests_verbose()

### DIFF
--- a/R/pretty.R
+++ b/R/pretty.R
@@ -5,7 +5,7 @@ renv_pretty_print <- function(values,
                               emitter   = NULL,
                               wrap      = TRUE)
 {
-  if (renv_tests_running() && !renv_tests_verbose())
+  if (!renv_verbose())
     return()
 
   msg <- stack()
@@ -44,7 +44,7 @@ renv_pretty_print_records <- function(records,
   if (empty(records))
     return(invisible(NULL))
 
-  if (renv_tests_running() && !renv_tests_verbose())
+  if (!renv_verbose())
     return(invisible(NULL))
 
   names(records) <- names(records) %??% map_chr(records, `[[`, "Package")

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -661,7 +661,7 @@ renv_retrieve_repos_error_report <- function(record, errors) {
     wrap     = FALSE
   )
 
-  if (renv_tests_running() && renv_tests_verbose())
+  if (renv_verbose())
     str(errors)
 
 }

--- a/R/tests.R
+++ b/R/tests.R
@@ -369,18 +369,6 @@ renv_tests_running <- function() {
   getOption("renv.tests.running", default = FALSE)
 }
 
-renv_tests_verbose <- function() {
-
-  # if we're not running tests, mark as true
-  if (!renv_tests_running())
-    return(TRUE)
-
-  # otherwise, respect option
-  # (we might set this to FALSE to silence output from expected errors)
-  getOption("renv.tests.verbose", default = TRUE)
-
-}
-
 renv_test_code <- function(code, data = list(), fileext = ".R") {
   code <- do.call(substitute, list(substitute(code), data))
   file <- tempfile("renv-code-", fileext = fileext)

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -28,12 +28,12 @@ vmessagef <- function(fmt = "", ..., appendLF = TRUE) {
 
 
 printf <- function(fmt = "", ..., file = stdout(), sep = "") {
-  if (!is.null(fmt) && renv_tests_verbose())
+  if (!is.null(fmt) && renv_verbose())
     cat(sprintf(fmt, ...), file = file, sep = sep)
 }
 
 eprintf <- function(fmt = "", ..., file = stderr(), sep = "") {
-  if (!is.null(fmt) && renv_tests_verbose())
+  if (!is.null(fmt) && renv_verbose())
     cat(sprintf(fmt, ...), file = file, sep = sep)
 }
 
@@ -50,12 +50,12 @@ veprintf <- function(fmt = "", ..., file = stderr(), sep = "") {
 
 
 writef <- function(fmt = "", ..., con = stdout()) {
-  if (!is.null(fmt) && renv_tests_verbose())
+  if (!is.null(fmt) && renv_verbose())
     writeLines(sprintf(fmt, ...), con = con)
 }
 
 ewritef <- function(fmt = "", ..., con = stderr()) {
-  if (!is.null(fmt) && renv_tests_verbose())
+  if (!is.null(fmt) && renv_verbose())
     writeLines(sprintf(fmt, ...), con = con)
 }
 
@@ -70,7 +70,7 @@ vewritef <- function(fmt = "", ..., con = stderr()) {
 }
 
 infof <- function(fmt = "", ..., con = stdout()) {
-  if (!is.null(fmt) && renv_tests_verbose()) {
+  if (!is.null(fmt) && renv_verbose()) {
     fmt <- paste(if (l10n_info()$`UTF-8`) "\u2139" else "i", fmt)
     writeLines(sprintf(fmt, ...), con = con)
   }

--- a/tests/testthat/helper-aaa.R
+++ b/tests/testthat/helper-aaa.R
@@ -114,13 +114,3 @@ test_that <- function(desc, code) {
   }
 
 }
-
-expect_error <- function(...) {
-  renv_scope_options(renv.tests.verbose = FALSE)
-  testthat::expect_error(...)
-}
-
-expect_warning <- function(...) {
-  renv_scope_options(renv.tests.verbose = FALSE)
-  testthat::expect_warning(...)
-}

--- a/tests/testthat/test-bioconductor.R
+++ b/tests/testthat/test-bioconductor.R
@@ -8,8 +8,6 @@ test_that("packages can be installed, restored from Bioconductor", {
   skip_if(getRversion() < "3.5.0")
   skip_if(R.version$nickname == "Unsuffered Consequences")
 
-  renv_scope_options(renv.tests.verbose = FALSE)
-
   renv_tests_scope("Biobase")
   renv_scope_options(repos = c(CRAN = "https://cloud.r-project.org"))
 
@@ -47,8 +45,6 @@ test_that("renv::install(<bioc>, rebuild = TRUE) works", {
   skip_if(getRversion() < "3.5.0")
   skip_if(R.version$nickname == "Unsuffered Consequences")
   skip_if_not_installed("BiocManager")
-
-  renv_scope_options(renv.tests.verbose = FALSE)
 
   requireNamespace("BiocManager", quietly = TRUE)
   on.exit(unloadNamespace("BiocManager"), add = TRUE)

--- a/tests/testthat/test-description.R
+++ b/tests/testthat/test-description.R
@@ -3,10 +3,8 @@ context("DESCRIPTION")
 
 test_that("snapshotting broken DESCRIPTION files is an error", {
 
-  file <- tempfile()
-  renv_scope_options(renv.tests.verbose = FALSE)
-
   # empty file
+  file <- tempfile()
   file.create(file)
   expect_s3_class(renv_snapshot_description(file), "error")
 

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -46,10 +46,7 @@ test_that("we cannot initialize a project using 'brunch'", {
   renv_tests_scope("brunch")
 
   # 'brunch' will fail to install
-  local({
-    renv_scope_options(renv.tests.verbose = FALSE)
-    renv::init()
-  })
+  renv::init()
 
   expect_false(file.exists(renv_paths_library("brunch")))
 
@@ -60,10 +57,7 @@ test_that("attempts to initialize a project with a missing package is okay", {
   renv_tests_scope("missing")
 
   # package 'missing' does not exist and so cannot be installed
-  local({
-    renv_scope_options(renv.tests.verbose = FALSE)
-    renv::init()
-  })
+  renv::init()
 
   expect_false(file.exists(renv_paths_library("missing")))
 
@@ -95,11 +89,7 @@ test_that("init succeeds even if there are parse errors in project", {
   renv_tests_scope()
   writeLines("oh no", con = "analysis.R")
 
-  local({
-    renv_scope_options(renv.tests.verbose = FALSE)
-    renv::init()
-  })
-
+  renv::init()
   expect_true(file.exists("renv.lock"))
 
 })

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -56,7 +56,6 @@ test_that("installation failure is well-reported", {
 
   # try to build it and confirm error
   record <- list(Package = package, Path = package)
-  renv_scope_options(renv.verbose = FALSE)
   expect_error(renv_install_package_impl(record))
 
 })

--- a/tests/testthat/test-repair.R
+++ b/tests/testthat/test-repair.R
@@ -4,7 +4,6 @@ context("Repair")
 test_that("we can repair a broken project library", {
 
   skip_on_cran()
-  renv_scope_options(renv.tests.verbose = FALSE)
   renv_tests_scope("breakfast")
 
   init()
@@ -28,7 +27,6 @@ test_that("we can repair a broken project library", {
 test_that("repair() uses the package version recorded in the lockfile", {
 
   skip_on_cran()
-  renv_scope_options(renv.tests.verbose = FALSE)
   renv_tests_scope("breakfast")
 
   init()

--- a/tests/testthat/test-restore.R
+++ b/tests/testthat/test-restore.R
@@ -5,7 +5,6 @@ test_that("library permissions are validated before restore", {
   skip_on_os("windows")
   inaccessible <- renv_scope_tempfile()
   dir.create(inaccessible, mode = "0100")
-  renv_scope_options(renv.verbose = FALSE)
   expect_false(renv_install_preflight_permissions(inaccessible))
 })
 
@@ -149,8 +148,6 @@ test_that("renv::restore(packages = <...>) works", {
 
 test_that("restore ignores packages of incompatible architecture", {
 
-  renv_scope_options(renv.tests.verbose = FALSE)
-
   renv_tests_scope(c("unixonly", "windowsonly"))
   renv::init()
 
@@ -273,7 +270,6 @@ test_that("restore() restores packages with broken symlinks", {
 
   skip_on_cran()
   renv_scope_options(renv.settings.cache.enabled = TRUE)
-  renv_scope_options(renv.tests.verbose = FALSE)
   renv_tests_scope("breakfast")
   init()
 

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -26,6 +26,7 @@ test_that("snapshot failures are reported", {
 
   output <- tempfile("renv-snapshot-output-")
   local({
+    renv_scope_options(renv.verbose = TRUE)
     renv_scope_sink(file = output)
     renv::snapshot(prompt = FALSE)
   })
@@ -47,6 +48,7 @@ test_that("broken symlinks are reported", {
 
   output <- tempfile("renv-snapshot-output-")
   local({
+    renv_scope_options(renv.verbose = TRUE)
     renv_scope_sink(file = output)
     renv::snapshot(prompt = FALSE)
   })
@@ -202,8 +204,6 @@ test_that("snapshot warns about unsatisfied dependencies", {
 
 test_that("snapshot records packages discovered in cellar", {
 
-  renv_scope_options(renv.tests.verbose = FALSE)
-
   renv_tests_scope("skeleton")
   renv_scope_envvars(RENV_PATHS_CACHE = tempfile())
 
@@ -247,10 +247,7 @@ test_that("parse errors cause snapshot to abort", {
   writeLines("parse error", con = "parse-error.R")
 
   # init should succeed even with parse errors
-  local({
-    renv_scope_options(renv.tests.verbose = FALSE)
-    init(bare = TRUE)
-  })
+  init(bare = TRUE)
 
   # snapshots should fail when configured to do so
   renv_scope_options(renv.config.dependency.errors = "fatal")
@@ -397,10 +394,7 @@ test_that("a project using explicit snapshots is marked in sync appropriately", 
 
   skip_on_cran()
   renv_tests_scope()
-  renv_scope_options(
-    renv.config.snapshot.type = "explicit",
-    renv.tests.verbose = FALSE
-  )
+  renv_scope_options(renv.config.snapshot.type = "explicit")
 
   init()
 


### PR DESCRIPTION
Since `renv_verbose()` now automatically suppresses output during tests