### PR TITLE
Simplify path handling in tests

### DIFF
--- a/R/tests.R
+++ b/R/tests.R
@@ -85,13 +85,6 @@ renv_tests_init_workarounds <- function() {
 
 }
 
-renv_tests_init_working_dir <- function() {
-  if (exists(".rs.getProjectDirectory")) {
-    home <- get(".rs.getProjectDirectory")
-    setwd(home())
-  }
-}
-
 renv_tests_init_options <- function() {
 
   # find path to renv sources
@@ -326,7 +319,6 @@ renv_tests_init <- function() {
 
   renv_tests_init_envvars()
   renv_tests_init_workarounds()
-  renv_tests_init_working_dir()
   renv_tests_init_options()
   renv_tests_init_repos()
   renv_tests_init_packages()

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -96,8 +96,7 @@ test_that("local sources are preferred when available", {
   skip_on_cran()
   renv_tests_scope()
 
-  root <- renv_tests_root()
-  renv_scope_envvars(RENV_PATHS_LOCAL = file.path(root, "local"))
+  renv_scope_envvars(RENV_PATHS_LOCAL = renv_tests_path("local"))
 
   record <- renv_available_packages_latest(package = "skeleton", type = "source")
   expect_identical(record$Source, "Cellar")

--- a/tests/testthat/test-bioconductor.R
+++ b/tests/testthat/test-bioconductor.R
@@ -80,7 +80,7 @@ test_that("we can restore a lockfile using multiple Bioconductor releases", {
 
   project <- renv_tests_scope()
 
-  path <- file.path(renv_tests_root(), "resources/bioconductor.lock")
+  path <- renv_tests_path("resources/bioconductor.lock")
   lockfile <- renv_lockfile_read(path)
 
   status <- restore(

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -3,7 +3,7 @@ context("Hash")
 
 test_that("whitespace does not affect hash", {
 
-  descpath <- file.path(renv_tests_root(), "packages/breakfast/DESCRIPTION")
+  descpath <- renv_tests_path("packages/breakfast/DESCRIPTION")
   contents <- readLines(descpath)
   hash <- renv_hash_description(descpath)
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -313,10 +313,9 @@ test_that("install() prefers cellar when available", {
   skip_on_cran()
   renv_tests_scope()
 
-  root <- renv_tests_root()
   locals <- paste(
-    file.path(root, "nowhere"),
-    file.path(root, "local"),
+    renv_tests_path("nowhere"),
+    renv_tests_path("local"),
     sep = ";"
   )
 
@@ -329,7 +328,7 @@ test_that("install() prefers cellar when available", {
   expect_equal(record$Source, "Cellar")
 
   prefix <- if (renv_platform_windows()) "file:///" else "file://"
-  uri <- paste0(prefix, root, "/local/skeleton")
+  uri <- paste0(prefix, renv_tests_path("local/skeleton"))
   expect_equal(attr(record, "url"), uri)
 
 })
@@ -412,17 +411,16 @@ test_that("packages installed from cellar via direct path", {
   skip_on_cran()
   renv_tests_scope("skeleton")
 
-  root <- renv_tests_root()
   locals <- paste(
-    file.path(root, "nowhere"),
-    file.path(root, "local"),
+    renv_tests_path("nowhere"),
+    renv_tests_path("local"),
     sep = ";"
   )
 
   renv_scope_options(renv.config.cache.enabled = FALSE)
   renv_scope_envvars(RENV_PATHS_CELLAR = locals)
 
-  path <- file.path(root, "local/skeleton/skeleton_1.0.1.tar.gz")
+  path <- renv_tests_path("local/skeleton/skeleton_1.0.1.tar.gz")
   records <- install(path, rebuild = TRUE)
   expect_equal(records$skeleton$Source, "Cellar")
 


### PR DESCRIPTION
Now that `renv_tests_root()` is no longer required in `tests/testhat.R` we can use `testthat::test_path()`.

I also removed the interactive working directory change when using RStudio, since in general that shouldn't be necessary. But I don't know why it was there in the first place, so I might be wrong.