### PR TITLE
Track and eliminate files left in the tempdir

### DIFF
--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -107,6 +107,8 @@ renv_available_packages_query <- function(type, repos, quiet = FALSE) {
 renv_available_packages_query_impl_packages_rds <- function(url) {
   path <- file.path(url, "PACKAGES.rds")
   destfile <- tempfile("renv-packages-", fileext = ".rds")
+  defer(unlink(destfile))
+
   download(url = path, destfile = destfile, quiet = TRUE)
   suppressWarnings(readRDS(destfile))
 }
@@ -114,6 +116,8 @@ renv_available_packages_query_impl_packages_rds <- function(url) {
 renv_available_packages_query_impl_packages_gz <- function(url) {
   path <- file.path(url, "PACKAGES.gz")
   destfile <- tempfile("renv-packages-", fileext = ".gz")
+  defer(unlink(destfile))
+
   download(url = path, destfile = destfile, quiet = TRUE)
   suppressWarnings(read.dcf(destfile))
 }
@@ -121,6 +125,8 @@ renv_available_packages_query_impl_packages_gz <- function(url) {
 renv_available_packages_query_impl_packages <- function(url) {
   path <- file.path(url, "PACKAGES")
   destfile <- tempfile("renv-packages-")
+  defer(unlink(destfile))
+
   download(url = path, destfile = destfile, quiet = TRUE)
   suppressWarnings(read.dcf(destfile))
 }

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -13,6 +13,7 @@ bootstrap <- function(version, library) {
   tarball <- tryCatch(renv_bootstrap_download(version), error = identity)
   if (inherits(tarball, "error"))
     stop("failed to download renv ", version)
+  on.exit(unlink(tarball), add = TRUE)
 
   # now attempt to install
   status <- tryCatch(renv_bootstrap_install(version, tarball, library), error = identity)

--- a/R/modify.R
+++ b/R/modify.R
@@ -98,7 +98,7 @@ renv_modify_noninteractive <- function(project, changes) {
   merged <- modifyList(lockfile, changes)
 
   # write updated lockfile to a temporary file
-  templock <- tempfile("renv-lock-")
+  templock <- renv_scope_tempfile("renv-lock-")
   renv_lockfile_write(merged, file = templock)
 
   # try reading it once more

--- a/R/package.R
+++ b/R/package.R
@@ -446,6 +446,8 @@ renv_package_unpack <- function(package, path, subdir = "", force = FALSE) {
   old <- tempfile("renv-package-old-")
   new <- tempfile("renv-package-new-")
   ensure_directory(c(old, new))
+  defer(unlink(old, recursive = TRUE))
+  defer(unlink(new, recursive = TRUE), envir = parent.frame())
 
   # decompress archive to dir
   renv_archive_decompress(path, exdir = old)

--- a/R/scope.R
+++ b/R/scope.R
@@ -1,10 +1,11 @@
 
 renv_scope_tempdir <- function(pattern = "renv-tempdir-",
                                tmpdir = tempdir(),
+                               umask = NULL,
                                envir = NULL)
 {
   dir <- tempfile(pattern = pattern, tmpdir = tmpdir)
-  ensure_directory(dir)
+  ensure_directory(dir, umask = umask)
   owd <- setwd(dir)
 
   envir <- envir %||% parent.frame()

--- a/R/tests.R
+++ b/R/tests.R
@@ -12,9 +12,11 @@ renv_tests_running <- function() {
   getOption("renv.tests.running", default = FALSE)
 }
 
-renv_test_code <- function(code, data = list(), fileext = ".R") {
+renv_test_code <- function(code, data = list(), fileext = ".R", envir = parent.frame()) {
   code <- do.call(substitute, list(substitute(code), data))
   file <- tempfile("renv-code-", fileext = fileext)
+  defer(unlink(file), envir = envir)
+
   writeLines(deparse(code), con = file)
   file
 }
@@ -24,7 +26,8 @@ renv_test_retrieve <- function(record) {
   renv_scope_error_handler()
 
   # avoid using cache
-  renv_scope_envvars(RENV_PATHS_CACHE = tempfile())
+  cache_path <- renv_scope_tempfile()
+  renv_scope_envvars(RENV_PATHS_CACHE = cache_path)
 
   # construct records
   package <- record$Package

--- a/tests/testthat/helper-scope.R
+++ b/tests/testthat/helper-scope.R
@@ -10,9 +10,11 @@ renv_tests_scope <- function(packages = character(), project = NULL, envir = par
   if (renv_rstudio_available())
     options(restart = function(...) TRUE)
 
-  # move to own test directory
+  # use own test directory
   dir <- project %||% tempfile("renv-test-")
   ensure_directory(dir)
+  defer(unlink(dir, recursive = TRUE), envir = envir)
+
   dir <- renv_path_normalize(dir, winslash = "/")
   owd <- setwd(dir)
 
@@ -40,7 +42,7 @@ renv_tests_scope <- function(packages = character(), project = NULL, envir = par
 }
 
 renv_tests_scope_repos <- function(envir = parent.frame()) {
-  repopath <- global("test.repo.path", renv_tests_repos_impl())
+  repopath <- renv_tests_repos()
 
   # update our repos option
   fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
@@ -55,6 +57,9 @@ renv_tests_scope_repos <- function(envir = parent.frame()) {
   )
 }
 
+renv_tests_repos <- function() {
+  global("test.repo.path", renv_tests_repos_impl())
+}
 renv_tests_repos_impl <- function() {
   # generate our dummy repository
   repopath <- tempfile("renv-tests-repos-")

--- a/tests/testthat/helper-test_that.R
+++ b/tests/testthat/helper-test_that.R
@@ -60,6 +60,7 @@ renv_test_state <- function() {
     options      = opts,
     repofiles    = if (!is.null(repopath)) list_files(repopath),
     userfiles    = list_files(userpath),
+    tempfiles    = list_files(tempdir()),
     envvars      = envvars
   )
 }

--- a/tests/testthat/helper-test_that.R
+++ b/tests/testthat/helper-test_that.R
@@ -26,11 +26,11 @@ test_that <- function(desc, code) {
 
 renv_test_state <- function() {
 
-  list_files <- function(path) {
+  list_files <- function(path, full.names = TRUE) {
     list.files(
       path = path,
       all.files = TRUE,
-      full.names = TRUE,
+      full.names = full.names,
       no.. = TRUE
     )
   }
@@ -54,13 +54,18 @@ renv_test_state <- function() {
   envvars$OPENBLAS <- NULL
   envvars <- envvars[csort(names(envvars))]
 
+  tempfiles <- list_files(tempdir(), full.names = FALSE)
+  tempfiles <- tempfiles[grep("^libloc_", tempfiles, invert = TRUE)]
+  tempfiles <- tempfiles[grep("^repos_http(s?)", tempfiles, invert = TRUE)]
+  tempfiles <- tempfiles[tempfiles != "downloaded_packages"]
+
   list(
     libpaths     = .libPaths(),
     connections  = getAllConnections(),
     options      = opts,
     repofiles    = if (!is.null(repopath)) list_files(repopath),
     userfiles    = list_files(userpath),
-    tempfiles    = list_files(tempdir()),
+    tempfiles    = tempfiles,
     envvars      = envvars
   )
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -79,6 +79,8 @@ renv_tests_init_packages <- function() {
 
 # cache path before working directory gets changed
 renv_tests_root()
+# force creation of temporary root path
+renv_paths_root()
 
 renv_tests_init_envvars()
 renv_tests_init_options()

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -79,8 +79,9 @@ renv_tests_init_packages <- function() {
 
 # cache path before working directory gets changed
 renv_tests_root()
-# force creation of temporary root path
+# force creation of temporary paths before tests are run
 renv_paths_root()
+renv_tests_repos()
 
 renv_tests_init_envvars()
 renv_tests_init_options()

--- a/tests/testthat/test-archive.R
+++ b/tests/testthat/test-archive.R
@@ -3,11 +3,11 @@ context("Archives")
 
 test_that("renv reports errors when decompressing invalid archives", {
 
-  badtar <- tempfile(fileext = ".tar")
+  badtar <- renv_scope_tempfile(fileext = ".tar")
   writeLines("oh no", con = badtar)
   expect_error(renv_archive_decompress(badtar, verbose = TRUE))
 
-  badzip <- tempfile(fileext = ".zip")
+  badzip <- renv_scope_tempfile(fileext = ".zip")
   writeLines("oh no", con = badzip)
   expect_error(renv_archive_decompress(badzip))
 
@@ -15,40 +15,36 @@ test_that("renv reports errors when decompressing invalid archives", {
 
 test_that("we can successfully compress / decompress some sample files", {
 
-  dir <- tempfile()
-  ensure_directory(dir)
-  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
-
-  owd <- setwd(dir)
-  on.exit(setwd(owd), add = TRUE)
+  renv_scope_tempdir()
 
   for (letter in letters)
     writeLines(letter, con = letter)
 
-  tarfile <- tempfile(fileext = ".tar.gz")
+  tarfile <- renv_scope_tempfile(fileext = ".tar.gz")
   tar(tarfile, files = ".")
 
-  actual <- list.files(dir)
+  actual <- list.files()
   expected <- setdiff(basename(renv_archive_list(tarfile)), ".")
   expect_setequal(actual, expected)
 
-  exdir <- tempfile()
+  exdir <- renv_scope_tempfile()
   renv_archive_decompress(tarfile, exdir = exdir)
-  expect_setequal(list.files(exdir), list.files(dir))
+  expect_setequal(list.files(exdir), list.files())
 
   zipper <- Sys.getenv("R_ZIPCMD", unset = "zip")
   if (nzchar(Sys.which(zipper))) {
 
-    zipfile <- tempfile(fileext = ".zip")
+    zipfile <- renv_scope_tempfile(fileext = ".zip")
     zip(zipfile, files = ".", extras = "-q")
 
-    actual <- list.files(dir)
+    actual <- list.files()
     expected <- basename(renv_archive_list(zipfile))
     expect_setequal(actual, expected)
 
     exdir <- tempfile()
+    defer(unlink(exdir, recursive = TRUE))
     renv_archive_decompress(zipfile, exdir = exdir)
-    expect_setequal(list.files(exdir), list.files(dir))
+    expect_setequal(list.files(exdir), list.files())
 
   }
 

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -6,9 +6,8 @@ test_that("issues within the cache are reported", {
 
   # use a temporary cache for this test as we're going
   # to mutate and invalidate it
-  tempcache <- tempfile("renv-tempcache-")
+  tempcache <- renv_scope_tempfile("renv-tempcache-")
   ensure_directory(tempcache)
-  on.exit(unlink(tempcache, recursive = TRUE), add = TRUE)
   renv_scope_envvars(RENV_PATHS_CACHE = tempcache)
 
   # initialize project
@@ -76,7 +75,7 @@ test_that("package installation does not fail with non-writable cache", {
 
   renv_tests_scope()
 
-  cache <- tempfile("renv-cache-")
+  cache <- renv_scope_tempfile("renv-cache-")
   dir.create(cache, mode = "0555")
   renv_scope_envvars(RENV_PATHS_CACHE = cache)
 
@@ -111,9 +110,8 @@ test_that("malformed folders in the cache are ignored", {
   skip_on_cran()
   renv_tests_scope()
 
-  cachepath <- tempfile("renv-cache-")
+  cachepath <- renv_scope_tempfile("renv-cache-")
   renv_scope_envvars(RENV_PATHS_CACHE = cachepath)
-  on.exit(unlink(cachepath, recursive = TRUE), add = TRUE)
 
   badpath <- renv_paths_cache("a-b/c-d/e-f/g-h/i-j")
   dir.create(dirname(badpath), recursive = TRUE)
@@ -131,9 +129,8 @@ test_that("corrupt Meta/package.rds is detected", {
   skip_on_cran()
   renv_tests_scope()
 
-  cachepath <- tempfile("renv-cache-")
+  cachepath <- renv_scope_tempfile("renv-cache-")
   renv_scope_envvars(RENV_PATHS_CACHE = cachepath)
-  on.exit(unlink(cachepath, recursive = TRUE), add = TRUE)
 
   init()
   install("bread")
@@ -160,9 +157,8 @@ test_that("invalid Built field is detected", {
   skip_on_cran()
   renv_tests_scope()
 
-  cachepath <- tempfile("renv-cache-")
+  cachepath <- renv_scope_tempfile("renv-cache-")
   renv_scope_envvars(RENV_PATHS_CACHE = cachepath)
-  on.exit(unlink(cachepath, recursive = TRUE), add = TRUE)
 
   init()
   install("bread")
@@ -200,10 +196,9 @@ test_that("ACLs set on packages in project library are reset", {
   on.exit(untrace("renv_install_package_impl", where = renv_envir_self()), add = TRUE)
 
   # use a custom cache
-  cachedir <- tempfile("renv-cache-")
+  cachedir <- renv_scope_tempfile("renv-cache-")
   ensure_directory(cachedir)
   renv_scope_envvars(RENV_PATHS_CACHE = cachedir)
-  on.exit(unlink(cachedir, recursive = TRUE), add = TRUE)
 
   # initialize project with bread; don't try to reset ACLs
   local({

--- a/tests/testthat/test-dcf.R
+++ b/tests/testthat/test-dcf.R
@@ -32,7 +32,7 @@ test_that("we can read a latin-1 DESCRIPTION file", {
   '})
 
   latin1 <- iconv(enc2utf8(contents), from = "UTF-8", to = "latin1")
-  file <- tempfile("DESCRIPTION-")
+  file <- renv_scope_tempfile("DESCRIPTION-")
   writeLines(latin1, con = file, useBytes = TRUE)
 
   dcf <- renv_dcf_read(file)
@@ -59,7 +59,7 @@ test_that("we can read a custom encoded DESCRIPTION file", {
     toRaw = TRUE
   )
 
-  file <- tempfile("DESCRIPTION-")
+  file <- renv_scope_tempfile("DESCRIPTION-")
   writeBin(bytes[[1L]], con = file)
 
   dcf <- renv_dcf_read(file)
@@ -76,7 +76,7 @@ test_that("we can read mis-encoded DESCRIPTION files", {
   ')
 
   latin1 <- iconv(enc2utf8(contents), from = "UTF-8", to = "latin1")
-  file <- tempfile("DESCRIPTION-")
+  file <- renv_scope_tempfile("DESCRIPTION-")
   writeLines(latin1, con = file, useBytes = TRUE)
 
   dcf <- renv_dcf_read(file)

--- a/tests/testthat/test-description.R
+++ b/tests/testthat/test-description.R
@@ -4,7 +4,7 @@ context("DESCRIPTION")
 test_that("snapshotting broken DESCRIPTION files is an error", {
 
   # empty file
-  file <- tempfile()
+  file <- renv_scope_tempfile()
   file.create(file)
   expect_s3_class(renv_snapshot_description(file), "error")
 

--- a/tests/testthat/test-download.R
+++ b/tests/testthat/test-download.R
@@ -55,28 +55,28 @@ test_that("we can successfully download files with different downloaders", {
 
   # download a small sample file
   url <- "https://cloud.r-project.org/src/base/THANKS"
-  destfile <- tempfile("r-thanks-")
+  destfile <- renv_scope_tempfile("r-thanks-")
   method <- renv_download_method()
   download.file(url, destfile = destfile, quiet = TRUE, method = method)
   thanks <- readLines(destfile)
 
   if (nzchar(Sys.which("curl"))) local({
     renv_scope_envvars(RENV_DOWNLOAD_FILE_METHOD = "curl")
-    destfile <- tempfile("r-curl-thanks-")
+    destfile <- renv_scope_tempfile("r-curl-thanks-")
     download(url, destfile, quiet = TRUE)
     expect_equal(readLines(destfile), thanks)
   })
 
   if (renv_platform_windows()) local({
     renv_scope_envvars(RENV_DOWNLOAD_FILE_METHOD = "wininet")
-    destfile <- tempfile("r-wininet-thanks-")
+    destfile <- renv_scope_tempfile("r-wininet-thanks-")
     download(url, destfile, quiet = TRUE)
     expect_equal(readLines(destfile), thanks)
   })
 
   if (capabilities("libcurl") %||% FALSE) local({
     renv_scope_envvars(RENV_DOWNLOAD_FILE_METHOD = "libcurl")
-    destfile <- tempfile("r-libcurl-thanks-")
+    destfile <- renv_scope_tempfile("r-libcurl-thanks-")
     download(url, destfile, quiet = TRUE)
     expect_equal(readLines(destfile), thanks)
   })
@@ -84,7 +84,7 @@ test_that("we can successfully download files with different downloaders", {
   # TODO: fails on winbuilder
   # if (nzchar(Sys.which("wget"))) local({
   #   renv_scope_envvars(RENV_DOWNLOAD_FILE_METHOD = "wget")
-  #   destfile <- tempfile("r-wget-thanks-")
+  #   destfile <- renv_scope_tempfile("r-wget-thanks-")
   #   download(url, destfile, quiet = TRUE)
   #   expect_equal(readLines(destfile), thanks)
   # })
@@ -98,7 +98,7 @@ test_that("downloads work with file URIs", {
   repos <- getOption("repos")[["CRAN"]]
   url <- file.path(repos, "src/contrib/PACKAGES")
 
-  destfile <- tempfile("packages-")
+  destfile <- renv_scope_tempfile("packages-")
   download(url, destfile = destfile)
 
   expect_true(file.exists(destfile))

--- a/tests/testthat/test-files.R
+++ b/tests/testthat/test-files.R
@@ -100,7 +100,7 @@ test_that("renv tempfiles are deleted at end of scope", {
 
 test_that("renv_file_find finds parent files", {
 
-  base <- tempfile("renv-files-")
+  base <- renv_scope_tempfile("renv-files-")
   rest <- c("alpha/beta/gamma")
   tip <- file.path(base, rest)
   ensure_directory(tip)
@@ -174,8 +174,7 @@ test_that("renv can list files not representable in the native encoding", {
 
 test_that("renv can detect broken junctions / symlinks", {
 
-  owd <- setwd(tempdir())
-  on.exit(setwd(owd), add = TRUE)
+  renv_scope_tempdir()
 
   if (renv_platform_windows()) {
 

--- a/tests/testthat/test-global.R
+++ b/tests/testthat/test-global.R
@@ -3,7 +3,7 @@ context("Global")
 
 test_that("global() only evaluates value once", {
 
-  name <- basename(tempfile("renv-example-"))
+  name <- basename(renv_scope_tempfile("renv-example-"))
   on.exit(renv_global_clear(name), add = TRUE)
 
   value <- 0L
@@ -16,7 +16,7 @@ test_that("global() only evaluates value once", {
 
 test_that("global values can be get, set", {
 
-  name <- basename(tempfile("renv-example-"))
+  name <- basename(renv_scope_tempfile("renv-example-"))
   on.exit(renv_global_clear(name), add = TRUE)
 
   renv_global_set(name, 42L)

--- a/tests/testthat/test-infrastructure.R
+++ b/tests/testthat/test-infrastructure.R
@@ -7,7 +7,7 @@ test_that("renv.lock is added to .Rbuildignore", {
   renv_tests_scope()
 
   # use custom userdir
-  userdir <- file.path(tempdir(), "renv-userdir-override")
+  userdir <- renv_scope_tempfile("renv-userdir-override")
   ensure_directory(userdir)
   userdir <- normalizePath(userdir, winslash = "/", mustWork = TRUE)
   renv_scope_options(renv.userdir.override = userdir)

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -130,7 +130,7 @@ test_that("we use an external library path for package projects", {
   renv_tests_scope()
 
   # use custom userdir
-  userdir <- file.path(tempdir(), "renv-userdir-override")
+  userdir <- renv_scope_tempfile("renv-userdir-override")
   ensure_directory(userdir)
   userdir <- normalizePath(userdir, winslash = "/", mustWork = TRUE)
   renv_scope_options(renv.userdir.override = userdir)

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -31,8 +31,7 @@ test_that("installation failure is well-reported", {
   # left open by utils::package.skeleton()
   skip_on_os("windows")
 
-  owd <- setwd(tempdir())
-  on.exit(setwd(owd), add = TRUE)
+  renv_scope_tempdir()
 
   # init dummy library
   library <- renv_scope_tempfile("renv-library-")
@@ -179,14 +178,7 @@ test_that("source packages in .zip files can be installed", {
 
   renv_tests_scope()
 
-  dir <- tempfile("renv-ziptest-")
-  dir.create(dir)
-  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
-
-  owd <- setwd(dir)
-  on.exit(setwd(owd), add = TRUE)
-
-  location <- download.packages("bread", destdir = tempdir())
+  location <- download.packages("bread", destdir = renv_scope_tempfile())
   path <- location[1, 2]
   renv_archive_decompress(path, exdir = "bread")
 

--- a/tests/testthat/test-lock.R
+++ b/tests/testthat/test-lock.R
@@ -4,7 +4,7 @@ context("Lock")
 test_that("locks can be acquired, released", {
 
   renv_scope_options(renv.config.locking.enabled = TRUE)
-  path <- renv_lock_path(tempfile())
+  path <- renv_lock_path(renv_scope_tempfile())
 
   renv_lock_acquire(path)
   expect_true(file.exists(path))
@@ -17,7 +17,7 @@ test_that("locks can be acquired, released", {
 test_that("scoped locks are released appropriately", {
 
   renv_scope_options(renv.config.locking.enabled = TRUE)
-  path <- renv_lock_path(tempfile())
+  path <- renv_lock_path(renv_scope_tempfile())
 
   local({
     renv_scope_lock(path)
@@ -31,7 +31,7 @@ test_that("scoped locks are released appropriately", {
 test_that("we can recursively acquire locks", {
 
   renv_scope_options(renv.config.locking.enabled = TRUE)
-  path <- renv_lock_path(tempfile())
+  path <- renv_lock_path(renv_scope_tempfile())
 
   local({
 
@@ -59,7 +59,7 @@ test_that("other processes cannot lock our owned locks", {
   )
 
   renv_scope_options(renv.config.locking.enabled = TRUE)
-  path <- renv_lock_path(tempfile())
+  path <- renv_lock_path(renv_scope_tempfile())
 
   renv_lock_acquire(path)
 
@@ -80,7 +80,7 @@ test_that("other processes cannot lock our owned locks", {
 test_that("locks are released on process exit", {
 
   renv_scope_options(renv.config.locking.enabled = TRUE)
-  path <- renv_lock_path(tempfile())
+  path <- renv_lock_path(renv_scope_tempfile())
 
   code <- substitute({
     renv:::renv_lock_acquire(path)
@@ -100,7 +100,7 @@ test_that("locks are released on process exit", {
 test_that("old locks are considered 'orphaned'", {
 
   renv_scope_options(renv.config.locking.enabled = TRUE)
-  path <- renv_lock_path(tempfile())
+  path <- renv_lock_path(renv_scope_tempfile())
 
   renv_scope_options(renv.lock.timeout = 0L)
   renv_lock_acquire(path)

--- a/tests/testthat/test-memoize.R
+++ b/tests/testthat/test-memoize.R
@@ -4,7 +4,7 @@ context("Memoize")
 test_that("memoization works as expected", {
 
   global <- 0L
-  scope <- basename(tempfile("renv-memoize-"))
+  scope <- basename(renv_scope_tempfile("renv-memoize-"))
 
   value <- memoize(
     scope = scope,
@@ -38,7 +38,7 @@ test_that("memoization works as expected", {
 test_that("memoize avoids evaluating expression multiple times", {
 
   value <- 0L
-  scope <- basename(tempfile("renv-memoize-"))
+  scope <- basename(renv_scope_tempfile("renv-memoize-"))
 
   memoize("example", { value <- value + 1L }, scope = scope)
   memoize("example", { value <- value + 1L }, scope = scope)

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -24,8 +24,8 @@ test_that("a sample Packrat project can be migrated", {
 
   # use dummy caches for this test
   renv_scope_envvars(
-    R_PACKRAT_CACHE_DIR = tempfile("packrat-cache-"),
-    RENV_PATHS_ROOT     = tempfile("renv-cache-")
+    R_PACKRAT_CACHE_DIR = renv_scope_tempfile("packrat-cache-"),
+    RENV_PATHS_ROOT     = renv_scope_tempfile("renv-cache-")
   )
 
   requireNamespace("packrat")
@@ -66,8 +66,8 @@ test_that("a Packrat project with no library can be migrated", {
 
   # use dummy caches for this test
   renv_scope_envvars(
-    R_PACKRAT_CACHE_DIR = tempfile("packrat-cache-"),
-    RENV_PATHS_ROOT     = tempfile("renv-cache-")
+    R_PACKRAT_CACHE_DIR = renv_scope_tempfile("packrat-cache-"),
+    RENV_PATHS_ROOT     = renv_scope_tempfile("renv-cache-")
   )
 
   renv_tests_scope("breakfast")

--- a/tests/testthat/test-paths.R
+++ b/tests/testthat/test-paths.R
@@ -59,6 +59,7 @@ test_that("UTF-8 paths can be normalized", {
   name <- enc2utf8("\u4f60\u597d")  # nihao
   root <- normalizePath(tempdir(), winslash = "/", mustWork = TRUE)
   path <- paste(root, name, sep = "/")
+  defer(unlink(path))
   expect_true(file.create(path))
 
   expected <- path

--- a/tests/testthat/test-python.R
+++ b/tests/testthat/test-python.R
@@ -107,7 +107,7 @@ test_that("installed Python packages are snapshotted / restored [virtualenv]", {
   # initialize python
   python <- renv::use_python(
     python,
-    name = tempfile("python-virtualenv-"),
+    name = renv_scope_tempfile("python-virtualenv-"),
     type = "virtualenv"
   )
 

--- a/tests/testthat/test-r.R
+++ b/tests/testthat/test-r.R
@@ -9,9 +9,7 @@ test_that("we can use R CMD build to build a package", {
       skip("test requires 'zip'")
   }
 
-  testdir <- tempfile("renv-r-tests-")
-  on.exit(unlink(testdir, recursive = TRUE), add = TRUE)
-
+  testdir <- renv_scope_tempfile("renv-r-tests-")
   ensure_directory(testdir)
   owd <- setwd(testdir)
   on.exit(setwd(owd), add = TRUE)
@@ -47,7 +45,7 @@ test_that("we can supply custom options to R CMD INSTALL", {
   renv_tests_scope()
 
   # work in new renv context (don't re-use cache)
-  renv_scope_envvars(RENV_PATHS_ROOT = tempfile())
+  renv_scope_envvars(RENV_PATHS_ROOT = renv_scope_tempfile())
 
   # make install 'fail' with bad option
   renv_scope_options(install.opts = list(oatmeal = "--version"))

--- a/tests/testthat/test-rehash.R
+++ b/tests/testthat/test-rehash.R
@@ -3,12 +3,8 @@ context("Rehash")
 
 test_that("rehash() migrates cached packages as expected", {
 
-  on.exit(Sys.unsetenv("RENV_CACHE_VERSION"), add = TRUE)
-
-  tempcache <- tempfile("renv-cache-")
-  on.exit(unlink(tempcache, recursive = TRUE), add = TRUE)
+  tempcache <- renv_scope_tempfile("renv-cache-")
   renv_scope_envvars(RENV_PATHS_CACHE = tempcache)
-
   renv_scope_envvars(RENV_CACHE_VERSION = "v4")
   renv_tests_scope("breakfast")
   init()

--- a/tests/testthat/test-restore.R
+++ b/tests/testthat/test-restore.R
@@ -91,7 +91,7 @@ test_that("install.staged works as expected", {
       install.opts = install.opts
     )
 
-    renv_scope_envvars(RENV_PATHS_CACHE = tempfile())
+    renv_scope_envvars(RENV_PATHS_CACHE = renv_scope_tempfile())
 
     unlink(renv_paths_library(), recursive = TRUE)
     expect_error(renv::restore())
@@ -108,7 +108,7 @@ test_that("install.staged works as expected", {
       install.opts = install.opts
     )
 
-    renv_scope_envvars(RENV_PATHS_CACHE = tempfile())
+    renv_scope_envvars(RENV_PATHS_CACHE = renv_scope_tempfile())
 
     unlink(renv_paths_library(), recursive = TRUE)
     expect_error(renv::restore())
@@ -207,8 +207,8 @@ test_that("restore doesn't re-use active library paths", {
   renv_tests_scope()
   renv_scope_options(renv.settings.snapshot.type = "all")
 
-  lib1 <- file.path(tempdir(), "lib1")
-  lib2 <- file.path(tempdir(), "lib2")
+  lib1 <- renv_scope_tempfile("lib1")
+  lib2 <- renv_scope_tempfile("lib2")
   ensure_directory(c(lib1, lib2))
   .libPaths(c(lib2, .libPaths()))
 

--- a/tests/testthat/test-sandbox.R
+++ b/tests/testthat/test-sandbox.R
@@ -2,7 +2,9 @@ context("Sandbox")
 
 renv_scoped_sandbox <- function(envir = parent.frame()) {
   renv_scope_options(renv.config.sandbox.enabled = TRUE, envir = envir)
-  renv_scope_envvars(RENV_PATHS_SANDBOX = tempdir(), envir = envir)
+
+  sandbox <- renv_scope_tempfile(envir = envir)
+  renv_scope_envvars(RENV_PATHS_SANDBOX = sandbox, envir = envir)
 
   old <- list(.Library.site, .Library, .libPaths())
   defer(envir = envir, {

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -17,14 +17,14 @@ test_that("snapshot is idempotent", {
 
 test_that("snapshot failures are reported", {
 
-  renv_scope_envvars(RENV_PATHS_ROOT = tempfile())
+  renv_scope_envvars(RENV_PATHS_ROOT = renv_scope_tempfile())
   renv_tests_scope("oatmeal")
   renv::init()
 
   descpath <- system.file("DESCRIPTION", package = "oatmeal")
   unlink(descpath)
 
-  output <- tempfile("renv-snapshot-output-")
+  output <- renv_scope_tempfile("renv-snapshot-output-")
   local({
     renv_scope_options(renv.verbose = TRUE)
     renv_scope_sink(file = output)
@@ -39,14 +39,14 @@ test_that("snapshot failures are reported", {
 test_that("broken symlinks are reported", {
   skip_on_os("windows")
 
-  renv_scope_envvars(RENV_PATHS_ROOT = tempfile())
+  renv_scope_envvars(RENV_PATHS_ROOT = renv_scope_tempfile())
   renv_tests_scope("oatmeal")
   renv::init()
 
   oatmeal <- renv_path_normalize(system.file(package = "oatmeal"), winslash = "/")
   unlink(oatmeal, recursive = TRUE)
 
-  output <- tempfile("renv-snapshot-output-")
+  output <- renv_scope_tempfile("renv-snapshot-output-")
   local({
     renv_scope_options(renv.verbose = TRUE)
     renv_scope_sink(file = output)
@@ -60,13 +60,13 @@ test_that("broken symlinks are reported", {
 
 test_that("multiple libraries can be used when snapshotting", {
 
-  renv_scope_envvars(RENV_PATHS_ROOT = tempfile())
+  renv_scope_envvars(RENV_PATHS_ROOT = renv_scope_tempfile())
   renv_tests_scope()
 
   renv::init()
 
-  lib1 <- tempfile("renv-lib1-")
-  lib2 <- tempfile("renv-lib2-")
+  lib1 <- renv_scope_tempfile("renv-lib1-")
+  lib2 <- renv_scope_tempfile("renv-lib2-")
   ensure_directory(c(lib1, lib2))
 
   oldlibpaths <- .libPaths()
@@ -206,7 +206,7 @@ test_that("snapshot records packages discovered in cellar", {
 
   renv_tests_scope("skeleton")
   renv_scope_envvars(
-    RENV_PATHS_CACHE = tempfile(),
+    RENV_PATHS_CACHE = renv_scope_tempfile(),
     RENV_PATHS_LOCAL = renv_tests_path("local")
   )
 
@@ -235,7 +235,7 @@ test_that("snapshot prefers RemoteType to biocViews", {
     biocViews = "Biology"
   )
 
-  descfile <- tempfile()
+  descfile <- renv_scope_tempfile()
   renv_dcf_write(desc, file = descfile)
   record <- renv_snapshot_description(descfile)
   expect_identical(record$Source, "GitHub")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -39,7 +39,7 @@ test_that("renv_path_aliased() correctly forms aliased path", {
 
 test_that("sink captures both stdout and stderr", {
 
-  file <- tempfile("renv-sink-", fileext = ".log")
+  file <- renv_scope_tempfile("renv-sink-", fileext = ".log")
 
   osinks <- sink.number(type = "output")
   msinks <- sink.number(type = "message")


### PR DESCRIPTION
I'm not sure how important this is, but most of the changes a straightforward, so I think it makes sense to merge this PR even if we decide to back out of systematically monitoring the tempdir.

@kevinushey I got stuck eliminating at `renv-library-*`, which I think is coming from `renv_libpaths_safe_tempdir()`.  It wasn't clear to me how to pick a scope to clean this up correctly. You should probably also carefully review the changes I made in `R/`, in case I got the scope wrong.