### PR TITLE
Use `csort()` in more places

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -89,8 +89,7 @@ renv_diagnostics_packages <- function(project) {
   )
 
   # sort
-  renv_scope_locale(category = "LC_COLLATE", locale = "C")
-  all <- sort(unique(all))
+  all <- csort(unique(all))
 
   # check which packages are direct, indirect requirements
   deps <- rep.int(NA_character_, length(all))

--- a/R/hash.R
+++ b/R/hash.R
@@ -32,10 +32,7 @@ renv_hash_description_impl <- function(path) {
   subsetted <- dcf[renv_vector_intersect(c(fields, remotes), names(dcf))]
 
   # sort names (use C locale to ensure consistent ordering)
-  ordered <- local({
-    renv_scope_locale("LC_COLLATE", "C")
-    subsetted[sort(names(subsetted))]
-  })
+  ordered <- subsetted[csort(names(subsetted))]
 
   # write to tempfile (use binary connection to ensure unix-style
   # newlines for cross-platform hash stability)

--- a/R/load.R
+++ b/R/load.R
@@ -372,10 +372,7 @@ renv_load_project_projlist <- function(project) {
     return(TRUE)
 
   # sort with C locale (ensure consistent sorting across OSes)
-  projlist <- local({
-    renv_scope_locale("LC_COLLATE", "C")
-    sort(c(projlist, project))
-  })
+  projlist <- csort(c(projlist, project))
 
   # update the project list
   ensure_parent_directory(projects)

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -142,16 +142,13 @@ renv_lockfile_load <- function(project) {
 
 renv_lockfile_sort <- function(lockfile) {
 
-  # ensure C locale for consistent sorting
-  renv_scope_locale("LC_COLLATE", "C")
-
   # extract R records (nothing to do if empty)
   records <- renv_lockfile_records(lockfile)
   if (empty(records))
     return(lockfile)
 
   # sort the records
-  sorted <- records[sort(names(records))]
+  sorted <- records[csort(names(records))]
   renv_lockfile_records(lockfile) <- sorted
 
   # sort top-level fields
@@ -210,8 +207,7 @@ renv_lockfile_compact <- function(lockfile) {
   records <- renv_lockfile_records(lockfile)
   remotes <- map_chr(records, renv_record_format_remote)
 
-  renv_scope_locale("LC_COLLATE", "C")
-  remotes <- sort(remotes)
+  remotes <- csort(remotes)
 
   formatted <- sprintf("  \"%s\"", remotes)
   joined <- paste(formatted, collapse = ",\n")

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -94,8 +94,7 @@ renv_pretty_print_records_pair <- function(old,
 
 renv_pretty_print_records_pair_impl <- function(old, new, formatter) {
 
-  renv_scope_locale("LC_COLLATE", "C")
-  all <- sort(union(names(old), names(new)))
+  all <- csort(union(names(old), names(new)))
 
   # compute groups
   groups <- map_chr(all, function(package) {
@@ -113,7 +112,7 @@ renv_pretty_print_records_pair_impl <- function(old, new, formatter) {
   n <- max(nchar(all))
 
   # iterate over each group and print
-  uapply(sort(unique(groups)), function(group) {
+  uapply(csort(unique(groups)), function(group) {
 
     lhs <- renv_records_select(old, groups, group)
     rhs <- renv_records_select(new, groups, group)

--- a/R/records.R
+++ b/R/records.R
@@ -6,8 +6,7 @@ renv_records_select <- function(records, actions, action) {
 }
 
 renv_records_sort <- function(records) {
-  renv_scope_locale("LC_COLLATE", "C")
-  records[order(names(records))]
+  records[csort(names(records))]
 }
 
 renv_records_override <- function(records) {


### PR DESCRIPTION
`csort()` now is the only place that uses `renv_scope_locale()`, so I could simplify/inline that logic too, if you wanted.