### PR TITLE
Eliminate use of %||% with environments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.17.3-47
+Version: 0.17.3-48
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1,5 +1,7 @@
 
 `%||%` <- function(x, y) {
+  if (is.environment(x)) warning("An environment!")
+
   if (is.environment(x) || length(x)) x else y
 }
 

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1,8 +1,6 @@
 
 `%||%` <- function(x, y) {
-  if (is.environment(x)) warning("An environment!")
-
-  if (is.environment(x) || length(x)) x else y
+  if (length(x)) x else y
 }
 
 `%??%` <- function(x, y) {

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1001,7 +1001,7 @@ renv_dependencies_discover_r <- function(path = NULL,
     renv_dependencies_discover_r_database
   )
 
-  envir <- envir %||% new.env(parent = emptyenv())
+  envir <- envir %??% new.env(parent = emptyenv())
   recurse(expr, function(node, stack) {
 
     # normalize calls (handle magrittr pipes)

--- a/R/filebacked.R
+++ b/R/filebacked.R
@@ -75,7 +75,7 @@ renv_filebacked_get <- function(scope, path) {
 
 renv_filebacked_envir <- function(scope) {
   `_renv_filebacked`[[scope]] <-
-    `_renv_filebacked`[[scope]] %||%
+    `_renv_filebacked`[[scope]] %??%
     new.env(parent = emptyenv())
 }
 

--- a/R/index.R
+++ b/R/index.R
@@ -104,7 +104,7 @@ renv_index_get <- function(root, scope, index, key, now, limit) {
 
   # add to in-memory cache
   `_renv_index`[[scope]] <-
-    `_renv_index`[[scope]] %||%
+    `_renv_index`[[scope]] %??%
     new.env(parent = emptyenv())
 
   `_renv_index`[[scope]][[key]] <- value

--- a/R/memoize.R
+++ b/R/memoize.R
@@ -14,7 +14,7 @@ memoize <- function(key, value, scope = NULL) {
   # initialize memoized environment
   envir <-
     `_renv_memoize`[[scope]] <-
-    `_renv_memoize`[[scope]] %||%
+    `_renv_memoize`[[scope]] %??%
     new.env(parent = emptyenv())
 
   # retrieve, or compute, memoized value

--- a/R/mran.R
+++ b/R/mran.R
@@ -144,7 +144,7 @@ renv_mran_database_update <- function(platform, version, dates = NULL) {
 
   # get reference to entry in database (initialize if not yet created)
   suffix <- renv_mran_database_key(platform, version)
-  database[[suffix]] <- database[[suffix]] %||% new.env(parent = emptyenv())
+  database[[suffix]] <- database[[suffix]] %??% new.env(parent = emptyenv())
   entry <- database[[suffix]]
 
   # rough release dates for R releases

--- a/R/scope.R
+++ b/R/scope.R
@@ -1,13 +1,11 @@
 
 renv_scope_tempdir <- function(pattern = "renv-tempdir-",
                                tmpdir = tempdir(),
-                               envir = NULL)
+                               envir = parent.frame())
 {
   dir <- tempfile(pattern = pattern, tmpdir = tmpdir)
   ensure_directory(dir)
   owd <- setwd(dir)
-
-  envir <- envir %||% parent.frame()
 
   defer({
     setwd(owd)
@@ -16,7 +14,7 @@ renv_scope_tempdir <- function(pattern = "renv-tempdir-",
 
 }
 
-renv_scope_auth <- function(record, envir = NULL) {
+renv_scope_auth <- function(record, envir = parent.frame()) {
 
   package <- if (is.list(record)) record$Package else record
   auth <- renv_options_override("renv.auth", package, extra = record)
@@ -40,21 +38,17 @@ renv_scope_auth <- function(record, envir = NULL) {
   if (empty(envvars))
     return(FALSE)
 
-  envir <- envir %||% parent.frame()
   renv_scope_envvars(list = as.list(envvars), envir = envir)
   return(TRUE)
 
 }
 
-renv_scope_libpaths <- function(new = .libPaths(), envir = NULL) {
-  envir <- envir %||% parent.frame()
+renv_scope_libpaths <- function(new = .libPaths(), envir = parent.frame()) {
   old <- renv_libpaths_set(new)
   defer(renv_libpaths_set(old), envir = envir)
 }
 
-renv_scope_options <- function(..., envir = NULL) {
-
-  envir <- envir %||% parent.frame()
+renv_scope_options <- function(..., envir = parent.frame()) {
 
   new <- list(...)
   old <- options(new)
@@ -62,18 +56,15 @@ renv_scope_options <- function(..., envir = NULL) {
 
 }
 
-renv_scope_locale <- function(category = "LC_ALL", locale = "", envir = NULL) {
-  envir <- envir %||% parent.frame()
+renv_scope_locale <- function(category = "LC_ALL", locale = "", envir = parent.frame()) {
   saved <- Sys.getlocale(category)
   Sys.setlocale(category, locale)
   defer(Sys.setlocale(category, saved), envir = envir)
 }
 
-renv_scope_envvars <- function(..., list = NULL, envir = NULL) {
+renv_scope_envvars <- function(..., list = NULL, envir = parent.frame()) {
 
-  envir <- envir %||% parent.frame()
-
-  dots <- list %||% list(...)
+  dots <- list %??% list(...)
   old <- as.list(Sys.getenv(names(dots), unset = NA))
   names(old) <- names(dots)
 
@@ -91,9 +82,7 @@ renv_scope_envvars <- function(..., list = NULL, envir = NULL) {
 
 }
 
-renv_scope_sink <- function(file = nullfile(), envir = NULL) {
-
-  envir <- envir %||% parent.frame()
+renv_scope_sink <- function(file = nullfile(), envir = parent.frame()) {
 
   # redirect stdout to file, and redirect stderr back to stdout
   # this ensures that both stdout, stderr are redirected to the same place
@@ -107,7 +96,7 @@ renv_scope_sink <- function(file = nullfile(), envir = NULL) {
 
 }
 
-renv_scope_error_handler <- function(envir = NULL) {
+renv_scope_error_handler <- function(envir = parent.frame()) {
 
   error <- getOption("error")
   if (!is.null(error))
@@ -116,7 +105,6 @@ renv_scope_error_handler <- function(envir = NULL) {
   call <- renv_error_handler_call()
   options(error = call)
 
-  envir <- envir %||% parent.frame()
   defer({
     if (identical(getOption("error"), call))
       options(error = error)
@@ -130,7 +118,7 @@ renv_scope_error_handler <- function(envir = NULL) {
 # renv_paths_extsoft folder when available on Windows
 
 # nocov start
-renv_scope_downloader <- function(envir = NULL) {
+renv_scope_downloader <- function(envir = parent.frame()) {
 
   if (!renv_platform_windows())
     return(FALSE)
@@ -149,14 +137,13 @@ renv_scope_downloader <- function(envir = NULL) {
 
   new <- paste(renv_path_normalize(dirname(curl)), old, sep = .Platform$path.sep)
 
-  envir <- envir %||% parent.frame()
   renv_scope_envvars(PATH = new, envir = envir)
 
 }
 # nocov end
 
 # nocov start
-renv_scope_rtools <- function(envir = NULL) {
+renv_scope_rtools <- function(envir = parent.frame()) {
 
   if (!renv_platform_windows())
     return(FALSE)
@@ -170,16 +157,13 @@ renv_scope_rtools <- function(envir = NULL) {
   vars <- renv_rtools_envvars(root)
 
   # scope envvars in parent
-  envir <- envir %||% parent.frame()
   renv_scope_envvars(list = vars, envir = envir)
 
 }
 # nocov end
 
 # nocov start
-renv_scope_install <- function(envir = NULL) {
-
-  envir <- envir %||% parent.frame()
+renv_scope_install <- function(envir = parent.frame()) {
 
   if (renv_platform_macos())
     renv_scope_install_macos(envir)
@@ -189,9 +173,7 @@ renv_scope_install <- function(envir = NULL) {
 
 }
 
-renv_scope_install_macos <- function(envir = NULL) {
-
-  envir <- envir %||% parent.frame()
+renv_scope_install_macos <- function(envir = parent.frame()) {
 
   # check that we have command line tools available before invoking
   # R CMD config, as this might fail otherwise
@@ -270,21 +252,17 @@ renv_scope_install_macos <- function(envir = NULL) {
 
 }
 
-renv_scope_install_wsl <- function(envir = NULL) {
-  envir <- envir %||% parent.frame()
+renv_scope_install_wsl <- function(envir = parent.frame()) {
   renv_scope_envvars(R_INSTALL_STAGED = "FALSE")
 }
 # nocov end
 
-renv_scope_restore <- function(..., envir = NULL) {
-  envir <- envir %||% parent.frame()
+renv_scope_restore <- function(..., envir = parent.frame()) {
   state <- renv_restore_begin(...)
   defer(renv_restore_end(state), envir = envir)
 }
 
-renv_scope_git_auth <- function(envir = NULL) {
-
-  envir <- envir %||% parent.frame()
+renv_scope_git_auth <- function(envir = parent.frame()) {
 
   # try and tell git to be non-interactive by default
   if (renv_platform_windows()) {
@@ -334,10 +312,8 @@ renv_scope_git_auth <- function(envir = NULL) {
 
 renv_scope_bioconductor <- function(project = NULL,
                                     version = NULL,
-                                    envir = NULL)
+                                    envir = parent.frame())
 {
-  envir <- envir %||% parent.frame()
-
   # get current repository
   repos <- getOption("repos")
 
@@ -355,15 +331,12 @@ renv_scope_bioconductor <- function(project = NULL,
   renv_scope_options(repos = renv_vector_unique(allrepos), envir = envir)
 }
 
-renv_scope_lock <- function(path = NULL, envir = NULL) {
-  envir <- envir %||% parent.frame()
+renv_scope_lock <- function(path = NULL, envir = parent.frame()) {
   renv_lock_acquire(path)
   defer(renv_lock_release(path), envir = envir)
 }
 
-renv_scope_trace <- function(what, tracer, envir = NULL) {
-
-  envir <- envir %||% parent.frame()
+renv_scope_trace <- function(what, tracer, envir = parent.frame()) {
 
   call <- sys.call()
   call[[1L]] <- base::trace
@@ -374,10 +347,8 @@ renv_scope_trace <- function(what, tracer, envir = NULL) {
 
 }
 
-renv_scope_var <- function(key, value, frame = NULL, envir = NULL) {
+renv_scope_var <- function(key, value, frame = NULL, envir = parent.frame()) {
 
-  frame <- frame %||% renv_envir_self()
-  envir <- envir %||% parent.frame()
   if (exists(key, envir = frame, inherits = FALSE)) {
     saved <- get(key, envir = frame, inherits = FALSE)
     assign(key, value, envir = frame, inherits = FALSE)
@@ -392,18 +363,16 @@ renv_scope_var <- function(key, value, frame = NULL, envir = NULL) {
 renv_scope_tempfile <- function(pattern = "renv-tempfile-",
                                 tmpdir  = tempdir(),
                                 fileext = "",
-                                envir  = NULL)
+                                envir  = parent.frame())
 {
   filepath <- tempfile(pattern, tmpdir, fileext)
 
-  envir <- envir %||% parent.frame()
   defer(unlink(filepath, recursive = TRUE, force = TRUE), envir = envir)
 
   invisible(filepath)
 }
 
-renv_scope_umask <- function(umask, envir = NULL) {
-  envir <- envir %||% parent.frame()
+renv_scope_umask <- function(umask, envir = parent.frame()) {
   oldmask <- Sys.umask(umask)
   defer(Sys.umask(oldmask), envir = envir)
   invisible(oldmask)

--- a/R/scope.R
+++ b/R/scope.R
@@ -347,7 +347,7 @@ renv_scope_trace <- function(what, tracer, envir = parent.frame()) {
 
 }
 
-renv_scope_var <- function(key, value, frame = NULL, envir = parent.frame()) {
+renv_scope_var <- function(key, value, frame, envir = parent.frame()) {
 
   if (exists(key, envir = frame, inherits = FALSE)) {
     saved <- get(key, envir = frame, inherits = FALSE)

--- a/R/update.R
+++ b/R/update.R
@@ -236,7 +236,7 @@ update <- function(packages = NULL,
   }
 
   # get package records
-  renv_scope_var("_renv_snapshot_hash", FALSE)
+  renv_scope_var("_renv_snapshot_hash", FALSE, frame = renv_envir_self())
   records <- renv_snapshot_libpaths(libpaths = libpaths, project = project)
   packages <- packages %||% names(records)
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -41,7 +41,7 @@ renv_tests_init_options <- function() {
     renv.config.user.library = FALSE,
     renv.config.sandbox.enabled = TRUE,
     restart = NULL,
-    # warn = 2,
+    warn = 2,
     # don't perform transactional installs by default for now
     # (causes strange CI failures, especially on Windows?)
     renv.config.install.transactional = FALSE,

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -41,7 +41,7 @@ renv_tests_init_options <- function() {
     renv.config.user.library = FALSE,
     renv.config.sandbox.enabled = TRUE,
     restart = NULL,
-    warn = 2,
+    # warn = 2,
     # don't perform transactional installs by default for now
     # (causes strange CI failures, especially on Windows?)
     renv.config.install.transactional = FALSE,


### PR DESCRIPTION
This is the first step towards unifying `%||%` and `%??%`. After a few abortive attempts, I figured out the best way to do this is to slowly move usage of `%||%` to `%??%`, since that makes it stricter. Then, once that's all done, I can rename `%??%` to `%||%`.

This first PR eliminates the use of `%||%` with environments by using argument defaults more in `scope.R`, and using `%??%` for environment caching elsewhere.

This includes a temporary warning in `%||%` and a temporary elimination of `warn = 1`. If you think this first step is sound, I'll remove these changes prior to merging.