### PR TITLE
Only temporarily unset RENV_CONFIG_*

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -545,5 +545,5 @@ untar <- function(tarfile,
 }
 
 rep_named <- function(names, x) {
-  setNames(rep_len(x, length(names)), names)
+  stats::setNames(rep_len(x, length(names)), names)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -543,3 +543,7 @@ untar <- function(tarfile,
   # return other results as-is
   result
 }
+
+rep_named <- function(names, x) {
+  setNames(rep_len(x, length(names)), names)
+}

--- a/tests/testthat/helper-scope.R
+++ b/tests/testthat/helper-scope.R
@@ -175,7 +175,10 @@ renv_tests_scope_envvars <- function(envir = parent.frame()) {
 
   envvars <- Sys.getenv()
   configvars <- grep("^RENV_CONFIG_", names(envvars), value = TRUE)
-  Sys.unsetenv(configvars)
+  renv_scope_envvars(
+    list = rep_named(configvars, list(NULL)),
+    envir = envir
+  )
 }
 
 renv_tests_scope_options <- function(envir = parent.frame()) {

--- a/tests/testthat/test-envvars.R
+++ b/tests/testthat/test-envvars.R
@@ -1,8 +1,6 @@
 test_that("renv_envvars_save() is idempotent", {
 
-  envs <- rep(list(NULL), length(renv_envvars_list()))
-  names(envs) <- renv_envvars_list()
-  renv_scope_envvars(list = envs)
+  renv_scope_envvars(list = rep_named(renv_envvars_list(), list(NULL)))
   renv_scope_envvars(RENV_DEFAULT_R_LIBS_USER = "xyz")
 
   renv_envvars_restore()


### PR DESCRIPTION
Includes `rep_named()` helper ported from rlang, which makes generating a named list of NULLs a bit easier.