### PR TITLE
Provide helper to execute deferred handlers interactively

### DIFF
--- a/R/defer.R
+++ b/R/defer.R
@@ -10,3 +10,6 @@ defer <- function(expr, envir = parent.frame()) {
 
 }
 
+deferred_run <- function(envir = parent.frame()) {
+  renv_exit_handlers_execute(envir)
+}

--- a/R/defer.R
+++ b/R/defer.R
@@ -9,7 +9,3 @@ defer <- function(expr, envir = parent.frame()) {
   invisible(handler)
 
 }
-
-deferred_run <- function(envir = parent.frame()) {
-  renv_exit_handlers_execute(envir)
-}

--- a/tests/testthat/helper-scope.R
+++ b/tests/testthat/helper-scope.R
@@ -1,3 +1,14 @@
+# helper to interactively reset scoped modifications on globalenv
+if (interactive()) {
+  makeActiveBinding(
+    "done",
+    function(value) {
+      renv_exit_handlers_execute(envir = globalenv())
+    },
+    env = globalenv()
+  )
+}
+
 renv_tests_scope <- function(packages = character(), project = NULL, envir = parent.frame()) {
 
   renv_tests_scope_repos(envir = envir)


### PR DESCRIPTION
This allows you to reset the state after running (e.g.) `renv_tests_scope()` interactively.