### PR TITLE
Gate slow tests behind an env var

### DIFF
--- a/.github/workflows/slow-tests.yaml
+++ b/.github/workflows/slow-tests.yaml
@@ -1,0 +1,38 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: slow-tests
+
+jobs:
+  slow-tests:
+    runs-on: ubuntu-latest
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      RENV_TESTTHAT_SLOW: true
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/R/skip.R
+++ b/R/skip.R
@@ -51,8 +51,3 @@ skip_if_no_miniconda <- function(python) {
   TRUE
 
 }
-
-skip_sometimes <- function(freq = 0.80) {
-  threshold <- sample.int(100L, size = 1L)
-  testthat::skip_if(freq * 100 >= threshold)
-}

--- a/tests/testthat/helper-slow.R
+++ b/tests/testthat/helper-slow.R
@@ -1,0 +1,16 @@
+skip_slow <- function()  {
+  skip_on_cran()
+  skip_if_not(is_slow(), "Skipping slow test")
+}
+
+is_slow <- function() {
+  identical(as.logical(Sys.getenv("RENV_TESTTHAT_SLOW", "false")), TRUE)
+}
+
+slow_test_disable <- function() {
+  Sys.unsetenv("RENV_TESTTHAT_SLOW")
+}
+
+slow_test_enable <- function() {
+  Sys.setenv("RENV_TESTTHAT_SLOW" = "true")
+}

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -168,7 +168,6 @@ test_that("we're compatible with R", {
 
 test_that("we can query the R universe", {
   skip_on_cran()
-  skip_sometimes()
 
   lhs <- as.data.frame(
     available.packages(

--- a/tests/testthat/test-bioconductor.R
+++ b/tests/testthat/test-bioconductor.R
@@ -1,7 +1,7 @@
 
 test_that("packages can be installed, restored from Bioconductor", {
 
-  skip_on_cran()
+  skip_slow()
   skip_on_os("windows")
   skip_if(getRversion() < "3.5.0")
   skip_if(R.version$nickname == "Unsuffered Consequences")
@@ -57,7 +57,7 @@ test_that("renv::install(<bioc>, rebuild = TRUE) works", {
 
 test_that("bioconductor.version can be used to freeze version", {
 
-  skip_on_cran()
+  skip_slow()
   project <- renv_tests_scope()
 
   settings$bioconductor.version("3.14", project = project)

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -265,8 +265,7 @@ test_that("renv can install packages from Bitbucket", {
 })
 
 test_that("renv can install packages from GitHub using remotes subdir syntax", {
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
   renv_tests_scope()
   install("kevinushey/skeleton/subdir")
   expect_true(renv_package_installed("skeleton"))
@@ -450,9 +449,8 @@ test_that("staging library path has same permissions as library path", {
 
 test_that("packages installed from a RemoteSubdir can be retrieved from cache", {
 
-  skip_on_cran()
   skip_on_windows()
-  skip_sometimes()
+  skip_slow()
 
   renv_tests_scope()
   cachepath <- renv_scope_tempfile("renv-cache-")
@@ -474,9 +472,8 @@ test_that("packages installed from a RemoteSubdir can be retrieved from cache", 
 
 test_that("repositories containing multiple packages can be installed", {
 
-  skip_on_cran()
   skip_on_windows()
-  skip_sometimes()
+  skip_slow()
 
   renv_tests_scope()
 

--- a/tests/testthat/test-json.R
+++ b/tests/testthat/test-json.R
@@ -51,8 +51,7 @@ test_that("empty R lists are converted as expected", {
 
 test_that("we can parse a GitHub remotes specification", {
 
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
 
   data <- renv_remotes_resolve("rstudio/renv")
   expect_true(data$Source == "GitHub")

--- a/tests/testthat/test-mran.R
+++ b/tests/testthat/test-mran.R
@@ -21,10 +21,9 @@ test_that("older binaries are installed from MRAN on Windows / macOS", {
 })
 
 test_that("we can install packages from MRAN", {
-  skip_on_cran()
   skip_on_os("linux")
   skip_if(getRversion() <= "3.5" || getRversion() > "3.6")
-  skip_sometimes()
+  skip_slow()
 
   renv_tests_scope()
   renv_scope_options(repos = character(), pkgType = "binary")

--- a/tests/testthat/test-python.R
+++ b/tests/testthat/test-python.R
@@ -31,8 +31,8 @@ test_that("we can activate Python with a project", {
 
 test_that("we can activate Python with a virtualenv in a project", {
 
+  skip_slow()
   skip_on_os("windows")
-  skip_on_cran()
   skip_if_no_virtualenv(python)
   renv_test_scope_python()
 
@@ -95,8 +95,8 @@ test_that("renv can bind to virtualenvs in WORKON_HOME", {
 
 test_that("installed Python packages are snapshotted / restored [virtualenv]", {
 
+  skip_slow()
   skip_on_os("windows")
-  skip_on_cran()
   skip_if_no_virtualenv(python)
   renv_test_scope_python()
 

--- a/tests/testthat/test-remotes.R
+++ b/tests/testthat/test-remotes.R
@@ -202,7 +202,7 @@ test_that("packages can be installed from GitLab groups", {
   expect_equal(remote, expected)
 
   # test installation
-  skip_sometimes()
+  skip_slow()
   renv_tests_scope()
   renv::install(spec)
   expect_true(renv_package_installed("subpackage"))

--- a/tests/testthat/test-retrieve.R
+++ b/tests/testthat/test-retrieve.R
@@ -1,8 +1,7 @@
 
 test_that("we can retrieve packages from CRAN", {
 
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
 
   renv_tests_scope()
 
@@ -18,8 +17,7 @@ test_that("we can retrieve packages from CRAN", {
 
 test_that("we can retrieve packages from the CRAN archive", {
 
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
 
   renv_tests_scope()
 
@@ -35,8 +33,7 @@ test_that("we can retrieve packages from the CRAN archive", {
 
 test_that("packages with an unknown source are retrieved from CRAN", {
 
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
 
   renv_tests_scope()
 
@@ -86,7 +83,7 @@ test_that("we can retrieve packages from git", {
 
 test_that("we can retrieve packages with git dependencies", {
   skip_on_cran()
-  skip_sometimes()
+  skip_slow()
 
   # GitHub doesn't like ssh (used as remote field in renv.git1)
   skip_on_ci()
@@ -104,8 +101,7 @@ test_that("we can retrieve packages with git dependencies", {
 
 test_that("we can retrieve packages from GitHub", {
 
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
 
   record <- list(
     Package        = "skeleton",
@@ -121,8 +117,7 @@ test_that("we can retrieve packages from GitHub", {
 
 test_that("we can retrieve packages from GitHub (in a sub-directory)", {
 
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
 
   record <- list(
     Package        = "subdir",
@@ -140,8 +135,7 @@ test_that("we can retrieve packages from GitHub (in a sub-directory)", {
 
 test_that("we can retrieve packages from GitLab", {
 
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
 
   record <- list(
     Package        = "skeleton",
@@ -156,8 +150,7 @@ test_that("we can retrieve packages from GitLab", {
 })
 
 test_that("we can retrieve packages with URLs", {
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
   url <- "https://api.github.com/repos/kevinushey/skeleton/tarball"
   record <- renv_remotes_resolve(url)
   renv_test_retrieve(record)
@@ -165,8 +158,7 @@ test_that("we can retrieve packages with URLs", {
 
 test_that("we can retrieve packages from URL sources", {
 
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
 
   renv_tests_scope()
   renv_scope_envvars(RENV_PATHS_LOCAL = file.path(getwd(), "local"))
@@ -269,8 +261,7 @@ test_that("remotes::install_local() records are handled", {
 
 test_that("we can retrieve packages from GitHub", {
 
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
 
   record <- list(
     Package        = "skeleton",

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -20,10 +20,9 @@ test_that("update() finds packages requiring updates from CRAN", {
 
 test_that("update() can upgrade GitHub packages", {
 
-  skip_on_cran()
   skip_if(getRversion() < "3.5.3")
   skip_if(is.na(Sys.getenv("GITHUB_PAT", unset = NA)))
-  skip_sometimes()
+  skip_slow()
 
   renv_tests_scope()
   renv::init()
@@ -52,10 +51,9 @@ test_that("update() can upgrade GitHub packages", {
 
 test_that("update() can upgrade Git packages", {
 
-  skip_on_cran()
   skip_if(getRversion() < "3.5.3")
   skip_if(is.na(Sys.getenv("GITHUB_PAT", unset = NA)))
-  skip_sometimes()
+  skip_slow()
 
   # this test appears to fail on CI (ssh clone from GitHub disallowed?)
   testthat::skip_on_ci()

--- a/tests/testthat/test-upgrade.R
+++ b/tests/testthat/test-upgrade.R
@@ -1,8 +1,7 @@
 
 test_that("the version of renv in a project can be changed (upgraded)", {
 
-  skip_on_cran()
-  skip_sometimes()
+  skip_slow()
 
   renv_tests_scope()
 


### PR DESCRIPTION
Mostly converted from `skip_sometimes()` with a few additional new tests to make `test-bioconductor.R` and `test-python.R` run a bit faster.