### PR TITLE
Tweak handling of GitHub auth

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ License: MIT + file LICENSE
 URL: https://rstudio.github.io/renv/
 BugReports: https://github.com/rstudio/renv/issues
 Imports: utils
-Suggests: BiocManager, cli, covr, cpp11, devtools, jsonlite, knitr, miniUI,
+Suggests: BiocManager, cli, covr, cpp11, devtools, gitcreds, jsonlite, knitr, miniUI,
     packrat, pak, R6, remotes, reticulate, rmarkdown, rstudioapi, shiny, testthat,
     uuid, waldo, yaml
 Remotes: r-lib/pkgload#241

--- a/R/remotes.R
+++ b/R/remotes.R
@@ -53,14 +53,6 @@ renv_remotes_resolve <- function(spec, latest = FALSE) {
     prefix <- sprintf(fmt, spec)
     message <- paste(prefix, e$message, sep = " -- ")
 
-    # if the error occurred while running tests, and the error appears
-    # to be due to an HTTP error (unauthorized), then just skip instead
-    if (renv_tests_running()) {
-      unauth <- any(grepl("403", e$message %||% ""))
-      if (unauth)
-        testthat::skip("Ignoring transient 403 error")
-    }
-
     # otherwise, propagate the error
     stop(simpleError(message = message, call = e$call))
 

--- a/tests/testthat/helper-scope.R
+++ b/tests/testthat/helper-scope.R
@@ -165,6 +165,13 @@ renv_tests_scope_envvars <- function(envir = parent.frame()) {
     envir = envir
   )
 
+  if (is.na(Sys.getenv("GITHUB_PATH", unset = NA))) {
+    token <- tryCatch(gitcreds::gitcreds_get(), error = function(e) NULL)
+    if (!is.null(token)) {
+      renv_scope_envvars(GITHUB_PAT = token$password, envir = envir)
+    }
+  }
+
   needs_tz <- renv_platform_macos() && !nzchar(Sys.getenv("TZ"))
   if (needs_tz) {
     renv_scope_envvars(

--- a/tests/testthat/helpers-skip.R
+++ b/tests/testthat/helpers-skip.R
@@ -1,0 +1,3 @@
+skip_if_no_GitHub_auth <- function() {
+  skip_if(is.na(Sys.getenv("GITHUB_PAT", unset = NA)), "GITHUB_PAT not set")
+}

--- a/tests/testthat/helpers-skip.R
+++ b/tests/testthat/helpers-skip.R
@@ -1,3 +1,3 @@
-skip_if_no_GitHub_auth <- function() {
+skip_if_no_github_auth <- function() {
   skip_if(is.na(Sys.getenv("GITHUB_PAT", unset = NA)), "GITHUB_PAT not set")
 }

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -109,7 +109,7 @@ test_that("packages can be installed from sources", {
 })
 
 test_that("various remote styles can be used during install", {
-  skip_on_cran()
+  skip_if_no_GitHub_auth()
 
   renv_tests_scope()
   renv::init()
@@ -152,7 +152,7 @@ test_that("various remote styles can be used during install", {
 })
 
 test_that("Remotes fields in a project DESCRIPTION are respected", {
-  skip_on_cran()
+  skip_if_no_GitHub_auth()
 
   renv_tests_scope()
   renv_scope_options(repos = character())
@@ -211,7 +211,7 @@ test_that("renv warns when installing an already-loaded package", {
 })
 
 test_that("renv::install() writes out Github fields for backwards compatibility", {
-  skip_on_cran()
+  skip_if_no_GitHub_auth()
   renv_tests_scope()
 
   install("rstudio/packrat")
@@ -265,9 +265,10 @@ test_that("renv can install packages from Bitbucket", {
 })
 
 test_that("renv can install packages from GitHub using remotes subdir syntax", {
-  skip_on_cran()
   skip_sometimes()
+  skip_if_no_GitHub_auth()
   renv_tests_scope()
+
   install("kevinushey/skeleton/subdir")
   expect_true(renv_package_installed("skeleton"))
   expect_true(renv_package_version("skeleton") == "1.1.0")

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -109,7 +109,7 @@ test_that("packages can be installed from sources", {
 })
 
 test_that("various remote styles can be used during install", {
-  skip_if_no_GitHub_auth()
+  skip_if_no_github_auth()
 
   renv_tests_scope()
   renv::init()
@@ -152,7 +152,7 @@ test_that("various remote styles can be used during install", {
 })
 
 test_that("Remotes fields in a project DESCRIPTION are respected", {
-  skip_if_no_GitHub_auth()
+  skip_if_no_github_auth()
 
   renv_tests_scope()
   renv_scope_options(repos = character())
@@ -211,7 +211,7 @@ test_that("renv warns when installing an already-loaded package", {
 })
 
 test_that("renv::install() writes out Github fields for backwards compatibility", {
-  skip_if_no_GitHub_auth()
+  skip_if_no_github_auth()
   renv_tests_scope()
 
   install("rstudio/packrat")
@@ -266,7 +266,7 @@ test_that("renv can install packages from Bitbucket", {
 
 test_that("renv can install packages from GitHub using remotes subdir syntax", {
   skip_sometimes()
-  skip_if_no_GitHub_auth()
+  skip_if_no_github_auth()
   renv_tests_scope()
 
   install("kevinushey/skeleton/subdir")

--- a/tests/testthat/test-retrieve.R
+++ b/tests/testthat/test-retrieve.R
@@ -348,7 +348,7 @@ test_that("we respect the default branch for gitlab repositories", {
 })
 
 test_that("renv can retrieve the latest release associated with a project", {
-  skip_if_no_GitHub_auth()
+  skip_if_no_github_auth()
 
   remote <- renv_remotes_resolve("rstudio/keras@*release")
   expect_true(is.list(remote))

--- a/tests/testthat/test-retrieve.R
+++ b/tests/testthat/test-retrieve.R
@@ -348,8 +348,8 @@ test_that("we respect the default branch for gitlab repositories", {
 })
 
 test_that("renv can retrieve the latest release associated with a project", {
-  skip_on_cran()
-  skip_on_ci()
+  skip_if_no_GitHub_auth()
+
   remote <- renv_remotes_resolve("rstudio/keras@*release")
   expect_true(is.list(remote))
 })

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -20,9 +20,8 @@ test_that("update() finds packages requiring updates from CRAN", {
 
 test_that("update() can upgrade GitHub packages", {
 
-  skip_on_cran()
   skip_if(getRversion() < "3.5.3")
-  skip_if(is.na(Sys.getenv("GITHUB_PAT", unset = NA)))
+  skip_if_no_GitHub_auth()
   skip_sometimes()
 
   renv_tests_scope()
@@ -52,9 +51,8 @@ test_that("update() can upgrade GitHub packages", {
 
 test_that("update() can upgrade Git packages", {
 
-  skip_on_cran()
   skip_if(getRversion() < "3.5.3")
-  skip_if(is.na(Sys.getenv("GITHUB_PAT", unset = NA)))
+  skip_if_no_GitHub_auth()
   skip_sometimes()
 
   # this test appears to fail on CI (ssh clone from GitHub disallowed?)

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -21,7 +21,7 @@ test_that("update() finds packages requiring updates from CRAN", {
 test_that("update() can upgrade GitHub packages", {
 
   skip_if(getRversion() < "3.5.3")
-  skip_if_no_GitHub_auth()
+  skip_if_no_github_auth()
   skip_sometimes()
 
   renv_tests_scope()
@@ -52,7 +52,7 @@ test_that("update() can upgrade GitHub packages", {
 test_that("update() can upgrade Git packages", {
 
   skip_if(getRversion() < "3.5.3")
-  skip_if_no_GitHub_auth()
+  skip_if_no_github_auth()
   skip_sometimes()
 
   # this test appears to fail on CI (ssh clone from GitHub disallowed?)


### PR DESCRIPTION
* Provide standardised helper
* No generic skip on 403 to force confrontation of problems
* Use gitcreds