### PR TITLE
Replace renv_scope_var() with renv_scope_binding()

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -983,7 +983,7 @@ renv_dependencies_discover_r <- function(path = NULL,
   # update current path
   state <- renv_dependencies_state()
   if (!is.null(state))
-    renv_scope_var("path", path, frame = state)
+    renv_scope_binding(state, "path", path)
 
   methods <- c(
     renv_dependencies_discover_r_methods,

--- a/R/download.R
+++ b/R/download.R
@@ -221,7 +221,6 @@ renv_download_default_agent_scope_impl <- function(headers, envir = parent.frame
 
   utils <- asNamespace("utils")
   makeUserAgent <- utils$makeUserAgent
-
   ok <-
     is.function(makeUserAgent) &&
     identical(formals(makeUserAgent), pairlist(format = TRUE))
@@ -233,11 +232,9 @@ renv_download_default_agent_scope_impl <- function(headers, envir = parent.frame
   all <- c("User-Agent" = agent, headers)
   headertext <- paste0(names(all), ": ", all, "\r\n", collapse = "")
 
-  renv_binding_replace("makeUserAgent", envir = utils, function(format = TRUE) {
+  renv_scope_binding(utils, "makeUserAgent", function(format = TRUE) {
     if (format) headertext else agent
-  })
-
-  defer(renv_binding_replace("makeUserAgent", makeUserAgent, envir = utils), envir = envir)
+  }, frame = envir)
 
   return(TRUE)
 

--- a/R/scope.R
+++ b/R/scope.R
@@ -347,17 +347,15 @@ renv_scope_trace <- function(what, tracer, envir = parent.frame()) {
 
 }
 
-renv_scope_var <- function(key, value, frame, envir = parent.frame()) {
 
-  if (exists(key, envir = frame, inherits = FALSE)) {
-    saved <- get(key, envir = frame, inherits = FALSE)
-    assign(key, value, envir = frame, inherits = FALSE)
-    defer(assign(key, saved, envir = frame, inherits = FALSE), envir = envir)
+renv_scope_binding <- function(envir, symbol, replacement, frame = parent.frame()) {
+  if (exists(symbol, envir, inherits = FALSE)) {
+    old <- renv_binding_replace(symbol, replacement, envir)
+    defer(renv_binding_replace(symbol, old, envir), envir = frame)
   } else {
-    assign(key, value, envir = frame, inherits = FALSE)
-    defer(rm(list = key, envir = frame, inherits = FALSE), envir = envir)
+    assign(symbol, replacement, envir = envir)
+    defer(rm(list = symbol, envir = envir, inherits = FALSE), envir = frame)
   }
-
 }
 
 renv_scope_tempfile <- function(pattern = "renv-tempfile-",

--- a/R/update.R
+++ b/R/update.R
@@ -236,7 +236,7 @@ update <- function(packages = NULL,
   }
 
   # get package records
-  renv_scope_var("_renv_snapshot_hash", FALSE, frame = renv_envir_self())
+  renv_scope_binding(renv_envir_self(), "_renv_snapshot_hash", FALSE)
   records <- renv_snapshot_libpaths(libpaths = libpaths, project = project)
   packages <- packages %||% names(records)
 

--- a/tests/testthat/test-sandbox.R
+++ b/tests/testthat/test-sandbox.R
@@ -4,8 +4,8 @@ renv_scoped_sandbox <- function(envir = parent.frame()) {
 
   old <- list(.Library.site, .Library, .libPaths())
   defer(envir = envir, {
-    renv_binding_replace(".Library.site", old[[1]], envir = base)
-    renv_binding_replace(".Library", old[[2]], envir = base)
+    renv_binding_replace(".Library.site", old[[1]], envir = baseenv())
+    renv_binding_replace(".Library", old[[2]], envir = baseenv())
     .libPaths(old[[3]])
   })
 }

--- a/tests/testthat/test-scope.R
+++ b/tests/testthat/test-scope.R
@@ -86,3 +86,37 @@ test_that("renv_scope_trace works", {
   expect_equal(count, 1L)
 
 })
+
+test_that("can temporarily replace binding", {
+  env <- environment()
+  x <- 10
+
+  local({
+    renv_scope_binding(env, "x", 20)
+    expect_equal(x, 20)
+  })
+
+  expect_equal(x, 10)
+})
+
+test_that("can temporarily create binding", {
+  env <- environment()
+
+  local({
+    renv_scope_binding(env, "x", 20)
+    expect_equal(x, 20)
+  })
+
+  expect_false(exists("x", inherits = FALSE))
+})
+
+test_that("can temporarily replace locked binding", {
+  original <- utils::adist
+
+  local({
+    renv_scope_binding(asNamespace("utils"), "adist", 20)
+    expect_equal(utils::adist, 20)
+  })
+
+  expect_equal(utils::adist, original)
+})


### PR DESCRIPTION
* Makes environment to be modified the first argument
* Calls the environment that defined the scope the `frame` (since technically it must be an environment that corresponds to a call frame)
* Add some tests
* Use in `renv_download_default_agent_scope_impl()`