### PR TITLE
Always show R version changes in snapshot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # renv 0.18.0  (UNRELEASED)
 
+* `renv::snapshot()` now shows if the R version changes, even if no packages
+  change (#962).
+  
 * Development versions of renv are now tracked using the Git SHA of the 
   current commit, rather than a version number that's incremented on every
   change (#1327). This shouldn't have any user facing impact, but makes

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -823,23 +823,25 @@ renv_snapshot_description_source_hack <- function(package) {
 # nocov start
 renv_snapshot_report_actions <- function(actions, old, new) {
 
-  if (!renv_verbose() || empty(actions))
+  if (!renv_verbose())
     return(invisible())
 
-  lhs <- renv_lockfile_records(old)
-  rhs <- renv_lockfile_records(new)
-  renv_pretty_print_records_pair(
-    lhs[names(lhs) %in% names(actions)],
-    rhs[names(rhs) %in% names(actions)],
-    "The following package(s) will be updated in the lockfile:"
-  )
+  if (length(actions)) {
+    lhs <- renv_lockfile_records(old)
+    rhs <- renv_lockfile_records(new)
+    renv_pretty_print_records_pair(
+      lhs[names(lhs) %in% names(actions)],
+      rhs[names(rhs) %in% names(actions)],
+      "The following package(s) will be updated in the lockfile:"
+    )
+  }
 
   oldr <- old$R$Version
   newr <- new$R$Version
   rdiff <- renv_version_compare(oldr %||% "0", newr %||% "0")
 
   if (rdiff != 0L) {
-    n <- max(nchar(names(actions)))
+    n <- max(nchar(names(actions)), 0)
     fmt <- paste("-", format("R", width = n), " ", "[%s -> %s]")
     msg <- sprintf(fmt, oldr %||% "*", newr %||% "*")
     writeLines(c("The version of R recorded in the lockfile will be updated:", msg, ""))

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -1,0 +1,9 @@
+# snapshot always reports on R version changes
+
+    Code
+      renv_snapshot_report_actions(list(), R4.1, R4.2)
+    Output
+      The version of R recorded in the lockfile will be updated:
+      - R   [4.1 -> 4.2]
+      
+

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -461,3 +461,13 @@ test_that("packages installed from Bioconductor using pak are handled", {
   record <- renv_snapshot_description(package = "Biobase")
   expect_identical(record$Source, "Bioconductor")
 })
+
+test_that("snapshot always reports on R version changes", {
+  renv_scope_options(renv.verbose = TRUE)
+
+  R4.1 <- list(R = list(Version = 4.1))
+  R4.2 <- list(R = list(Version = 4.2))
+  expect_snapshot({
+    renv_snapshot_report_actions(list(), R4.1, R4.2)
+  })
+})


### PR DESCRIPTION
Even if there are no changes to packages. Fixes #962