### PR TITLE
Standardize output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.17.3-67
+Version: 0.17.3-68
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.17.3-69
+Version: 0.17.3-70
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.17.3-63
+Version: 0.17.3-64
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.17.3-71
+Version: 0.17.3-72
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.17.3-66
+Version: 0.17.3-67
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.17.3-70
+Version: 0.17.3-71
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.17.3-62
+Version: 0.17.3-63
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.17.3-64
+Version: 0.17.3-65
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.17.3-68
+Version: 0.17.3-69
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 0.17.3-65
+Version: 0.17.3-66
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/R/activate.R
+++ b/R/activate.R
@@ -162,9 +162,7 @@ renv_activate_prompt <- function(action, library, prompt, project) {
     "Please see `?renv::activate` for more details.",
     ""
   )
-
-  notice <- sprintf(fmt, action)
-  writef(notice)
+  writef(fmt, action)
 
   fmt <- "Would you like to activate this project before %s() is called?"
   question <- sprintf(fmt, action)

--- a/R/activate.R
+++ b/R/activate.R
@@ -164,7 +164,7 @@ renv_activate_prompt <- function(action, library, prompt, project) {
   )
 
   notice <- sprintf(fmt, action)
-  vwritef(notice)
+  writef(notice)
 
   fmt <- "Would you like to activate this project before %s() is called?"
   question <- sprintf(fmt, action)

--- a/R/archive.R
+++ b/R/archive.R
@@ -63,8 +63,7 @@ renv_archive_decompress_zip <- function(archive, files = NULL, exdir = ".", ...)
 
   if (inherits(status, "condition")) {
     fmt <- "failed to decompress '%s' [%s]"
-    message <- sprintf(fmt, basename(archive), conditionMessage(status))
-    stop(simpleError(message))
+    stopf(fmt, basename(archive), conditionMessage(status))
   }
 
   TRUE

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -67,7 +67,7 @@ renv_available_packages_query <- function(type, repos, quiet = FALSE) {
     renv_scope_options(renv.verbose = FALSE)
 
   fmt <- "* Querying repositories for available %s packages ... "
-  vprintf(fmt, type)
+  printf(fmt, type)
 
   # exclude repositories which are known to not have packages available
   if (type == "binary") {

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -82,7 +82,7 @@ renv_available_packages_query <- function(type, repos, quiet = FALSE) {
   names(dbs) <- names(repos)
 
   # notify finished
-  vwritef("Done!")
+  writef("Done!")
 
   # propagate errors
   errors <- as.list(errors)

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -405,7 +405,7 @@ renv_bootstrap_download_augment <- function(destfile) {
     paste("RemoteRef: ", sha),
     paste("RemoteSha: ", sha)
   )
-  writeLines(c(desc_lines[desc_lines != ""], remotes_fields), desc_path)
+  writeLines(c(desc_lines[desc_lines != ""], remotes_fields), con = desc_path)
 
   # Re-tar
   local({

--- a/R/cache.R
+++ b/R/cache.R
@@ -176,7 +176,7 @@ renv_cache_synchronize_impl <- function(cache, record, linkable, path) {
 
   # get ready to copy / move into cache
   fmt <- "%s %s [%s] into the cache ..."
-  vwritef(fmt, if (linkable) "Moving" else "Copying", record$Package, record$Version)
+  writef(fmt, if (linkable) "Moving" else "Copying", record$Package, record$Version)
 
   before <- Sys.time()
 
@@ -229,7 +229,7 @@ renv_cache_synchronize_impl <- function(cache, record, linkable, path) {
 
   # report status to user
   fmt <- "\tOK [%s to cache in %s]"
-  vwritef(fmt, if (linkable) "moved" else "copied", renv_difftime_format(time))
+  writef(fmt, if (linkable) "moved" else "copied", renv_difftime_format(time))
 
   TRUE
 

--- a/R/checkout.R
+++ b/R/checkout.R
@@ -200,7 +200,7 @@ renv_checkout_repos <- function(date) {
     url <- file.path(root, candidate)
     if (renv_download_available(file.path(url, "src/contrib/PACKAGES"))) {
       fmt <- "* Snapshot date '%s' not available; using '%s' instead"
-      messagef(fmt, date, candidate)
+      printf(fmt, date, candidate)
       return(url)
     }
   }

--- a/R/ci.R
+++ b/R/ci.R
@@ -61,7 +61,7 @@ renv_ci_repair <- function() {
   # check which failed to load
   broken <- packages[!ok]
   if (empty(broken)) {
-    vwritef("* All installed packages can be successfully loaded.")
+    writef("* All installed packages can be successfully loaded.")
     return(broken)
   }
 

--- a/R/cite.R
+++ b/R/cite.R
@@ -24,7 +24,7 @@ cite <- function(type = c("plain", "bibtex"),
 
   packages <- sort(.packages(all.available = TRUE))
   names(packages) <- packages
-  vprintf("Generating citations ... ")
+  printf("Generating citations ... ")
   citations <- lapply(packages, function(package) {
     catchall(citation(package))
   })

--- a/R/cite.R
+++ b/R/cite.R
@@ -28,7 +28,7 @@ cite <- function(type = c("plain", "bibtex"),
   citations <- lapply(packages, function(package) {
     catchall(citation(package))
   })
-  vwritef("Done!")
+  writef("Done!")
 
   erridx <- map_lgl(citations, inherits, what = "condition")
   errs <- citations[erridx]

--- a/R/clean.R
+++ b/R/clean.R
@@ -95,7 +95,7 @@ clean <- function(project = NULL,
   for (method in methods)
     tryCatch(method(project, prompt), error = warning)
 
-  vwritef("* The project has been cleaned.")
+  writef("* The project has been cleaned.")
   invisible(project)
 }
 
@@ -118,7 +118,7 @@ renv_clean_actions <- function(prompt) {
 renv_clean_library_tempdirs <- function(project, prompt) {
 
   ntd <- function() {
-    vwritef("* No temporary directories were found in the project library.")
+    writef("* No temporary directories were found in the project library.")
     FALSE
   }
 
@@ -154,7 +154,7 @@ renv_clean_library_tempdirs <- function(project, prompt) {
 renv_clean_system_library <- function(project, prompt) {
 
   ntd <- function() {
-    vwritef("* No non-system packages were discovered in the system library.")
+    writef("* No non-system packages were discovered in the system library.")
     FALSE
   }
 
@@ -206,7 +206,7 @@ renv_clean_system_library <- function(project, prompt) {
 renv_clean_unused_packages <- function(project, prompt) {
 
   ntd <- function() {
-    vwritef("* No unused packages were found in the project library.")
+    writef("* No unused packages were found in the project library.")
     FALSE
   }
 
@@ -252,7 +252,7 @@ renv_clean_unused_packages <- function(project, prompt) {
 renv_clean_package_locks <- function(project, prompt) {
 
   ntd <- function() {
-    vwritef("* No stale package locks were found.")
+    writef("* No stale package locks were found.")
     FALSE
   }
 
@@ -295,7 +295,7 @@ renv_clean_package_locks <- function(project, prompt) {
 renv_clean_cache <- function(project, prompt) {
 
   ntd <- function() {
-    vwritef("* No unused packages were found in the renv cache.")
+    writef("* No unused packages were found in the renv cache.")
     FALSE
   }
 
@@ -361,7 +361,7 @@ renv_clean_cache <- function(project, prompt) {
   # remove the directories
   unlink(diff, recursive = TRUE)
   renv_cache_clean_empty()
-  vwritef("* %i package(s) have been removed.", length(diff))
+  writef("* %i package(s) have been removed.", length(diff))
   TRUE
 
 }

--- a/R/clean.R
+++ b/R/clean.R
@@ -319,7 +319,7 @@ renv_clean_cache <- function(project, prompt) {
     if (prompt && !proceed())
       return(FALSE)
 
-    writeLines(projlist[!missing], projects, useBytes = TRUE)
+    writeLines(projlist[!missing], con = projects, useBytes = TRUE)
 
   }
 

--- a/R/cli.R
+++ b/R/cli.R
@@ -138,7 +138,7 @@ renv_cli_unknown <- function(method, exports) {
 
   candidates <- names(distance)[distance == n]
   fmt <- "did you mean %s?"
-  vwritef(fmt, paste(shQuote(candidates), collapse = " or "))
+  writef(fmt, paste(shQuote(candidates), collapse = " or "))
   return(1L)
 
 }

--- a/R/consent.R
+++ b/R/consent.R
@@ -46,7 +46,7 @@ consent <- function(provided = FALSE) {
   contents <- readLines(template)
   replacements <- list(RENV_PATHS_ROOT = renv_path_pretty(root))
   welcome <- renv_template_replace(contents, replacements)
-  writeLines(welcome)
+  writef(welcome)
 
   # ask user if they want to proceed
   response <- catchall(proceed(default = provided))

--- a/R/consent.R
+++ b/R/consent.R
@@ -37,7 +37,7 @@ consent <- function(provided = FALSE) {
   # compute path to root directory
   root <- renv_paths_root()
   if (renv_file_type(root) == "directory") {
-    vwritef("* Consent to use renv has already been provided -- nothing to do.")
+    writef("* Consent to use renv has already been provided -- nothing to do.")
     return(invisible(TRUE))
   }
 
@@ -58,7 +58,7 @@ consent <- function(provided = FALSE) {
   # cache the user response
   options(renv.consent = TRUE)
   ensure_directory(root)
-  vwritef("* %s has been created.", renv_path_pretty(root))
+  writef("* %s has been created.", renv_path_pretty(root))
 
   invisible(TRUE)
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -453,7 +453,7 @@ renv_dependencies_discover <- function(paths, progress, errors) {
   printf("Finding R package dependencies ... ")
   callback <- renv_progress_callback(renv_dependencies_discover_impl, length(paths))
   deps <- lapply(paths, callback)
-  vwritef("Done!")
+  writef("Done!")
 
   bind(deps)
   # nocov end
@@ -494,7 +494,7 @@ renv_dependencies_discover_preflight <- function(paths, errors) {
     "Set `options(renv.config.dependencies.limit = Inf)` to disable this warning.",
     ""
   )
-  vwritef(lines, length(paths))
+  writef(lines, length(paths))
 
   if (identical(errors, "reported"))
     return(TRUE)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -450,7 +450,7 @@ renv_dependencies_discover <- function(paths, progress, errors) {
   # otherwise, run with progress reporting
 
   # nocov start
-  vprintf("Finding R package dependencies ... ")
+  printf("Finding R package dependencies ... ")
   callback <- renv_progress_callback(renv_dependencies_discover_impl, length(paths))
   deps <- lapply(paths, callback)
   vwritef("Done!")

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1598,8 +1598,7 @@ renv_dependencies_require <- function(package, type = NULL) {
     )
 
     within <- if (is.null(type)) "this project" else paste(type, "files")
-    msg <- sprintf(fmt, package, within)
-    warning(msg, call. = FALSE)
+    warningf(fmt, package, within)
 
   }
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1655,7 +1655,7 @@ renv_dependencies_report <- function(errors) {
   if (empty(problems))
     return(TRUE)
 
-  ewritef("WARNING: One or more problems were discovered while enumerating dependencies.\n")
+  writef("WARNING: One or more problems were discovered while enumerating dependencies.\n")
 
   # bind into list
   bound <- bapply(problems, function(problem) {
@@ -1674,10 +1674,10 @@ renv_dependencies_report <- function(errors) {
     prefix <- format(paste("ERROR", seq_along(problem$message)))
     messages <- paste(prefix, problem$message, sep = ": ", collapse = "\n\n")
     text <- c(file, lines, "", messages, "")
-    ewritef(text)
+    writef(text)
   })
 
-  ewritef("Please see `?renv::dependencies` for more information.")
+  writef("Please see `?renv::dependencies` for more information.")
 
   if (identical(errors, "fatal")) {
     fmt <- "one or more errors occurred while enumerating dependencies"

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -40,34 +40,34 @@ diagnostics <- function(project = NULL) {
   fmt <- "Diagnostics Report [renv %s]"
   title <- sprintf(fmt, renv_metadata_version())
   lines <- paste(rep.int("=", nchar(title)), collapse = "")
-  vwritef(c(title, lines, ""))
+  writef(c(title, lines, ""))
 
   for (reporter in reporters) {
     tryCatch(reporter(project), error = renv_error_handler)
-    vwritef()
+    writef()
   }
 
 }
 
 renv_diagnostics_session <- function(project) {
-  vwritef(header("Session Info"))
+  writef(header("Session Info"))
   renv_scope_options(width = 80)
   print(sessionInfo())
 }
 
 renv_diagnostics_project <- function(project) {
-  vwritef(header("Project"))
-  vwritef("Project path: %s", renv_path_pretty(project))
+  writef(header("Project"))
+  writef("Project path: %s", renv_path_pretty(project))
 }
 
 renv_diagnostics_status <- function(project) {
-  vwritef(header("Status"))
+  writef(header("Status"))
   status(project = project)
 }
 
 renv_diagnostics_packages <- function(project) {
 
-  vwritef(header("Packages"))
+  writef(header("Packages"))
 
   # collect state of lockfile, library, dependencies
   lockfile <- renv_diagnostics_packages_lockfile(project)
@@ -126,8 +126,8 @@ renv_diagnostics_packages <- function(project) {
 
   # print library codes
   fmt <- "[%s]: %s"
-  vwritef()
-  vwritef(fmt, format(seq_along(levels(flibpaths))), format(levels(flibpaths)))
+  writef()
+  writef(fmt, format(seq_along(levels(flibpaths))), format(levels(flibpaths)))
 
 }
 
@@ -161,7 +161,7 @@ renv_diagnostics_packages_lockfile <- function(project) {
 
   lockpath <- renv_lockfile_path(project = project)
   if (!file.exists(lockpath)) {
-    vwritef("This project has not yet been snapshotted: 'renv.lock' does not exist.")
+    writef("This project has not yet been snapshotted: 'renv.lock' does not exist.")
     return(list())
   }
 
@@ -174,7 +174,7 @@ renv_diagnostics_packages_library <- function(project) {
   library <- renv_paths_library(project = project)
   if (!file.exists(library)) {
     fmt <- "The project library %s does not exist."
-    vwritef(fmt, renv_path_pretty(library))
+    writef(fmt, renv_path_pretty(library))
   }
 
   snapshot(project = project, lockfile = NULL, type = "all")
@@ -192,11 +192,11 @@ renv_diagnostics_packages_dependencies <- function(project) {
 
 renv_diagnostics_abi <- function(project) {
 
-  vwritef(header("ABI"))
+  writef(header("ABI"))
   tryCatch(
     renv_abi_check(),
     error = function(e) {
-      vwritef(conditionMessage(e))
+      writef(conditionMessage(e))
     }
   )
 
@@ -204,11 +204,11 @@ renv_diagnostics_abi <- function(project) {
 
 renv_diagnostics_profile <- function(project) {
 
-  vwritef(header("User Profile"))
+  writef(header("User Profile"))
 
   userprofile <- "~/.Rprofile"
   if (!file.exists(userprofile))
-    return(vwritef("[no user profile detected]"))
+    return(writef("[no user profile detected]"))
 
   deps <- dependencies(userprofile,
                        progress = FALSE,
@@ -216,7 +216,7 @@ renv_diagnostics_profile <- function(project) {
                        dev = TRUE)
 
   if (empty(deps))
-    return(vwritef("[no R packages referenced in user profile"))
+    return(writef("[no R packages referenced in user profile"))
 
   renv_scope_options(width = 200)
   print(deps)
@@ -224,13 +224,13 @@ renv_diagnostics_profile <- function(project) {
 }
 
 renv_diagnostics_settings <- function(project) {
-  vwritef(header("Settings"))
+  writef(header("Settings"))
   str(renv_settings_get(project))
 }
 
 renv_diagnostics_options <- function(project) {
 
-  vwritef(header("Options"))
+  writef(header("Options"))
 
   keys <- c(
     "defaultPackages",
@@ -251,7 +251,7 @@ renv_diagnostics_options <- function(project) {
 
 renv_diagnostics_envvars <- function(project) {
 
-  vwritef(header("Environment Variables"))
+  writef(header("Environment Variables"))
 
   envvars <- convert(as.list(Sys.getenv()), "character")
 
@@ -263,7 +263,7 @@ renv_diagnostics_envvars <- function(project) {
 
   matches <- envvars[useful]
   if (empty(matches))
-    return(vwritef("[no renv environment variables available]"))
+    return(writef("[no renv environment variables available]"))
 
   names(matches) <- useful
   matches[is.na(matches)] <- "<NA>"
@@ -272,23 +272,23 @@ renv_diagnostics_envvars <- function(project) {
   keys <- names(matches)
   vals <- matches
   formatted <- paste(format(keys), vals, sep = " = ")
-  vwritef(formatted)
+  writef(formatted)
 
 }
 
 renv_diagnostics_path <- function(project) {
-  vwritef(header("PATH"))
+  writef(header("PATH"))
   path <- strsplit(Sys.getenv("PATH"), .Platform$path.sep, fixed = TRUE)[[1]]
-  vwritef(paste("-", path))
+  writef(paste("-", path))
 }
 
 renv_diagnostics_cache <- function(project) {
 
-  vwritef(header("Cache"))
+  writef(header("Cache"))
 
   fmt <- "There are a total of %s installed in the renv cache."
   cachelist <- renv_cache_list()
-  vwritef(fmt, nplural("package", length(cachelist)))
-  vwritef("Cache path: %s", renv_path_pretty(renv_paths_cache()))
+  writef(fmt, nplural("package", length(cachelist)))
+  writef("Cache path: %s", renv_path_pretty(renv_paths_cache()))
 
 }

--- a/R/download.R
+++ b/R/download.R
@@ -867,7 +867,7 @@ renv_download_trace_begin <- function(url, type) {
   msg <- sprintf(fmt, url, type)
 
   title <- header(msg, n = 78L)
-  writeLines(c(title, ""))
+  writef(c(title, ""))
 
 }
 
@@ -877,7 +877,7 @@ renv_download_trace_request <- function(text) {
     return()
 
   title <- header("Request", n = 78L, prefix = "##")
-  writeLines(c(title, text, ""))
+  writef(c(title, text, ""))
 
 }
 
@@ -889,11 +889,11 @@ renv_download_trace_result <- function(output) {
   title <- header("Output", prefix = "##", n = 78L)
   text <- if (empty(output)) "[no output generated]" else output
   all <- c(title, text, "")
-  writeLines(all)
+  writef(all)
 
   status <- attr(output, "status", exact = TRUE) %||% 0L
   title <- header("Status", prefix = "##", n = 78L)
   all <- c(title, status, "")
-  writeLines(all)
+  writef(all)
 
 }

--- a/R/download.R
+++ b/R/download.R
@@ -39,7 +39,7 @@ download <- function(url, destfile, type = NULL, quiet = FALSE, headers = NULL) 
   destfile <- chartr("\\", "/", destfile)
 
   # notify user we're about to try downloading
-  vwritef("Retrieving '%s' ...", url)
+  writef("Retrieving '%s' ...", url)
 
   # add custom headers as appropriate for the URL
   headers <- c(headers, renv_download_custom_headers(url))
@@ -57,7 +57,7 @@ download <- function(url, destfile, type = NULL, quiet = FALSE, headers = NULL) 
   if (identical(info$isdir, FALSE)) {
     size <- renv_download_size(url, type, headers)
     if (info$size == size) {
-      vwritef("\tOK [file is up to date]")
+      writef("\tOK [file is up to date]")
       return(destfile)
     }
   }
@@ -646,7 +646,7 @@ renv_download_report <- function(elapsed, file) {
   size <- structure(info$size, class = "object_size")
 
   fmt <- "\tOK [downloaded %s in %s]"
-  vwritef(fmt, format(size, units = "auto"), renv_difftime_format(elapsed))
+  writef(fmt, format(size, units = "auto"), renv_difftime_format(elapsed))
 
 }
 
@@ -850,7 +850,7 @@ renv_download_available_fallback <- function(url) {
 
 renv_download_error <- function(url, fmt, ...) {
   msg <- sprintf(fmt, ...)
-  vwritef("\tERROR [%s]", msg)
+  writef("\tERROR [%s]", msg)
   stopf("error downloading '%s' [%s]", url, msg, call. = FALSE)
 }
 

--- a/R/equip-macos.R
+++ b/R/equip-macos.R
@@ -71,7 +71,7 @@ renv_equip_macos_toolchain <- function() {
   clang <- file.path(dst, "bin/clang")
   if (file.exists(clang)) {
     fmt <- "* LLVM toolchain for R %s is already installed at %s."
-    vwritef(fmt, getRversion(), shQuote(dst))
+    writef(fmt, getRversion(), shQuote(dst))
     return(TRUE)
   }
 

--- a/R/errors.R
+++ b/R/errors.R
@@ -137,7 +137,7 @@ renv_error_handler <- function(...) {
     return(character())
 
   formatted <- renv_error_format(calls, frames)
-  writeLines(formatted, con = stderr())
+  writef(formatted)
 
   formatted
 

--- a/R/extsoft.R
+++ b/R/extsoft.R
@@ -25,7 +25,7 @@ renv_extsoft_install <- function(quiet = FALSE) {
   # check for missing installs
   files <- Filter(renv_extsoft_install_required, files)
   if (empty(files)) {
-    if (!quiet) vwritef("* External software is up to date.")
+    if (!quiet) writef("* External software is up to date.")
     return(TRUE)
   }
 
@@ -86,7 +86,7 @@ renv_extsoft_install <- function(quiet = FALSE) {
 
   }
 
-  vwritef("* External software successfully updated.")
+  writef("* External software successfully updated.")
   TRUE
 
 }
@@ -147,7 +147,7 @@ renv_extsoft_use <- function(quiet = FALSE) {
 
   }
 
-  if (!quiet) vwritef("* '%s' has been updated.", path)
+  if (!quiet) writef("* '%s' has been updated.", path)
   writeLines(contents, path)
   TRUE
 

--- a/R/extsoft.R
+++ b/R/extsoft.R
@@ -148,7 +148,7 @@ renv_extsoft_use <- function(quiet = FALSE) {
   }
 
   if (!quiet) writef("* '%s' has been updated.", path)
-  writeLines(contents, path)
+  writeLines(contents, con = path)
   TRUE
 
 }

--- a/R/graph.R
+++ b/R/graph.R
@@ -91,7 +91,7 @@ graph <- function(root = NULL,
   remaining <- intersect(root, names(graph)[ok])
   if (empty(remaining)) {
     fmt <- "* Could not find any relationship between the requested packages."
-    vwritef(fmt)
+    writef(fmt)
     return(invisible(NULL))
   }
 

--- a/R/history.R
+++ b/R/history.R
@@ -76,7 +76,7 @@ revert <- function(commit = "HEAD", ..., project = NULL) {
   system2("git", c("reset", "HEAD", renv_shell_path(lockpath)), stdout = FALSE, stderr = FALSE)
   system2("git", c("diff", "--", renv_shell_path(lockpath)))
 
-  vwritef("* renv.lock from commit %s has been checked out.", commit)
+  writef("* renv.lock from commit %s has been checked out.", commit)
   invisible(commit)
 
 }

--- a/R/hydrate.R
+++ b/R/hydrate.R
@@ -231,7 +231,7 @@ renv_hydrate_dependencies <- function(project,
                                       packages = NULL,
                                       libpaths = NULL)
 {
-  vprintf("* Discovering package dependencies ... ")
+  printf("* Discovering package dependencies ... ")
   ignored <- renv_project_ignored_packages(project = project)
   packages <- renv_vector_diff(packages, ignored)
   libpaths <- libpaths %||% renv_hydrate_libpaths()
@@ -297,7 +297,7 @@ renv_hydrate_link_packages <- function(packages, library, project) {
   else
     sprintf("* Linking packages into %s ... ", renv_path_pretty(library))
 
-  vprintf(header)
+  printf(header)
   callback <- renv_progress_callback(renv_hydrate_link_package, length(packages))
   cached <- enumerate(packages, callback, library = library)
   vwritef("Done!")
@@ -319,7 +319,7 @@ renv_hydrate_copy_packages <- function(packages, library, project) {
   else
     sprintf("* Copying packages into %s ... ", renv_path_pretty(library))
 
-  vprintf(header)
+  printf(header)
   callback <- renv_progress_callback(renv_hydrate_copy_package, length(packages))
   copied <- enumerate(packages, callback, library = library)
   vwritef("Done!")

--- a/R/hydrate.R
+++ b/R/hydrate.R
@@ -117,7 +117,7 @@ hydrate <- function(packages = NULL,
   # check for nothing to be done
   if (empty(packages) && empty(na)) {
     if (report)
-      vwritef("* No new packages were discovered in this project; nothing to do.")
+      writef("* No new packages were discovered in this project; nothing to do.")
     return(invisible(list(packages = list(), missing = list())))
   }
 
@@ -134,7 +134,7 @@ hydrate <- function(packages = NULL,
   if (report) {
     time <- difftime(after, before, units = "auto")
     fmt <- "* Hydrated %s packages in %s."
-    vwritef(fmt, length(packages), renv_difftime_format(time))
+    writef(fmt, length(packages), renv_difftime_format(time))
   }
 
   # attempt to install missing packages (if any)
@@ -236,7 +236,7 @@ renv_hydrate_dependencies <- function(project,
   packages <- renv_vector_diff(packages, ignored)
   libpaths <- libpaths %||% renv_hydrate_libpaths()
   all <- renv_package_dependencies(packages, project = project, libpaths = libpaths)
-  vwritef("Done!")
+  writef("Done!")
 
   all
 }
@@ -300,7 +300,7 @@ renv_hydrate_link_packages <- function(packages, library, project) {
   printf(header)
   callback <- renv_progress_callback(renv_hydrate_link_package, length(packages))
   cached <- enumerate(packages, callback, library = library)
-  vwritef("Done!")
+  writef("Done!")
   cached
 
 }
@@ -322,7 +322,7 @@ renv_hydrate_copy_packages <- function(packages, library, project) {
   printf(header)
   callback <- renv_progress_callback(renv_hydrate_copy_package, length(packages))
   copied <- enumerate(packages, callback, library = library)
-  vwritef("Done!")
+  writef("Done!")
   copied
 }
 
@@ -344,7 +344,7 @@ renv_hydrate_resolve_missing <- function(project, library, na) {
   if (all(packages %in% installed$Package))
     return()
 
-  vwritef("* Resolving missing dependencies ... ")
+  writef("* Resolving missing dependencies ... ")
 
   # define a custom error handler for packages which
   # we failed to retrieve

--- a/R/hydrate.R
+++ b/R/hydrate.R
@@ -292,12 +292,11 @@ renv_hydrate_link_package <- function(package, location, library) {
 
 renv_hydrate_link_packages <- function(packages, library, project) {
 
-  header <- if (renv_path_same(library, renv_paths_library(project = project)))
-    "* Linking packages into the project library ... "
+  if (renv_path_same(library, renv_paths_library(project = project)))
+    printf("* Linking packages into the project library ... ")
   else
-    sprintf("* Linking packages into %s ... ", renv_path_pretty(library))
+    printf("* Linking packages into %s ... ", renv_path_pretty(library))
 
-  printf(header)
   callback <- renv_progress_callback(renv_hydrate_link_package, length(packages))
   cached <- enumerate(packages, callback, library = library)
   writef("Done!")
@@ -314,12 +313,11 @@ renv_hydrate_copy_package <- function(package, location, library) {
 
 renv_hydrate_copy_packages <- function(packages, library, project) {
 
-  header <- if (renv_path_same(library, renv_paths_library(project = project)))
-    "* Copying packages into the project library ... "
+  if (renv_path_same(library, renv_paths_library(project = project)))
+    printf("* Copying packages into the project library ... ")
   else
-    sprintf("* Copying packages into %s ... ", renv_path_pretty(library))
+    printf("* Copying packages into %s ... ", renv_path_pretty(library))
 
-  printf(header)
   callback <- renv_progress_callback(renv_hydrate_copy_package, length(packages))
   copied <- enumerate(packages, callback, library = library)
   writef("Done!")

--- a/R/imbue.R
+++ b/R/imbue.R
@@ -26,9 +26,9 @@ imbue <- function(project = NULL,
   renv_scope_options(renv.verbose = !quiet)
 
   vtext <- version %||% renv_metadata_version()
-  vwritef("Installing renv [%s] ...", vtext)
+  writef("Installing renv [%s] ...", vtext)
   status <- renv_imbue_impl(project, version)
-  vwritef("* Done! renv has been successfully installed.")
+  writef("* Done! renv has been successfully installed.")
 
   invisible(status)
 
@@ -67,12 +67,12 @@ renv_imbue_impl <- function(project, version = NULL, force = FALSE) {
   ensure_directory(library)
   renv_scope_libpaths(library)
 
-  vwritef("Installing renv [%s] ...", version)
+  writef("Installing renv [%s] ...", version)
   before <- Sys.time()
   with(record, r_cmd_install(Package, Path, library))
   after <- Sys.time()
   elapsed <- difftime(after, before, units = "auto")
-  vwritef("\tOK [built source in %s]", renv_difftime_format(elapsed))
+  writef("\tOK [built source in %s]", renv_difftime_format(elapsed))
 
   invisible(record)
 

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -132,7 +132,7 @@ renv_infrastructure_write_entry_impl <- function(add, remove, file, create) {
 
     # otherwise, write the file
     ensure_parent_directory(file)
-    writeLines(add, file)
+    writeLines(add, con = file)
     return(TRUE)
 
   }
@@ -168,7 +168,7 @@ renv_infrastructure_write_entry_impl <- function(add, remove, file, create) {
 
   # write to file if we have changes
   if (!identical(before, after))
-    writeLines(after, file)
+    writeLines(after, con = file)
 
   TRUE
 
@@ -232,7 +232,7 @@ renv_infrastructure_remove_entry_impl <- function(line, file, removable) {
   # otherwise, just mutate the file
   replacement <- gsub("^(\\s*)", "\\1# ", contents[matches], perl = TRUE)
   contents[matches] <- replacement
-  writeLines(contents, file)
+  writeLines(contents, con = file)
 
   TRUE
 

--- a/R/init.R
+++ b/R/init.R
@@ -92,7 +92,7 @@ init <- function(project = NULL,
     options(repos = biocrepos)
 
     # notify user
-    vwritef("* Using Bioconductor version '%s'.", biocver)
+    writef("* Using Bioconductor version '%s'.", biocver)
     settings[["bioconductor.version"]] <- biocver
 
   }

--- a/R/install.R
+++ b/R/install.R
@@ -145,7 +145,7 @@ install <- function(packages = NULL,
   # get and resolve the packages / remotes to be installed
   remotes <- packages %||% renv_project_remotes(project, dependencies)
   if (empty(remotes)) {
-    vwritef("* There are no packages to install.")
+    writef("* There are no packages to install.")
     return(invisible(list()))
   }
 
@@ -180,7 +180,7 @@ install <- function(packages = NULL,
   # retrieve packages
   records <- retrieve(names(remotes))
   if (empty(records)) {
-    vwritef("* There are no packages to install.")
+    writef("* There are no packages to install.")
     return(invisible(list()))
   }
 
@@ -191,13 +191,13 @@ install <- function(packages = NULL,
   if (!renv_tests_running()) {
     time <- renv_difftime_format(difftime(after, before))
     n <- length(records)
-    vwritef("* Installed %s in %s.", nplural("package", n), time)
+    writef("* Installed %s in %s.", nplural("package", n), time)
   }
 
   # a bit of extra test reporting
   if (renv_tests_running()) {
     fmt <- "Installed %s into library at path %s."
-    vwritef(
+    writef(
       fmt,
       nplural("package", length(records)),
       renv_path_pretty(renv_libpaths_active())
@@ -372,7 +372,7 @@ renv_install_package <- function(record) {
   withCallingHandlers(
     renv_install_package_impl(record),
     error = function(e) {
-      vwritef("\tFAILED")
+      writef("\tFAILED")
       writef(e$output)
     }
   )
@@ -383,7 +383,7 @@ renv_install_package <- function(record) {
   feedback <- renv_install_package_feedback(path, type)
 
   elapsed <- difftime(after, before, units = "auto")
-  vwritef("\tOK [%s in %s]", feedback, renv_difftime_format(elapsed))
+  writef("\tOK [%s in %s]", feedback, renv_difftime_format(elapsed))
 
   # link into cache
   if (renv_cache_config_enabled(project = project))
@@ -417,7 +417,7 @@ renv_install_package_cache <- function(record, cache, linker) {
 
   # report successful link to user
   fmt <- "Installing %s [%s] ..."
-  with(record, vwritef(fmt, Package, Version))
+  with(record, writef(fmt, Package, Version))
 
   before <- Sys.time()
   linker(cache, target)
@@ -429,7 +429,7 @@ renv_install_package_cache <- function(record, cache, linker) {
   )
 
   elapsed <- difftime(after, before, units = "auto")
-  vwritef("\tOK [%s cache in %s]", type, renv_difftime_format(elapsed))
+  writef("\tOK [%s cache in %s]", type, renv_difftime_format(elapsed))
 
   return(TRUE)
 
@@ -451,7 +451,7 @@ renv_install_package_cache_skip <- function(record, cache) {
 
 renv_install_package_preamble <- function(record) {
   fmt <- "Installing %s [%s] ..."
-  with(record, vwritef(fmt, Package, Version))
+  with(record, writef(fmt, Package, Version))
 }
 
 renv_install_package_impl_prebuild <- function(record, path, quiet) {
@@ -493,12 +493,12 @@ renv_install_package_impl_prebuild <- function(record, path, quiet) {
   builder <- desc[["VignetteBuilder"]]
   if (!is.null(builder) && !renv_package_installed(builder)) {
     fmt <- "Skipping package build: vignette builder '%s' is not installed"
-    vwritef(fmt, builder)
+    writef(fmt, builder)
     return(path)
   }
 
   fmt <- "Building %s [%s] ..."
-  with(record, vwritef(fmt, Package, Version))
+  with(record, writef(fmt, Package, Version))
 
   before <- Sys.time()
   package <- record$Package
@@ -507,7 +507,7 @@ renv_install_package_impl_prebuild <- function(record, path, quiet) {
   elapsed <- difftime(after, before, units = "auto")
 
   fmt <- "\tOK [built package in %s]"
-  vwritef(fmt, renv_difftime_format(elapsed))
+  writef(fmt, renv_difftime_format(elapsed))
 
   newpath
 

--- a/R/isolate.R
+++ b/R/isolate.R
@@ -65,7 +65,7 @@ renv_isolate_unix <- function(project) {
     unlink(targets)
     copy <- renv_progress_callback(renv_file_copy, length(targets))
     enumerate(targets, copy, overwrite = TRUE)
-    vwritef("Done!")
+    writef("Done!")
   }
 
   writef("* This project has been isolated from the cache.")
@@ -87,7 +87,7 @@ renv_isolate_windows <- function(project) {
     unlink(targets)
     copy <- renv_progress_callback(renv_file_copy, length(targets))
     enumerate(targets, copy, overwrite = TRUE)
-    vwritef("Done!")
+    writef("Done!")
   }
 
   writef("* This project has been isolated from the cache.")

--- a/R/isolate.R
+++ b/R/isolate.R
@@ -61,7 +61,7 @@ renv_isolate_unix <- function(project) {
   names(targets) <- sources
 
   if (length(targets)) {
-    vprintf("* Copying packages into the private library ... ")
+    printf("* Copying packages into the private library ... ")
     unlink(targets)
     copy <- renv_progress_callback(renv_file_copy, length(targets))
     enumerate(targets, copy, overwrite = TRUE)
@@ -82,7 +82,7 @@ renv_isolate_windows <- function(project) {
   names(targets) <- sources
 
   if (length(targets)) {
-    vprintf("* Copying packages into the private library ... ")
+    printf("* Copying packages into the private library ... ")
     targets <- targets[file.exists(sources)]
     unlink(targets)
     copy <- renv_progress_callback(renv_file_copy, length(targets))

--- a/R/load.R
+++ b/R/load.R
@@ -216,8 +216,8 @@ renv_load_r <- function(project, fields) {
 
   # only compare major, minor versions
   if (!identical(requested[1:2], current[1:2])) {
-    fmt <- "Using R %s (lockfile was generated with R %s)"
-    infof(fmt, getRversion(), version)
+    fmt <- "%s Using R %s (lockfile was generated with R %s)"
+    writef(fmt, info_bullet(), getRversion(), version)
   }
 
 }

--- a/R/load.R
+++ b/R/load.R
@@ -376,7 +376,7 @@ renv_load_project_projlist <- function(project) {
 
   # update the project list
   ensure_parent_directory(projects)
-  catchall(writeLines(enc2utf8(projlist), projects, useBytes = TRUE))
+  catchall(writeLines(enc2utf8(projlist), con = projects, useBytes = TRUE))
 
   TRUE
 

--- a/R/load.R
+++ b/R/load.R
@@ -748,10 +748,10 @@ renv_load_report_project <- function(project) {
 
   if (length(profile)) {
     fmt <- "* (%s) Project '%s' loaded. [renv %s]"
-    vwritef(fmt, profile, renv_path_aliased(project), version)
+    writef(fmt, profile, renv_path_aliased(project), version)
   } else {
     fmt <- "* Project '%s' loaded. [renv %s]"
-    vwritef(fmt, renv_path_aliased(project), version)
+    writef(fmt, renv_path_aliased(project), version)
   }
 
 }
@@ -763,7 +763,7 @@ renv_load_report_python <- function(project) {
     return(FALSE)
 
   # fmt <- "* Using Python %s. [%s]"
-  # vwritef(fmt, renv_python_version(python), renv_python_type(python))
+  # writef(fmt, renv_python_version(python), renv_python_type(python))
 
 }
 
@@ -792,7 +792,7 @@ renv_load_report_updates_impl <- function(project) {
   if (!available)
     return(FALSE)
 
-  vwritef("* Use `renv::update()` to install updated packages.")
+  writef("* Use `renv::update()` to install updated packages.")
   if (!interactive())
     print(status)
 

--- a/R/load.R
+++ b/R/load.R
@@ -680,8 +680,7 @@ renv_load_cache <- function(project) {
     "* The cache version has been updated in this version of renv.",
     "* Use `renv::rehash()` to migrate packages from the old renv cache."
   )
-
-  vmessagef(msg)
+  printf(msg)
 
 }
 

--- a/R/lockfile-write.R
+++ b/R/lockfile-write.R
@@ -92,15 +92,14 @@ renv_lockfile_write_json <- function(lockfile, file = stdout()) {
 
 renv_lockfile_write_internal <- function(lockfile,
                                          file = stdout(),
-                                         delim = "=",
-                                         emitter = NULL)
+                                         delim = "=")
 {
   if (is.character(file)) {
     file <- textfile(file)
     defer(close(file))
   }
 
-  emitter <- emitter %||% function(text) writeLines(text, con = file)
+  emitter <- function(text) writeLines(text, con = file)
 
   renv_lockfile_state_set("delim", delim)
   renv_lockfile_state_set("emitter", emitter)

--- a/R/manifest-convert.R
+++ b/R/manifest-convert.R
@@ -82,7 +82,7 @@ renv_lockfile_from_manifest <- function(manifest,
   # otherwise, write to file and report for user
   renv_lockfile_write(lock, file = lockfile)
   fmt <- "* Lockfile written to %s."
-  vwritef(fmt, renv_path_pretty(lockfile))
+  writef(fmt, renv_path_pretty(lockfile))
 
   invisible(lock)
 

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -99,9 +99,9 @@ renv_migrate_packrat <- function(project = NULL, components = NULL) {
   renv_imbue_impl(project)
 
   fmt <- "* Project '%s' has been migrated from Packrat to renv."
-  vwritef(fmt, renv_path_aliased(project))
+  writef(fmt, renv_path_aliased(project))
 
-  vwritef("* Consider deleting the project 'packrat' folder if it is no longer needed.")
+  writef("* Consider deleting the project 'packrat' folder if it is no longer needed.")
   invisible(TRUE)
 }
 
@@ -215,7 +215,7 @@ renv_migrate_packrat_sources <- function(project) {
     ensure_parent_directory(target)
     copy(source, target)
   })
-  vwritef("Done!")
+  writef("Done!")
 
   TRUE
 
@@ -238,7 +238,7 @@ renv_migrate_packrat_library <- function(project) {
   names(targets) <- sources
   targets <- targets[!file.exists(targets)]
   if (empty(targets)) {
-    vwritef("* The renv library is already synchronized with the Packrat library.")
+    writef("* The renv library is already synchronized with the Packrat library.")
     return(TRUE)
   }
 
@@ -247,7 +247,7 @@ renv_migrate_packrat_library <- function(project) {
   ensure_parent_directory(targets)
   copy <- renv_progress_callback(renv_file_copy, length(targets))
   enumerate(targets, copy)
-  vwritef("Done!")
+  writef("Done!")
 
   # move packages into the cache
   if (renv_cache_config_enabled(project = project)) {
@@ -255,7 +255,7 @@ renv_migrate_packrat_library <- function(project) {
     records <- lapply(targets, renv_description_read)
     sync <- renv_progress_callback(renv_cache_synchronize, length(targets))
     lapply(records, sync, linkable = TRUE)
-    vwritef("Done!")
+    writef("Done!")
   }
 
   TRUE
@@ -291,7 +291,7 @@ renv_migrate_packrat_cache <- function(project) {
   # only copy to cache target paths that don't exist
   targets <- targets[!file.exists(targets)]
   if (empty(targets)) {
-    vwritef("* The renv cache is already synchronized with the Packrat cache.")
+    writef("* The renv cache is already synchronized with the Packrat cache.")
     return(TRUE)
   }
 
@@ -317,7 +317,7 @@ renv_migrate_packrat_cache_impl <- function(targets) {
     list(source = source, target = target, broken = broken, reason = reason)
   })
 
-  vwritef("Done!")
+  writef("Done!")
 
   # report failures
   status <- bind(result)
@@ -336,6 +336,6 @@ renv_migrate_packrat_cache_impl <- function(targets) {
 renv_migrate_packrat_infrastructure <- function(project) {
   unlink(file.path(project, ".Rprofile"))
   renv_infrastructure_write(project)
-  vwritef("* renv support infrastructure has been written.")
+  writef("* renv support infrastructure has been written.")
   TRUE
 }

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -209,7 +209,7 @@ renv_migrate_packrat_sources <- function(project) {
   keep <- !file.exists(targets)
   sources <- sources[keep]; targets <- targets[keep]
 
-  vprintf("* Migrating package sources from Packrat to renv ... ")
+  printf("* Migrating package sources from Packrat to renv ... ")
   copy <- renv_progress_callback(renv_file_copy, length(targets))
   mapply(sources, targets, FUN = function(source, target) {
     ensure_parent_directory(target)
@@ -243,7 +243,7 @@ renv_migrate_packrat_library <- function(project) {
   }
 
   # copy packages from Packrat to renv private library
-  vprintf("* Migrating library from Packrat to renv ... ")
+  printf("* Migrating library from Packrat to renv ... ")
   ensure_parent_directory(targets)
   copy <- renv_progress_callback(renv_file_copy, length(targets))
   enumerate(targets, copy)
@@ -251,7 +251,7 @@ renv_migrate_packrat_library <- function(project) {
 
   # move packages into the cache
   if (renv_cache_config_enabled(project = project)) {
-    vprintf("* Moving packages into the renv cache ... ")
+    printf("* Moving packages into the renv cache ... ")
     records <- lapply(targets, renv_description_read)
     sync <- renv_progress_callback(renv_cache_synchronize, length(targets))
     lapply(records, sync, linkable = TRUE)
@@ -306,7 +306,7 @@ renv_migrate_packrat_cache <- function(project) {
 renv_migrate_packrat_cache_impl <- function(targets) {
 
   # attempt to copy packages from Packrat to renv cache
-  vprintf("* Migrating Packrat cache to renv cache ... ")
+  printf("* Migrating Packrat cache to renv cache ... ")
   ensure_parent_directory(targets)
   copy <- renv_progress_callback(renv_file_copy, length(targets))
 

--- a/R/mran.R
+++ b/R/mran.R
@@ -162,7 +162,7 @@ renv_mran_database_update <- function(platform, version, dates = NULL) {
   }
 
   # save at end
-  vprintf("[%s]: saving database ... ", date)
+  printf("[%s]: saving database ... ", date)
   renv_mran_database_save(database)
   vwritef("DONE")
 
@@ -170,7 +170,7 @@ renv_mran_database_update <- function(platform, version, dates = NULL) {
 
 renv_mran_database_update_impl <- function(date, url, entry) {
 
-  vprintf("[%s]: reading package database ... ", date)
+  printf("[%s]: reading package database ... ", date)
 
   # get date as number of days since epoch
   idate <- as.integer(date)

--- a/R/mran.R
+++ b/R/mran.R
@@ -164,7 +164,7 @@ renv_mran_database_update <- function(platform, version, dates = NULL) {
   # save at end
   printf("[%s]: saving database ... ", date)
   renv_mran_database_save(database)
-  vwritef("DONE")
+  writef("DONE")
 
 }
 
@@ -179,7 +179,7 @@ renv_mran_database_update_impl <- function(date, url, entry) {
   errors <- new.env(parent = emptyenv())
   db <- renv_available_packages_query_impl(url, errors)
   if (is.null(db)) {
-    vwritef("ERROR")
+    writef("ERROR")
     return(FALSE)
   }
 
@@ -196,7 +196,7 @@ renv_mran_database_update_impl <- function(date, url, entry) {
 
   }
 
-  vwritef("OK")
+  writef("OK")
   TRUE
 
 }
@@ -297,10 +297,10 @@ renv_mran_database_sync <- function(platform, version) {
     return(FALSE)
 
   # invoke update for missing dates
-  vwritef("==> Synchronizing MRAN database (%s/%s)", platform, version)
+  writef("==> Synchronizing MRAN database (%s/%s)", platform, version)
   dates <- as.Date(seq(last + 1L, now, by = 1L), origin = "1970-01-01")
   renv_mran_database_update(platform, version, dates)
-  vwritef("Finished synchronizing MRAN database (%s/%s)", platform, version)
+  writef("Finished synchronizing MRAN database (%s/%s)", platform, version)
 
   # return TRUE to indicate update occurred
   return(TRUE)

--- a/R/preflight.R
+++ b/R/preflight.R
@@ -21,7 +21,7 @@ renv_preflight <- function(lockfile) {
       "The environment may not be restored correctly."
     )
 
-    vwritef(feedback)
+    writef(feedback)
 
   }
 

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -32,14 +32,12 @@ renv_pretty_print <- function(values,
   msg$push("")
   text <- paste(as.character(msg$data()), collapse = "\n")
 
-  emitter <- emitter %||% renv_pretty_print_emitter()
-  emitter(text)
+  writef(text)
 }
 
 renv_pretty_print_records <- function(records,
                                       preamble  = NULL,
-                                      postamble = NULL,
-                                      emitter   = NULL)
+                                      postamble = NULL)
 {
   if (empty(records))
     return(invisible(NULL))
@@ -65,8 +63,7 @@ renv_pretty_print_records <- function(records,
     if (length(postamble)) c(postamble, "")
   )
 
-  emitter <- emitter %||% renv_pretty_print_emitter()
-  emitter(all)
+  writef(all)
 
   invisible(NULL)
 }
@@ -75,8 +72,7 @@ renv_pretty_print_records_pair <- function(old,
                                            new,
                                            preamble  = NULL,
                                            postamble = NULL,
-                                           formatter = NULL,
-                                           emitter   = NULL)
+                                           formatter = NULL)
 {
   formatter <- formatter %||% renv_record_format_pair
 
@@ -86,8 +82,7 @@ renv_pretty_print_records_pair <- function(old,
     if (length(postamble)) c(postamble, "")
   )
 
-  emitter <- emitter %||% renv_pretty_print_emitter()
-  emitter(all)
+  writef(all)
 
   invisible(NULL)
 }
@@ -135,18 +130,5 @@ renv_pretty_print_records_pair_impl <- function(old, new, formatter) {
     )
 
   })
-
-}
-
-renv_pretty_print_emitter <- function() {
-
-  emitter <- getOption("renv.pretty.print.emitter", default = NULL)
-  if (!is.null(emitter))
-    return(emitter)
-
-  if (interactive())
-    function(text, ...) writeLines(text, con = stdout(), ...)
-  else
-    function(text, ...) writeLines(text, con = stderr(), ...)
 
 }

--- a/R/project.R
+++ b/R/project.R
@@ -292,7 +292,7 @@ renv_project_synchronized_check <- function(project = NULL, lockfile = NULL) {
         "* This project contains a lockfile, but none of the recorded packages are installed.",
         "* Use `renv::restore()` to restore the project library."
       )
-      ewritef(msg)
+      writef(msg)
       return(FALSE)
     }
   }
@@ -304,7 +304,7 @@ renv_project_synchronized_check <- function(project = NULL, lockfile = NULL) {
       "* One or more packages recorded in the lockfile are not installed.",
       "* Use `renv::status()` for more details."
     )
-    ewritef(msg)
+    writef(msg)
     return(FALSE)
   }
 
@@ -321,7 +321,7 @@ renv_project_synchronized_check <- function(project = NULL, lockfile = NULL) {
       "* Use `renv::status()` for more details."
     )
 
-    ewritef(msg)
+    writef(msg)
     return(FALSE)
 
   }

--- a/R/purge.R
+++ b/R/purge.R
@@ -55,7 +55,7 @@ renv_purge_impl <- function(package,
     stop("argument 'package' is not of length one", call. = FALSE)
 
   bail <- function() {
-    vwritef("* The requested package is not installed in the cache -- nothing to do.")
+    writef("* The requested package is not installed in the cache -- nothing to do.")
     character()
   }
 
@@ -116,7 +116,7 @@ renv_purge_impl <- function(package,
   renv_cache_clean_empty()
 
   n <- length(paths)
-  vwritef("* Removed %s from the cache.", nplural("package", n))
+  writef("* Removed %s from the cache.", nplural("package", n))
 
   invisible(paths)
 

--- a/R/python-conda.R
+++ b/R/python-conda.R
@@ -59,7 +59,7 @@ renv_python_conda_snapshot <- function(project, prompt, python) {
   output <- if (renv_tests_running()) FALSE else ""
   system2(conda, args, stdout = output, stderr = output)
 
-  vwritef("* Wrote Python packages to '%s'.", renv_path_aliased(path))
+  writef("* Wrote Python packages to '%s'.", renv_path_aliased(path))
   return(TRUE)
 }
 

--- a/R/python-virtualenv.R
+++ b/R/python-virtualenv.R
@@ -91,7 +91,7 @@ renv_python_virtualenv_snapshot <- function(project, prompt, python) {
 
   after <- pip_freeze(python = python)
   if (setequal(before, after)) {
-    vwritef("* Python requirements are already up to date.")
+    writef("* Python requirements are already up to date.")
     return(FALSE)
   }
 
@@ -106,7 +106,7 @@ renv_python_virtualenv_snapshot <- function(project, prompt, python) {
   writeLines(after, con = path)
 
   fmt <- "* Wrote Python packages to %s."
-  vwritef(fmt, renv_path_pretty(path))
+  writef(fmt, renv_path_pretty(path))
   return(TRUE)
 
 }
@@ -123,7 +123,7 @@ renv_python_virtualenv_restore <- function(project, prompt, python) {
   after <- pip_freeze(python = python)
   diff <- renv_vector_diff(before, after)
   if (empty(diff)) {
-    vwritef("* The Python library is already up to date.")
+    writef("* The Python library is already up to date.")
     return(FALSE)
   }
 

--- a/R/python.R
+++ b/R/python.R
@@ -68,8 +68,7 @@ renv_python_find_impl <- function(version, path = NULL) {
       "See `?renv::use_python` for more details."
     )
 
-    msg <- sprintf(fmt, version)
-    stop(msg)
+    stopf(fmt, version)
 
   }
 

--- a/R/python.R
+++ b/R/python.R
@@ -18,7 +18,7 @@ renv_python_resolve <- function(python = NULL) {
     python <- renv_python_select()
 
     fmt <- "* Selected %s [Python %s]."
-    vwritef(fmt, renv_path_pretty(python), renv_python_version(python))
+    writef(fmt, renv_path_pretty(python), renv_python_version(python))
 
     return(path.expand(python))
 

--- a/R/rebuild.R
+++ b/R/rebuild.R
@@ -59,7 +59,7 @@ rebuild <- function(packages  = NULL,
   # make sure records are named
   names(records) <- map_chr(records, `[[`, "Package")
   if (empty(records)) {
-    vwritef("* There are no packages currently installed -- nothing to rebuild.")
+    writef("* There are no packages currently installed -- nothing to rebuild.")
     return(invisible(records))
   }
 

--- a/R/record.R
+++ b/R/record.R
@@ -59,7 +59,7 @@ record <- function(records,
 
   n <- length(records)
   fmt <- "* Updated %s in %s."
-  vwritef(fmt, nplural("record", n), renv_path_pretty(lockfile))
+  writef(fmt, nplural("record", n), renv_path_pretty(lockfile))
 
   renv <- records[["renv"]]
   if (!is.null(renv) && !is.null(renv[["Version"]])) {

--- a/R/rehash.R
+++ b/R/rehash.R
@@ -37,7 +37,7 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
   # re-compute package hashes
   old <- renv_cache_list(cache = cache)
 
-  vprintf("* Re-computing package hashes ... ")
+  printf("* Re-computing package hashes ... ")
   new <- map_chr(old, renv_progress_callback(renv_cache_path, length(old)))
   vwritef("Done!")
 
@@ -69,7 +69,7 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
   names(sources) <- targets
   names(targets) <- sources
 
-  vprintf("* Re-caching packages ... ")
+  printf("* Re-caching packages ... ")
   enumerate(targets, renv_progress_callback(action, length(targets)))
   vwritef("Done!")
 

--- a/R/rehash.R
+++ b/R/rehash.R
@@ -39,11 +39,11 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
 
   printf("* Re-computing package hashes ... ")
   new <- map_chr(old, renv_progress_callback(renv_cache_path, length(old)))
-  vwritef("Done!")
+  writef("Done!")
 
   changed <- which(old != new & file.exists(old) & !file.exists(new))
   if (empty(changed)) {
-    vwritef("* Your cache is already up-to-date -- nothing to do.")
+    writef("* Your cache is already up-to-date -- nothing to do.")
     return(TRUE)
   }
 
@@ -71,11 +71,11 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
 
   printf("* Re-caching packages ... ")
   enumerate(targets, renv_progress_callback(action, length(targets)))
-  vwritef("Done!")
+  writef("Done!")
 
   n <- length(targets)
   fmt <- "Successfully re-cached %s."
-  vwritef(fmt, nplural("package", n))
+  writef(fmt, nplural("package", n))
 
   renv_cache_clean_empty()
 

--- a/R/remove.R
+++ b/R/remove.R
@@ -65,7 +65,7 @@ renv_remove_impl <- function(package, library) {
   }
 
   recursive <- renv_file_type(path) == "directory"
-  vprintf("Removing package '%s' ... ", package)
+  printf("Removing package '%s' ... ", package)
   unlink(path, recursive = recursive)
   vwritef("Done!")
 

--- a/R/remove.R
+++ b/R/remove.R
@@ -35,10 +35,10 @@ remove <- function(packages,
   records <- Filter(function(record) !inherits(record, "error"), records)
 
   if (library == renv_paths_library(project = project)) {
-    vwritef("* Removing package(s) from project library ...")
+    writef("* Removing package(s) from project library ...")
   } else {
     fmt <- "* Removing package(s) from library '%s' ..."
-    vwritef(fmt, renv_path_aliased(library))
+    writef(fmt, renv_path_aliased(library))
   }
 
   if (length(packages) == 1) {
@@ -52,7 +52,7 @@ remove <- function(packages,
       count <- count + 1
   }
 
-  vwritef("* Done! Removed %s.", nplural("package", count))
+  writef("* Done! Removed %s.", nplural("package", count))
   invisible(records)
 }
 
@@ -60,14 +60,14 @@ renv_remove_impl <- function(package, library) {
 
   path <- file.path(library, package)
   if (!renv_file_exists(path)) {
-    vwritef("* Package '%s' is not installed -- nothing to do.", package)
+    writef("* Package '%s' is not installed -- nothing to do.", package)
     return(FALSE)
   }
 
   recursive <- renv_file_type(path) == "directory"
   printf("Removing package '%s' ... ", package)
   unlink(path, recursive = recursive)
-  vwritef("Done!")
+  writef("Done!")
 
   TRUE
 

--- a/R/repair.R
+++ b/R/repair.R
@@ -30,7 +30,7 @@ repair <- function(library  = NULL,
   packages <- basename(paths[broken])
   if (empty(packages)) {
     fmt <- "* The project library has no broken links -- nothing to do."
-    vwritef(fmt)
+    writef(fmt)
     return(invisible(packages))
   }
 

--- a/R/restart.R
+++ b/R/restart.R
@@ -22,7 +22,7 @@ renv_restart_request_default <- function(project, reason, ...) {
   # otherwise, ask the user to restart
   if (interactive()) {
     fmt <- "* %s -- please restart the R session."
-    vwritef(fmt, sprintf(reason, ...), con = stderr())
+    writef(fmt, sprintf(reason, ...), con = stderr())
   }
 
 }

--- a/R/restart.R
+++ b/R/restart.R
@@ -22,7 +22,7 @@ renv_restart_request_default <- function(project, reason, ...) {
   # otherwise, ask the user to restart
   if (interactive()) {
     fmt <- "* %s -- please restart the R session."
-    writef(fmt, sprintf(reason, ...), con = stderr())
+    writef(fmt, sprintf(reason, ...))
   }
 
 }

--- a/R/restore.R
+++ b/R/restore.R
@@ -129,7 +129,7 @@ restore <- function(project  = NULL,
 
   if (!length(diff)) {
     name <- if (!missing(library)) "library" else "project"
-    vwritef("* The %s is already synchronized with the lockfile.", name)
+    writef("* The %s is already synchronized with the lockfile.", name)
     return(renv_restore_successful(diff, prompt, project))
   }
 
@@ -292,11 +292,11 @@ renv_restore_report_actions <- function(actions, current, lockfile) {
 renv_restore_remove <- function(project, package, lockfile) {
   records <- renv_lockfile_records(lockfile)
   record <- records[[package]]
-  vwritef("Removing %s [%s] ...", package, record$Version)
+  writef("Removing %s [%s] ...", package, record$Version)
   paths <- renv_paths_library(project = project, package)
   recursive <- renv_file_type(paths) == "directory"
   unlink(paths, recursive = recursive)
-  vwritef("\tOK [removed from library]")
+  writef("\tOK [removed from library]")
   TRUE
 }
 

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -403,7 +403,7 @@ renv_retrieve_git_impl <- function(record, path) {
   if (renv_platform_windows())
     command <- paste(comspec(), "/C", command)
 
-  vwritef("Cloning '%s' ...", url)
+  writef("Cloning '%s' ...", url)
 
   before <- Sys.time()
 
@@ -422,7 +422,7 @@ renv_retrieve_git_impl <- function(record, path) {
 
   fmt <- "\tOK [cloned repository in %s]"
   elapsed <- difftime(after, before, units = "auto")
-  vwritef(fmt, renv_difftime_format(elapsed))
+  writef(fmt, renv_difftime_format(elapsed))
 
   TRUE
 
@@ -474,7 +474,7 @@ renv_retrieve_cellar_report <- function(record) {
     return(record)
 
   fmt <- "* Package %s [%s] will be installed from the cellar."
-  with(record, vwritef(fmt, Package, Version))
+  with(record, writef(fmt, Package, Version))
 
   record
 

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -1169,8 +1169,7 @@ renv_retrieve_missing_record <- function(package) {
   entry <- renv_available_packages_entry(package, type = "source")
   version <- entry$Version %||% "<unknown>"
 
-  msg <- sprintf(fmt, package, version)
-  writeLines(msg)
+  writef(fmt, package, version)
 
   stopf("failed to find a compatible version of the '%s' package", package)
 

--- a/R/scaffold.R
+++ b/R/scaffold.R
@@ -69,7 +69,7 @@ scaffold <- function(project  = NULL,
 
   # notify user
   fmt <- "* renv infrastructure has been generated for project %s."
-  vwritef(fmt, renv_path_pretty(project))
+  writef(fmt, renv_path_pretty(project))
 
   # return project invisibly
   invisible(project)

--- a/R/settings.R
+++ b/R/settings.R
@@ -233,7 +233,7 @@ renv_settings_updated_cache <- function(project, old, new) {
     return(TRUE)
   }
 
-  vprintf("* Synchronizing project library with the cache ... ")
+  printf("* Synchronizing project library with the cache ... ")
 
   if (new) {
 

--- a/R/settings.R
+++ b/R/settings.R
@@ -229,7 +229,7 @@ renv_settings_updated_cache <- function(project, old, new) {
 
   if (empty(pkgpaths)) {
     fmt <- "* The cache has been %s for this project."
-    vwritef(fmt, if (new) "enabled" else "disabled")
+    writef(fmt, if (new) "enabled" else "disabled")
     return(TRUE)
   }
 
@@ -267,10 +267,10 @@ renv_settings_updated_cache <- function(project, old, new) {
 
   }
 
-  vwritef("Done!")
+  writef("Done!")
 
   fmt <- "* The cache has been %s for this project."
-  vwritef(fmt, if (new) "enabled" else "disabled")
+  writef(fmt, if (new) "enabled" else "disabled")
 
 }
 

--- a/R/snapshot-auto.R
+++ b/R/snapshot-auto.R
@@ -18,7 +18,7 @@ renv_snapshot_auto <- function(project) {
     return(FALSE)
 
   lockfile <- renv_lockfile_path(project = project)
-  vwritef("* Automatic snapshot has updated '%s'.", renv_path_aliased(lockfile))
+  writef("* Automatic snapshot has updated '%s'.", renv_path_aliased(lockfile))
   TRUE
 
 }

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -349,7 +349,7 @@ renv_snapshot_validate_bioconductor <- function(project, lockfile, libpaths) {
     )
 
     if (!renv_tests_running())
-      writeLines(sprintf(text, package))
+      writef(text, package)
 
     ok <- FALSE
   }

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -179,7 +179,7 @@ snapshot <- function(project  = NULL,
     # check if there are any changes in the lockfile
     diff <- renv_lockfile_diff(old, alt)
     if (empty(diff)) {
-      vwritef("* The lockfile is already up to date.")
+      writef("* The lockfile is already up to date.")
       return(renv_snapshot_successful(alt, prompt, project))
     }
 
@@ -211,7 +211,7 @@ snapshot <- function(project  = NULL,
   # write it out
   ensure_parent_directory(lockfile)
   renv_lockfile_write(new, file = lockfile)
-  vwritef("* Lockfile written to '%s'.", renv_path_aliased(lockfile))
+  writef("* Lockfile written to '%s'.", renv_path_aliased(lockfile))
 
   # ensure the lockfile is .Rbuildignore-d
   renv_infrastructure_write_rbuildignore(project)
@@ -936,7 +936,7 @@ renv_snapshot_filter <- function(project, records, type, packages, exclude) {
       weeks = "weeks"
     )
 
-    vwritef(lines, elapsed, units)
+    writef(lines, elapsed, units)
 
   }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -844,7 +844,7 @@ renv_snapshot_report_actions <- function(actions, old, new) {
     n <- max(nchar(names(actions)), 0)
     fmt <- paste("-", format("R", width = n), " ", "[%s -> %s]")
     msg <- sprintf(fmt, oldr %||% "*", newr %||% "*")
-    writeLines(c("The version of R recorded in the lockfile will be updated:", msg, ""))
+    writef(c("The version of R recorded in the lockfile will be updated:", msg, ""))
   }
 
 }

--- a/R/status.R
+++ b/R/status.R
@@ -143,12 +143,11 @@ renv_status_check_missing_lockfile <- function(project, lockpath) {
   if (file.exists(lockpath))
     return(TRUE)
 
-  text <- if (identical(lockpath, renv_lockfile_path(project)))
-    "* This project has not yet been snapshotted -- 'renv.lock' does not exist."
+  if (identical(lockpath, renv_lockfile_path(project)))
+    writef("* This project has not yet been snapshotted -- 'renv.lock' does not exist.")
   else
-    sprintf("* Lockfile %s does not exist.", renv_path_pretty(lockpath))
+    writef("* Lockfile %s does not exist.", renv_path_pretty(lockpath))
 
-  writef(text)
   FALSE
 
 }
@@ -159,12 +158,11 @@ renv_status_check_missing_library <- function(project, libpaths) {
   if (file.exists(projlib))
     return(TRUE)
 
-  text <- if (identical(projlib, renv_paths_library(project = project)))
-    "* This project's private library is empty or does not exist."
+  if (identical(projlib, renv_paths_library(project = project)))
+    writef("* This project's private library is empty or does not exist.")
   else
-    sprintf("* Library %s is empty or does not exist.", renv_path_pretty(projlib))
+    writef("* Library %s is empty or does not exist.", renv_path_pretty(projlib))
 
-  writef(text)
   FALSE
 
 }

--- a/R/status.R
+++ b/R/status.R
@@ -349,13 +349,14 @@ renv_status_check_synchronized <- function(project,
       check.names          = FALSE
     )
 
-    writeLines("The following package(s) are out of sync:")
-    writeLines("")
-    print(data, row.names = FALSE)
-    writeLines("")
-    writeLines("Use `renv::snapshot()` to save the state of your library to the lockfile.")
-    writeLines("Use `renv::restore()` to restore your library from the lockfile.")
-    writeLines("")
+    writef("The following package(s) are out of sync:")
+    writef("")
+    if (renv_verbose())
+      print(data, row.names = FALSE)
+    writef("")
+    writef("Use `renv::snapshot()` to save the state of your library to the lockfile.")
+    writef("Use `renv::restore()` to restore your library from the lockfile.")
+    writef("")
 
     ok <- FALSE
 

--- a/R/status.R
+++ b/R/status.R
@@ -58,7 +58,7 @@ renv_status_impl <- function(project, libpaths, lockpath, sources, cache) {
 
   # check to see if we've initialized this project
   if (!renv_project_initialized(project)) {
-    vwritef("* This project has not yet been initialized.")
+    writef("* This project has not yet been initialized.")
     return(default)
   }
 
@@ -128,7 +128,7 @@ renv_status_impl <- function(project, libpaths, lockpath, sources, cache) {
     renv_status_check_cache(project)
 
   if (synchronized)
-    vwritef("* The project is already synchronized with the lockfile.")
+    writef("* The project is already synchronized with the lockfile.")
 
   list(
     library      = library,
@@ -148,7 +148,7 @@ renv_status_check_missing_lockfile <- function(project, lockpath) {
   else
     sprintf("* Lockfile %s does not exist.", renv_path_pretty(lockpath))
 
-  vwritef(text)
+  writef(text)
   FALSE
 
 }
@@ -164,7 +164,7 @@ renv_status_check_missing_library <- function(project, libpaths) {
   else
     sprintf("* Library %s is empty or does not exist.", renv_path_pretty(projlib))
 
-  vwritef(text)
+  writef(text)
   FALSE
 
 }

--- a/R/system.R
+++ b/R/system.R
@@ -65,7 +65,7 @@ renv_system_exec <- function(command,
       output
 
     # write to stderr
-    writeLines(c(header, "", body), con = stderr())
+    writef(c(header, "", body))
 
   }
 

--- a/R/task.R
+++ b/R/task.R
@@ -26,8 +26,7 @@ renv_task_callback <- function(callback, name) {
     status <- tryCatch(callback(), error = identity)
     if (inherits(status, "error")) {
       fmt <- "renv background task '%s' failed; it will be stopped"
-      msg <- sprintf(fmt, name)
-      warning(msg, call. = FALSE)
+      warningf(fmt, name)
       return(FALSE)
     }
 

--- a/R/update.R
+++ b/R/update.R
@@ -297,7 +297,7 @@ update <- function(packages = NULL,
     }
   }
 
-  vprintf("* Checking for updated packages ... ")
+  printf("* Checking for updated packages ... ")
 
   # remove records that appear to be from an R package repository,
   # but are not actually available in the current repositories

--- a/R/update.R
+++ b/R/update.R
@@ -315,12 +315,12 @@ update <- function(packages = NULL,
   })
 
   updates <- renv_update_find(selected)
-  vwritef("Done!")
+  writef("Done!")
 
   renv_update_errors_emit()
 
   if (empty(updates)) {
-    vwritef("* All packages appear to be up-to-date.")
+    writef("* All packages appear to be up-to-date.")
     return(invisible(TRUE))
   }
 
@@ -337,7 +337,7 @@ update <- function(packages = NULL,
       length(diff) != 1 ~ "* %i packages have updates available."
     )
 
-    vwritef(fmt, length(diff))
+    writef(fmt, length(diff))
     renv_updates_report(diff, old, new)
     return(invisible(renv_updates_create(diff, old, new)))
 

--- a/R/upgrade.R
+++ b/R/upgrade.R
@@ -60,7 +60,7 @@ renv_upgrade_impl <- function(project, version, reload, prompt) {
   # check for some form of change
   if (renv_records_equal(old, new)) {
     fmt <- "* renv [%s] is already installed and active for this project."
-    vwritef(fmt, new$Version)
+    writef(fmt, new$Version)
     return(TRUE)
   }
 

--- a/R/use-python.R
+++ b/R/use-python.R
@@ -364,11 +364,11 @@ renv_use_python_virtualenv_impl <- function(project,
       return(exe)
   }
 
-  vprintf("* Creating virtual environment '%s' ... ", basename(name))
+  printf("* Creating virtual environment '%s' ... ", basename(name))
   vpython <- renv_python_virtualenv_create(python, path)
   vwritef("Done!")
 
-  vprintf("* Updating Python packages ... ")
+  printf("* Updating Python packages ... ")
   renv_python_virtualenv_update(vpython)
   vwritef("Done!")
 

--- a/R/use-python.R
+++ b/R/use-python.R
@@ -278,10 +278,10 @@ renv_use_python_fini <- function(info,
   if (!renv_tests_running()) {
     if (is.null(info$type)) {
       fmt <- "* Activated Python %s (%s)."
-      vwritef(fmt, version, renv_path_aliased(info$python))
+      writef(fmt, version, renv_path_aliased(info$python))
     } else {
       fmt <- "* Activated Python %s [%s; %s]"
-      vwritef(fmt, version, info$type, renv_path_aliased(name))
+      writef(fmt, version, info$type, renv_path_aliased(name))
     }
   }
 
@@ -366,11 +366,11 @@ renv_use_python_virtualenv_impl <- function(project,
 
   printf("* Creating virtual environment '%s' ... ", basename(name))
   vpython <- renv_python_virtualenv_create(python, path)
-  vwritef("Done!")
+  writef("Done!")
 
   printf("* Updating Python packages ... ")
   renv_python_virtualenv_update(vpython)
-  vwritef("Done!")
+  writef("Done!")
 
   renv_python_virtualenv_validate(path, version)
 
@@ -424,7 +424,7 @@ renv_python_deactivate <- function(project) {
 
   lockfile$Python <- NULL
   renv_lockfile_write(lockfile, file = file)
-  vwritef("* Deactived Python -- the lockfile has been updated.")
+  writef("* Deactived Python -- the lockfile has been updated.")
   TRUE
 
 }

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -31,10 +31,6 @@ ewritef <- function(fmt = "", ..., con = stderr()) {
     writeLines(sprintf(fmt, ...), con = con)
 }
 
-vwritef <- function(fmt = "", ..., con = stdout()) {
-  if (!is.null(fmt) && renv_verbose())
-    writeLines(sprintf(fmt, ...), con = con)
-}
 
 infof <- function(fmt = "", ..., con = stdout()) {
   if (!is.null(fmt) && renv_verbose()) {

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -21,22 +21,10 @@ printf <- function(fmt = "", ..., file = stdout(), sep = "") {
     cat(sprintf(fmt, ...), file = file, sep = sep)
 }
 
-eprintf <- function(fmt = "", ..., file = stderr(), sep = "") {
-  if (!is.null(fmt) && renv_verbose())
-    cat(sprintf(fmt, ...), file = file, sep = sep)
-}
-
 vprintf <- function(fmt = "", ..., file = stdout(), sep = "") {
   if (!is.null(fmt) && renv_verbose())
     cat(sprintf(fmt, ...), file = file, sep = sep)
 }
-
-veprintf <- function(fmt = "", ..., file = stderr(), sep = "") {
-  if (!is.null(fmt) && renv_verbose())
-    cat(sprintf(fmt, ...), file = file, sep = sep)
-}
-
-
 
 writef <- function(fmt = "", ..., con = stdout()) {
   if (!is.null(fmt) && renv_verbose())
@@ -49,11 +37,6 @@ ewritef <- function(fmt = "", ..., con = stderr()) {
 }
 
 vwritef <- function(fmt = "", ..., con = stdout()) {
-  if (!is.null(fmt) && renv_verbose())
-    writeLines(sprintf(fmt, ...), con = con)
-}
-
-vewritef <- function(fmt = "", ..., con = stderr()) {
   if (!is.null(fmt) && renv_verbose())
     writeLines(sprintf(fmt, ...), con = con)
 }

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -26,9 +26,6 @@ writef <- function(fmt = "", ..., con = stdout()) {
     writeLines(sprintf(fmt, ...), con = con)
 }
 
-infof <- function(fmt = "", ..., con = stdout()) {
-  if (!is.null(fmt) && renv_verbose()) {
-    fmt <- paste(if (l10n_info()$`UTF-8`) "\u2139" else "i", fmt)
-    writeLines(sprintf(fmt, ...), con = con)
-  }
+info_bullet <- function() {
+  if (l10n_info()$`UTF-8`) "\u2139" else "i"
 }

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -21,11 +21,6 @@ printf <- function(fmt = "", ..., file = stdout(), sep = "") {
     cat(sprintf(fmt, ...), file = file, sep = sep)
 }
 
-vprintf <- function(fmt = "", ..., file = stdout(), sep = "") {
-  if (!is.null(fmt) && renv_verbose())
-    cat(sprintf(fmt, ...), file = file, sep = sep)
-}
-
 writef <- function(fmt = "", ..., con = stdout()) {
   if (!is.null(fmt) && renv_verbose())
     writeLines(sprintf(fmt, ...), con = con)

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -26,12 +26,6 @@ writef <- function(fmt = "", ..., con = stdout()) {
     writeLines(sprintf(fmt, ...), con = con)
 }
 
-ewritef <- function(fmt = "", ..., con = stderr()) {
-  if (!is.null(fmt) && renv_verbose())
-    writeLines(sprintf(fmt, ...), con = con)
-}
-
-
 infof <- function(fmt = "", ..., con = stdout()) {
   if (!is.null(fmt) && renv_verbose()) {
     fmt <- paste(if (l10n_info()$`UTF-8`) "\u2139" else "i", fmt)

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -16,17 +16,6 @@ warningf <- function(fmt = "", ..., call. = FALSE, immediate. = FALSE) {
   warning(sprintf(fmt, ...), call. = call., immediate. = immediate.)
 }
 
-messagef <- function(fmt = "", ..., appendLF = TRUE) {
-  message(sprintf(fmt, ...), appendLF = appendLF)
-}
-
-vmessagef <- function(fmt = "", ..., appendLF = TRUE) {
-  if (renv_verbose())
-    message(sprintf(fmt, ...), appendLF = appendLF)
-}
-
-
-
 printf <- function(fmt = "", ..., file = stdout(), sep = "") {
   if (!is.null(fmt) && renv_verbose())
     cat(sprintf(fmt, ...), file = file, sep = sep)

--- a/R/vendor.R
+++ b/R/vendor.R
@@ -77,8 +77,7 @@ vendor <- function(version    = NULL,
     #
   ")
 
-  blurb <- sprintf(template, renv_path_pretty(embed), renv_path_pretty(loader))
-  writeLines(blurb)
+  writef(template, renv_path_pretty(embed), renv_path_pretty(loader))
 
   invisible(TRUE)
 

--- a/tests/testthat/test-internal.R
+++ b/tests/testthat/test-internal.R
@@ -11,7 +11,7 @@ test_that("R files have balanced covr exclusions", {
     nocov <- FALSE
     contents <- catch(readLines(file))
     if (inherits(contents, "error")) {
-      vwritef("[%s]: %s", file, conditionMessage(contents))
+      writef("[%s]: %s", file, conditionMessage(contents))
       return()
     }
 

--- a/tools/tools-generate-config.R
+++ b/tools/tools-generate-config.R
@@ -53,4 +53,4 @@ all <- c(
 )
 
 writeLines(all, con = target)
-vwritef("* 'R/config-defaults.R' has been updated.")
+writef("* 'R/config-defaults.R' has been updated.")

--- a/tools/tools-git-tags.R
+++ b/tools/tools-git-tags.R
@@ -33,7 +33,7 @@ repeat {
     break
 
   # attempt to tag this commit
-  vwritef("* Tagging version '%s'", version)
+  writef("* Tagging version '%s'", version)
   system(paste("git tag", version))
 
   # go to the previous commit
@@ -44,6 +44,6 @@ repeat {
 
 }
 
-vwritef("* Updating tags")
+writef("* Updating tags")
 system("git push --tags")
 setwd(owd)


### PR DESCRIPTION
This has probably become too big to review easily, so it's probably best taken as discussion starter . Overall it ensures that we use `writef()` and friends for all user facing output, and ensure all output goes to `stdout()`, not `stderr()`. (Let me know if you need more justification for why I think this is the right approach).

Separately I think we should consider the names of `printf` and `writef`, as it's not obvious from their names how they differ (i.e. handling of vector inputs and whether or not there's a trailing line break).