### PR TITLE
Eliminate renv_scope_sink()

### DIFF
--- a/R/scope.R
+++ b/R/scope.R
@@ -77,20 +77,6 @@ renv_scope_envvars <- function(..., list = NULL, envir = parent.frame()) {
 
 }
 
-renv_scope_sink <- function(file = nullfile(), envir = parent.frame()) {
-
-  # redirect stdout to file, and redirect stderr back to stdout
-  # this ensures that both stdout, stderr are redirected to the same place
-  sink(file = file,     type = "output")
-  sink(file = stdout(), type = "message")
-
-  defer({
-    sink(type = "output")
-    sink(type = "message")
-  }, envir = envir)
-
-}
-
 renv_scope_error_handler <- function(envir = parent.frame()) {
 
   error <- getOption("error")

--- a/tests/testthat/_snaps/preflight.md
+++ b/tests/testthat/_snaps/preflight.md
@@ -1,0 +1,14 @@
+# renv warns when snapshotting missing dependencies
+
+    Code
+      snapshot()
+    Output
+      The following required packages are not installed:
+      
+      	oatmeal  [required by breakfast]
+      
+      Consider reinstalling these packages before snapshotting the lockfile.
+      
+    Error <simpleError>
+      aborting snapshot due to pre-flight validation failure
+

--- a/tests/testthat/test-clean.R
+++ b/tests/testthat/test-clean.R
@@ -16,10 +16,7 @@ test_that("clean removes stale lockfiles", {
   Sys.setFileTime(lockpath, Sys.time() - 36000)
 
   # installed but unused package
-  local({
-    renv_scope_sink()
-    suppressWarnings(install("toast"))
-  })
+  suppressWarnings(install("toast"))
 
   # clean up the project
   actions <- c("package.locks", "library.tempdirs", "unused.packages")

--- a/tests/testthat/test-preflight.R
+++ b/tests/testthat/test-preflight.R
@@ -26,11 +26,7 @@ test_that("renv warns when snapshotting missing dependencies", {
   init()
 
   remove("oatmeal")
-
-  local({
-    renv_scope_sink()
-    expect_error(snapshot())
-  })
+  expect_snapshot(snapshot(), error = TRUE)
 
   lockfile <- renv_lockfile_load(project)
   expect_true(!is.null(lockfile$Packages$oatmeal))

--- a/tests/testthat/test-python.R
+++ b/tests/testthat/test-python.R
@@ -111,10 +111,7 @@ test_that("installed Python packages are snapshotted / restored [virtualenv]", {
   expect_true(renv_python_module_available(python, "dotenv"))
 
   # snapshot changes
-  local({
-    renv_scope_sink()
-    snapshot()
-  })
+  snapshot()
 
   # check requirements.txt for install
   expect_true(file.exists("requirements.txt"))
@@ -127,10 +124,7 @@ test_that("installed Python packages are snapshotted / restored [virtualenv]", {
   expect_false(renv_python_module_available(python, "dotenv"))
 
   # try to restore
-  local({
-    renv_scope_sink()
-    restore()
-  })
+  restore()
 
   # check that we can load python-dotenv now
   expect_true(renv_python_module_available(python, "dotenv"))

--- a/tests/testthat/test-rebuild.R
+++ b/tests/testthat/test-rebuild.R
@@ -4,11 +4,7 @@ test_that("rebuild forces a package to rebuilt, bypassing cache", {
   renv_tests_scope("bread")
   init()
 
-  records <- local({
-    renv_scope_sink()
-    rebuild("bread")
-  })
-
+  records <- rebuild("bread")
   expect_length(records, 1L)
 
 })
@@ -18,11 +14,7 @@ test_that("rebuild installs latest-available package if not installed", {
   renv_tests_scope()
   init()
 
-  records <- local({
-    renv_scope_sink()
-    rebuild("bread")
-  })
-
+  rebuild("bread")
   expect_true(renv_package_installed("bread"))
 
 })

--- a/tests/testthat/test-restore.R
+++ b/tests/testthat/test-restore.R
@@ -28,13 +28,10 @@ test_that("restore can recover when required packages are missing", {
   renv_tests_scope("breakfast")
   init()
 
-  local({
-    renv_scope_sink()
-    remove("oatmeal")
-    snapshot(force = TRUE)
-    unlink(renv_paths_library(), recursive = TRUE)
-    restore()
-  })
+  remove("oatmeal")
+  snapshot(force = TRUE)
+  unlink(renv_paths_library(), recursive = TRUE)
+  restore()
 
   expect_true(renv_package_installed("oatmeal"))
 

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -9,11 +9,7 @@ test_that("update() finds packages requiring updates from CRAN", {
   install("breakfast@0.1.0")
   expect_true(renv_package_version("breakfast") == "0.1.0")
 
-  local({
-    renv_scope_sink()
-    update()
-  })
-
+  update()
   expect_true(renv_package_version("breakfast") == "1.0.0")
 
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -34,28 +34,6 @@ test_that("renv_path_aliased() correctly forms aliased path", {
   expect_equal(path, renv_path_aliased(expanded))
 })
 
-test_that("sink captures both stdout and stderr", {
-
-  file <- renv_scope_tempfile("renv-sink-", fileext = ".log")
-
-  osinks <- sink.number(type = "output")
-  msinks <- sink.number(type = "message")
-
-  local({
-    renv_scope_sink(file)
-    writeLines("stdout", con = stdout())
-    writeLines("stderr", con = stderr())
-  })
-
-  contents <- readLines(file)
-  expect_equal(contents, c("stdout", "stderr"))
-
-  expect_equal(sink.number(type = "output"),  osinks)
-  expect_equal(sink.number(type = "message"), msinks)
-
-
-})
-
 test_that("find() returns first non-null matching value", {
 
   data <- list(x = 1, y = 2, z = 3)

--- a/tests/testthat/test-vendor.R
+++ b/tests/testthat/test-vendor.R
@@ -34,10 +34,7 @@ test_that("renv can be vendored in a separate R package", {
   file.create("NAMESPACE")
 
   # vendor renv
-  local({
-    renv_scope_sink()
-    vendor(sources = sources)
-  })
+  vendor(sources = sources)
 
   # make sure renv is initializes in .onLoad()
   code <- heredoc('


### PR DESCRIPTION
I don't think it's been routinely needed for a while (since `renv_verbose()`) and the remaining uses have been superseded by snapshotting.