### PR TITLE
Tweak display of status

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # renv 0.18.0  (UNRELEASED)
 
+* `renv::status()` now works more like `renv::restore()` when package versions
+  are different (#675).
+
 * `renv::init()` now uses [Posit Public Package Manager](https://packagemanager.posit.co)
   by default, for new projects where the repositories have not already been
   configured externally. See the options `renv.config.ppm.enabled`,

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -46,21 +46,19 @@ renv_pretty_print_records <- function(records,
     return(invisible(NULL))
 
   names(records) <- names(records) %||% map_chr(records, `[[`, "Package")
-  records <- records[csort(names(records))]
+  # NOTE: use 'sort()' rather than 'csort()' here so that
+  # printed output is sorted in the expected way in the users locale
+  # https://github.com/rstudio/renv/issues/1289
+  records <- records[sort(names(records))]
   packages <- names(records)
   descs <- map_chr(records, renv_record_format_short)
 
-  lhs <- paste(" ", format(packages))
-  rhs <- descs
-
-  n <- max(nchar(lhs))
-  header <- paste(c(rep.int(" ", n + 1), "_"), collapse = "")
-  text <- sprintf("%s   [%s]", lhs, rhs)
+  text <- sprintf("- %s [%s]", format(packages), descs)
 
   all <- c(
-    if (length(preamble)) preamble,
-    c(header, text, ""),
-    if (length(postamble)) c(postamble, "")
+    preamble, if (length(postamble)) "",
+    text, "",
+    postamble, if (length(postamble)) ""
   )
 
   writef(all)

--- a/R/status.R
+++ b/R/status.R
@@ -296,23 +296,15 @@ renv_status_check_synchronized <- function(project,
     rlock <- renv_lockfile_records(lockfile)[names(matches)]
     rlibs <- renv_lockfile_records(library)[names(matches)]
 
-    data <- data.frame(
-      "  Package"          = names(matches),
-      "  Lockfile Version" = extract_chr(rlock, "Version"),
-      "  Library Version"  = extract_chr(rlibs, "Version"),
-      row.names            = NULL,
-      stringsAsFactors     = FALSE,
-      check.names          = FALSE
+    renv_pretty_print_records_pair(
+      rlock,
+      rlibs,
+      preamble = "The following package(s) are out of sync [lockfile -> library]:",
+      postamble = c(
+        "Use `renv::snapshot()` to save the state of your library to the lockfile.",
+        "Use `renv::restore()` to restore your library from the lockfile."
+      )
     )
-
-    writef("The following package(s) are out of sync:")
-    writef("")
-    if (renv_verbose())
-      print(data, row.names = FALSE)
-    writef("")
-    writef("Use `renv::snapshot()` to save the state of your library to the lockfile.")
-    writef("Use `renv::restore()` to restore your library from the lockfile.")
-    writef("")
 
     ok <- FALSE
 

--- a/tests/testthat/_snaps/status.md
+++ b/tests/testthat/_snaps/status.md
@@ -1,37 +1,53 @@
-# status reports packages to be installed / changed
+# not installed/recorded/used
 
     Code
-      snapshot()
+      status()
     Output
-      The following required packages are not installed:
+      The following packages are recorded in the lockfile, but not installed:
+              _
+        bread   [1.0.0]
       
-      	breakfast, toast
+      Use `renv::restore()` to restore the packages recorded in the lockfile.
       
-      Packages must first be installed before renv can snapshot them.
-      Consider installing these packages using `renv::install()`.
-      Use `renv::dependencies()` to see where this package is used in your project.
+
+# installed/not recorded/used
+
+    Code
+      status()
+    Output
+      The following package(s) are installed, but not recorded in the lockfile:
+              _
+        bread   [1.0.0]
       
-      The version of R recorded in the lockfile will be updated:
-      - R   [* -> <r-version>]
+      Use `renv::snapshot()` to add these packages to the lockfile.
       
-      * Lockfile written to '<wd>/renv.lock'.
+
+# not installed/*/used
+
+    Code
+      status()
+    Output
+      The following packages are used in this project, but not installed:
+      
+      	bread
+      
+      Consider installing these packages -- for example, with `renv::install()`.
+      Use `renv::status()` afterwards to re-assess the project state.
+      
 
 ---
 
     Code
       status()
     Output
-      The following package(s) are installed, but not recorded in the lockfile:
-                  _
-        bread       [1.0.0]
-        breakfast   [1.0.0]
-        oatmeal     [1.0.0]
-        toast       [1.0.0]
+      The following packages are recorded in the lockfile, but not installed:
+              _
+        bread   [1.0.0]
       
-      Use `renv::snapshot()` to add these packages to the lockfile.
+      Use `renv::restore()` to restore the packages recorded in the lockfile.
       
 
----
+# */recorded/not used
 
     Code
       status()
@@ -43,16 +59,18 @@
       Use `renv::snapshot()` if you'd like to remove these packages from the lockfile.
       
 
-# status reports packages which are used but not installed
+# other changes
 
     Code
       status()
     Output
-      The following packages are used in this project, but not installed:
+      The following package(s) are out of sync:
       
-      	bread
+         Package   Lockfile Version   Library Version
+             egg              2.0.0             1.0.0
+         oatmeal              0.9.0             1.0.0
       
-      Consider installing these packages -- for example, with `renv::install()`.
-      Use `renv::status()` afterwards to re-assess the project state.
+      Use `renv::snapshot()` to save the state of your library to the lockfile.
+      Use `renv::restore()` to restore your library from the lockfile.
       
 

--- a/tests/testthat/_snaps/status.md
+++ b/tests/testthat/_snaps/status.md
@@ -4,8 +4,8 @@
       status()
     Output
       The following packages are recorded in the lockfile, but not installed:
-              _
-        bread   [1.0.0]
+      
+      - bread [1.0.0]
       
       Use `renv::restore()` to restore the packages recorded in the lockfile.
       
@@ -16,8 +16,8 @@
       status()
     Output
       The following package(s) are installed, but not recorded in the lockfile:
-              _
-        bread   [1.0.0]
+      
+      - bread [1.0.0]
       
       Use `renv::snapshot()` to add these packages to the lockfile.
       
@@ -41,8 +41,8 @@
       status()
     Output
       The following packages are recorded in the lockfile, but not installed:
-              _
-        bread   [1.0.0]
+      
+      - bread [1.0.0]
       
       Use `renv::restore()` to restore the packages recorded in the lockfile.
       
@@ -53,8 +53,8 @@
       status()
     Output
       The following packages are recorded in the lockfile, but do not appear to be used in this project:
-            _
-        egg   [1.0.0]
+      
+      - egg [1.0.0]
       
       Use `renv::snapshot()` if you'd like to remove these packages from the lockfile.
       
@@ -64,11 +64,11 @@
     Code
       status()
     Output
-      The following package(s) are out of sync:
+      The following package(s) are out of sync [lockfile -> library]:
       
-         Package   Lockfile Version   Library Version
-             egg              2.0.0             1.0.0
-         oatmeal              0.9.0             1.0.0
+      # CRAN ===============================
+      - egg       [repo: * -> CRAN; ver: 2.0.0 -> 1.0.0]
+      - oatmeal   [repo: * -> CRAN; ver: 0.9.0 -> 1.0.0]
       
       Use `renv::snapshot()` to save the state of your library to the lockfile.
       Use `renv::restore()` to restore your library from the lockfile.

--- a/tests/testthat/test-status.R
+++ b/tests/testthat/test-status.R
@@ -1,29 +1,54 @@
+test_that("not installed/recorded/used", {
 
-test_that("status reports packages to be installed / changed", {
-
-  renv_tests_scope(c("toast", "breakfast"))
-  renv_scope_options(renv.config.auto.snapshot = FALSE)
-
-  init(bare = TRUE)
-  expect_snapshot({
-    snapshot()
-  })
-
-  install("breakfast")
-  expect_snapshot(status())
+  renv_tests_scope("bread")
+  init()
   snapshot()
+  remove("bread")
 
-  record("egg")
   expect_snapshot(status())
 
 })
 
-test_that("status reports packages which are used but not installed", {
+test_that("installed/not recorded/used", {
 
   renv_tests_scope()
   init()
-
+  install("bread")
   writeLines("library(bread)", con = "script.R")
+
+  expect_snapshot(status())
+
+})
+
+test_that("not installed/*/used", {
+
+  renv_tests_scope()
+  init()
+  writeLines("library(bread)", con = "script.R")
+  expect_snapshot(status())
+
+  record("bread")
+  expect_snapshot(status())
+
+})
+
+test_that("*/recorded/not used", {
+
+  renv_tests_scope()
+  init()
+  record("egg")
+
+  expect_snapshot(status())
+
+})
+
+test_that("other changes", {
+
+  renv_tests_scope(c("egg", "oatmeal"))
+  init()
+  record("egg@2.0.0")
+  record("oatmeal@0.9.0")
+
   expect_snapshot(status())
 
 })


### PR DESCRIPTION
* Use `renv_print_records_pair()` for {up,down,cross}grades
* Use matching bulleted list for other cases

Fixes #675. Built on top of #1365