### PR TITLE
Eliminate emitter and wrap arguments

### DIFF
--- a/R/abi.R
+++ b/R/abi.R
@@ -54,8 +54,7 @@ renv_abi_check <- function(packages = NULL,
           "however, Rcpp", renv_package_version("Rcpp"), "is currently installed."
         ),
         "Consider installing a new version of Rcpp with 'install.packages(\"Rcpp\")'."
-      ),
-      wrap = FALSE
+      )
     )
   }
 

--- a/R/cache.R
+++ b/R/cache.R
@@ -284,7 +284,7 @@ renv_cache_diagnose_corrupt_metadata <- function(paths, problems, verbose) {
       renv_pretty_print(
         renv_cache_format_path(bad),
         "The following package(s) are missing 'Meta/package.rds':",
-        "These packages should be purged and reinstalled.",
+        "These packages should be purged and reinstalled."
       )
     }
     # nocov end

--- a/R/cache.R
+++ b/R/cache.R
@@ -285,7 +285,6 @@ renv_cache_diagnose_corrupt_metadata <- function(paths, problems, verbose) {
         renv_cache_format_path(bad),
         "The following package(s) are missing 'Meta/package.rds':",
         "These packages should be purged and reinstalled.",
-        wrap = FALSE
       )
     }
     # nocov end
@@ -314,8 +313,7 @@ renv_cache_diagnose_corrupt_metadata <- function(paths, problems, verbose) {
       renv_pretty_print(
         renv_cache_format_path(bad),
         "The following package(s) have corrupt 'Meta/package.rds' files:",
-        "These packages should be purged and reinstalled.",
-        wrap = FALSE
+        "These packages should be purged and reinstalled."
       )
     }
     # nocov end
@@ -346,8 +344,7 @@ renv_cache_diagnose_missing_descriptions <- function(paths, problems, verbose) {
     renv_pretty_print(
       renv_cache_format_path(bad),
       "The following packages are missing DESCRIPTION files in the cache:",
-      "These packages should be purged and reinstalled.",
-      wrap = FALSE
+      "These packages should be purged and reinstalled."
     )
   }
   # nocov end
@@ -381,8 +378,7 @@ renv_cache_diagnose_bad_hash <- function(paths, problems, verbose) {
     renv_pretty_print(
       entries,
       "The following packages have incorrect hashes:",
-      "Consider using `renv::rehash()` to re-hash these packages.",
-      wrap = FALSE
+      "Consider using `renv::rehash()` to re-hash these packages."
     )
   }
   # nocov end
@@ -425,8 +421,7 @@ renv_cache_diagnose_wrong_built_version <- function(paths, problems, verbose) {
       renv_pretty_print(
         paths[isna],
         "The following packages have no 'Built' field recorded in their DESCRIPTION file:",
-        "renv is unable to validate the version of R this package was built for.",
-        wrap = FALSE
+        "renv is unable to validate the version of R this package was built for."
       )
 
     }
@@ -464,8 +459,7 @@ renv_cache_diagnose_wrong_built_version <- function(paths, problems, verbose) {
     renv_pretty_print(
       renv_cache_format_path(paths[wrong]),
       "The following packages in the cache were built for a different version of R:",
-      "These packages will need to be purged and reinstalled.",
-      wrap = FALSE
+      "These packages will need to be purged and reinstalled."
     )
 
   }

--- a/R/ci.R
+++ b/R/ci.R
@@ -67,10 +67,9 @@ renv_ci_repair <- function() {
 
   # notify the user
   renv_pretty_print(
-    values    = paste("-", packages),
+    values    = packages,
     preamble  = "The following package(s) could not be successfully loaded:",
-    postamble = "These packages will be removed and later reinstalled.",
-    wrap      = FALSE
+    postamble = "These packages will be removed and later reinstalled."
   )
 
   # remove each broken package

--- a/R/cite.R
+++ b/R/cite.R
@@ -42,8 +42,7 @@ cite <- function(type = c("plain", "bibtex"),
     renv_pretty_print(
       msg,
       "renv could not generate citations for the following packages:",
-      "You may need to manually form a citation for these packages.",
-      wrap = FALSE
+      "You may need to manually form a citation for these packages."
     )
 
   }

--- a/R/clean.R
+++ b/R/clean.R
@@ -134,8 +134,7 @@ renv_clean_library_tempdirs <- function(project, prompt) {
 
     renv_pretty_print(
       bad,
-      "The following directories will be removed:",
-      wrap = FALSE
+      "The following directories will be removed:"
     )
 
     if (prompt && !proceed())
@@ -277,8 +276,7 @@ renv_clean_package_locks <- function(project, prompt) {
     renv_pretty_print(
       basename(old),
       "The following stale package locks were discovered in your library:",
-      "These locks will be removed.",
-      wrap = FALSE
+      "These locks will be removed."
     )
 
     if (prompt && !proceed())
@@ -312,8 +310,7 @@ renv_clean_cache <- function(project, prompt) {
     renv_pretty_print(
       projlist[missing],
       "The following projects are monitored by renv, but no longer exist:",
-      "These projects will be removed from renv's project list.",
-      wrap = FALSE
+      "These projects will be removed from renv's project list."
     )
 
     if (prompt && !proceed())
@@ -349,8 +346,7 @@ renv_clean_cache <- function(project, prompt) {
     renv_pretty_print(
       renv_cache_format_path(diff),
       "The following packages are installed in the cache but no longer used:",
-      "These packages will be removed.",
-      wrap = FALSE
+      "These packages will be removed."
     )
 
     if (prompt && !proceed())

--- a/R/equip-macos.R
+++ b/R/equip-macos.R
@@ -83,8 +83,7 @@ renv_equip_macos_toolchain <- function() {
   renv_pretty_print(
     command,
     "The R LLVM toolchain has been successfully downloaded. Please execute:",
-    "in a separate terminal to complete installation.",
-    wrap = FALSE
+    "in a separate terminal to complete installation."
   )
 
   TRUE
@@ -127,8 +126,7 @@ renv_equip_macos_rstudio <- function(spec, destfile) {
   renv_pretty_print(
     spec$dst,
     "The R LLVM toolchain has been downloaded and installed to:",
-    "This toolchain will be used by renv when installing packages from source.",
-    wrap = FALSE
+    "This toolchain will be used by renv when installing packages from source."
   )
 
   return(TRUE)

--- a/R/extsoft.R
+++ b/R/extsoft.R
@@ -34,8 +34,7 @@ renv_extsoft_install <- function(quiet = FALSE) {
     renv_pretty_print(
       files,
       "The following external software tools will be installed:",
-      sprintf("Tools will be installed into %s.", renv_path_pretty(extsoft)),
-      wrap = FALSE
+      sprintf("Tools will be installed into %s.", renv_path_pretty(extsoft))
     )
 
     cancel_if(!proceed())
@@ -139,8 +138,7 @@ renv_extsoft_use <- function(quiet = FALSE) {
     renv_pretty_print(
       c(localsoft, libxml, localcpp, locallibs),
       "The following entries will be added to ~/.R/Makevars:",
-      "These tools will be used when compiling R packages from source.",
-      wrap = FALSE
+      "These tools will be used when compiling R packages from source."
     )
 
     cancel_if(!proceed())

--- a/R/hydrate.R
+++ b/R/hydrate.R
@@ -373,8 +373,7 @@ renv_hydrate_resolve_missing <- function(project, library, na) {
     renv_pretty_print(
       text,
       "The following package(s) were not installed successfully:",
-      "You may need to manually download and install these packages.",
-      wrap = FALSE
+      "You may need to manually download and install these packages."
     )
 
   }

--- a/R/install.R
+++ b/R/install.R
@@ -650,8 +650,7 @@ renv_install_preflight_requirements <- function(records) {
     renv_pretty_print(
       text,
       "The following issues were discovered while preparing for installation:",
-      "Installation of these packages may not succeed.",
-      wrap = FALSE
+      "Installation of these packages may not succeed."
     )
   }
 
@@ -700,8 +699,7 @@ renv_install_postamble <- function(packages) {
     renv_pretty_print(
       text,
       "The following package(s) have been updated:",
-      "Consider restarting the R session and loading the newly-installed packages.",
-      wrap = FALSE
+      "Consider restarting the R session and loading the newly-installed packages."
     )
   }
   # nocov end
@@ -740,8 +738,7 @@ renv_install_preflight_permissions <- function(library) {
     renv_pretty_print(
       values = library,
       preamble = preamble,
-      postamble = postamble,
-      wrap = FALSE
+      postamble = postamble
     )
 
   }

--- a/R/library.R
+++ b/R/library.R
@@ -25,8 +25,7 @@ renv_library_diagnose <- function(project, libpath) {
     renv_pretty_print(
       basename(children[missing]),
       "The following package(s) are missing entries in the cache:",
-      "These packages will need to be reinstalled.",
-      warningf
+      "These packages will need to be reinstalled."
     )
 
     return(FALSE)

--- a/R/load.R
+++ b/R/load.R
@@ -711,8 +711,7 @@ renv_load_check_description <- function(project) {
     postamble = c(
       "DESCRIPTION files cannot contain blank lines between fields.",
       "Please remove these blank lines from the file."
-    ),
-    wrap = FALSE
+    )
   )
 
   return(FALSE)

--- a/R/lockfile-read.R
+++ b/R/lockfile-read.R
@@ -60,9 +60,7 @@ renv_lockfile_read_preflight <- function(contents) {
     renv_pretty_print(
       values    = head(all, n = -1L),
       preamble  = "The lockfile contains one or more merge conflict markers:",
-      postamble = "You will need to resolve these merge conflicts before the file can be read.",
-      emitter   = message,
-      wrap      = FALSE
+      postamble = "You will need to resolve these merge conflicts before the file can be read."
     )
 
     stop("lockfile contains merge conflict markers; cannot proceed", call. = FALSE)

--- a/R/modify.R
+++ b/R/modify.R
@@ -65,19 +65,16 @@ renv_modify_interactive <- function(project) {
   renv_file_edit(templock)
 
   # check that the new lockfile can be read
-  lockfile <- catch(renv_lockfile_read(file = templock))
-  if (inherits(lockfile, "error")) {
-
-    renv_pretty_print(
-      conditionMessage(lockfile),
-      preamble  = "renv was uanble to parse the modified lockfile:",
-      postamble = "Your changes will be discarded.",
-      wrap = FALSE
-    )
-
-    stop("error modifying lockfile")
-
-  }
+  withCallingHandlers(
+    lockfile <- catch(renv_lockfile_read(file = templock)),
+    error = function(cnd) {
+      stop(lines(
+        "renv was unable to parse the modified lockfile:",
+        conditionMessage(cnd),
+        "Your changes will be discarded"
+      ))
+    }
+  )
 
   lockfile
 

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -1,9 +1,7 @@
 
 renv_pretty_print <- function(values,
                               preamble  = NULL,
-                              postamble = NULL,
-                              emitter   = NULL,
-                              wrap      = TRUE)
+                              postamble = NULL)
 {
   if (!renv_verbose())
     return()
@@ -17,12 +15,7 @@ renv_pretty_print <- function(values,
     msg$push("")
   }
 
-  formatted <- if (wrap)
-    strwrap(paste(values, collapse = ", "), width = 60)
-  else
-    values
-
-  msg$push(paste("\t", formatted, sep = "", collapse = "\n"))
+  msg$push(paste0("- ", values, collapse = "\n"))
 
   if (!is.null(postamble)) {
     msg$push("")

--- a/R/purge.R
+++ b/R/purge.R
@@ -90,8 +90,7 @@ renv_purge_impl <- function(package,
     renv_pretty_print(
       paths[missing],
       "The following entries were not found in the cache:",
-      "They will be ignored.",
-      wrap = FALSE
+      "They will be ignored."
     )
 
     paths <- paths[!missing]
@@ -103,8 +102,7 @@ renv_purge_impl <- function(package,
 
     renv_pretty_print(
       renv_cache_format_path(paths),
-      "The following packages will be purged from the cache:",
-      wrap = FALSE
+      "The following packages will be purged from the cache:"
     )
 
     cancel_if(prompt && !proceed())

--- a/R/python-virtualenv.R
+++ b/R/python-virtualenv.R
@@ -97,8 +97,7 @@ renv_python_virtualenv_snapshot <- function(project, prompt, python) {
 
   renv_pretty_print(
     values   = after,
-    preamble = "The following will be written to requirements.txt:",
-    wrap     = FALSE
+    preamble = "The following will be written to requirements.txt:"
   )
 
   cancel_if(prompt && !proceed())
@@ -129,8 +128,7 @@ renv_python_virtualenv_restore <- function(project, prompt, python) {
 
   renv_pretty_print(
     values   = diff,
-    preamble = "The following Python packages will be restored:",
-    wrap     = FALSE
+    preamble = "The following Python packages will be restored:"
   )
 
   cancel_if(prompt && !proceed())

--- a/R/rehash.R
+++ b/R/rehash.R
@@ -56,8 +56,7 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
     renv_pretty_print(
       sprintf(fmt, format(packages), format(oldhash), format(newhash)),
       "The following packages will be re-cached:",
-      sprintf("Packages will be %s to their new locations in the cache.", label),
-      wrap = FALSE
+      sprintf("Packages will be %s to their new locations in the cache.", label)
     )
 
     cancel_if(prompt && !proceed())

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -657,8 +657,7 @@ renv_retrieve_repos_error_report <- function(record, errors) {
 
   renv_pretty_print(
     values   = paste("-", messages),
-    preamble = preamble,
-    wrap     = FALSE
+    preamble = preamble
   )
 
   if (renv_verbose())
@@ -1234,8 +1233,7 @@ renv_retrieve_incompatible_report <- function(package, record, replacement, comp
     renv_pretty_print(
       values = values,
       preamble = preamble,
-      postamble = postamble,
-      wrap = FALSE
+      postamble = postamble
     )
   }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -397,8 +397,7 @@ renv_snapshot_validate_bioconductor <- function(project, lockfile, libpaths) {
       c(
         "renv may be unable to restore these packages.",
         paste("Bioconductor version:", version)
-      ),
-      wrap = FALSE
+      )
     )
 
     ok <- FALSE
@@ -453,8 +452,7 @@ renv_snapshot_validate_dependencies_available <- function(project, lockfile, lib
   renv_pretty_print(
     sprintf("%s  [required by %s]", format(missing), usedby),
     "The following required packages are not installed:",
-    "Consider reinstalling these packages before snapshotting the lockfile.",
-    wrap = FALSE
+    "Consider reinstalling these packages before snapshotting the lockfile."
   )
 
   FALSE
@@ -519,7 +517,6 @@ renv_snapshot_validate_dependencies_compatible <- function(project, lockfile, li
     txt,
     "The following package(s) have unsatisfied dependencies:",
     "Consider updating the required dependencies as appropriate.",
-    wrap = FALSE
   )
 
   FALSE
@@ -669,8 +666,7 @@ renv_snapshot_library_diagnose_missing_description <- function(library, pkgs) {
     c(
       "These may be left over from a prior, failed installation attempt.",
       "Consider removing or reinstalling these packages."
-    ),
-    wrap = FALSE
+    )
   )
 
   pkgs[!missing]

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -516,7 +516,7 @@ renv_snapshot_validate_dependencies_compatible <- function(project, lockfile, li
   renv_pretty_print(
     txt,
     "The following package(s) have unsatisfied dependencies:",
-    "Consider updating the required dependencies as appropriate.",
+    "Consider updating the required dependencies as appropriate."
   )
 
   FALSE

--- a/R/tests.R
+++ b/R/tests.R
@@ -62,30 +62,26 @@ renv_tests_diagnostics <- function() {
   # print library paths
   renv_pretty_print(
     paste("-", .libPaths()),
-    "The following R libraries are set:",
-    wrap = FALSE
+    "The following R libraries are set:"
   )
 
   # print repositories
   repos <- getOption("repos")
   renv_pretty_print(
     paste(names(repos), repos, sep = ": "),
-    "The following repositories are set:",
-    wrap = FALSE
+    "The following repositories are set:"
   )
 
   # print renv root
   renv_pretty_print(
     paste("-", paths$root()),
-    "The following renv root directory is being used:",
-    wrap = FALSE
+    "The following renv root directory is being used:"
   )
 
   # print cache root
   renv_pretty_print(
     paste("-", paths$cache()),
     "The following renv cache directory is being used:",
-    wrap = FALSE
   )
 
   writeLines("The following packages are available in the test repositories:")
@@ -104,8 +100,7 @@ renv_tests_diagnostics <- function() {
 
   renv_pretty_print(
     paste("-", splat),
-    "The following PATH is set:",
-    wrap = FALSE
+    "The following PATH is set:"
   )
 
   envvars <- c(
@@ -123,8 +118,7 @@ renv_tests_diagnostics <- function() {
 
   renv_pretty_print(
     paste(keys, vals, sep = " : "),
-    "The following environment variables of interest are set:",
-    wrap = FALSE
+    "The following environment variables of interest are set:"
   )
 
 }

--- a/R/update.R
+++ b/R/update.R
@@ -251,8 +251,7 @@ update <- function(packages = NULL,
       renv_pretty_print(
         missing,
         "The following package(s) are not currently installed:",
-        "The latest available versions of these packages will be installed instead.",
-        wrap = FALSE
+        "The latest available versions of these packages will be installed instead."
       )
     }
 
@@ -399,8 +398,7 @@ renv_update_errors_emit_impl <- function(key, preamble, postamble) {
   renv_pretty_print(
     values = messages,
     preamble = preamble,
-    postamble = postamble,
-    wrap = FALSE
+    postamble = postamble
   )
 
 }

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -8,7 +8,7 @@
       Installed 1 package into library at path "<tempdir>/<renv-library>".
       The following package(s) have been updated:
       
-      	bread [installed version 0.1.0 != loaded version 1.0.0]
+      - bread [installed version 0.1.0 != loaded version 1.0.0]
       
       Consider restarting the R session and loading the newly-installed packages.
       

--- a/tests/testthat/_snaps/preflight.md
+++ b/tests/testthat/_snaps/preflight.md
@@ -5,7 +5,7 @@
     Output
       The following required packages are not installed:
       
-      	oatmeal  [required by breakfast]
+      - oatmeal  [required by breakfast]
       
       Consider reinstalling these packages before snapshotting the lockfile.
       

--- a/tests/testthat/_snaps/pretty.md
+++ b/tests/testthat/_snaps/pretty.md
@@ -1,0 +1,28 @@
+# renv_pretty_print() creates bulleted list with optional preamble/postable
+
+    Code
+      renv_pretty_print(letters[1:3])
+    Output
+      - a
+      - b
+      - c
+      
+    Code
+      renv_pretty_print(letters[1:3], preamble = "before")
+    Output
+      before
+      
+      - a
+      - b
+      - c
+      
+    Code
+      renv_pretty_print(letters[1:3], postamble = "after")
+    Output
+      - a
+      - b
+      - c
+      
+      after
+      
+

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -55,8 +55,15 @@
 
     Code
       snapshot()
+    Output
+      The following package(s) have unsatisfied dependencies:
+      
+      - toast requires bread (> 1.0.0), but version 1.0.0 is installed
+      
+      Consider updating the required dependencies as appropriate.
+      
     Error <simpleError>
-      unused argument (alist())
+      aborting snapshot due to pre-flight validation failure
 
 # renv reports missing packages in explicit snapshots
 

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -5,14 +5,14 @@
     Output
       The following package(s) are missing their DESCRIPTION files:
       
-      	oatmeal [<wd>/renv/library/<platform-prefix>/oatmeal]
+      - oatmeal [<wd>/renv/library/<platform-prefix>/oatmeal]
       
       These may be left over from a prior, failed installation attempt.
       Consider removing or reinstalling these packages.
       
       The following required packages are not installed:
       
-      	oatmeal
+      - oatmeal
       
       Packages must first be installed before renv can snapshot them.
       Consider installing these packages using `renv::install()`.
@@ -32,13 +32,13 @@
     Output
       The following package(s) have broken symlinks into the cache:
       
-      	oatmeal
+      - oatmeal
       
       Use `renv::repair()` to try and reinstall these packages.
       
       The following required packages are not installed:
       
-      	oatmeal
+      - oatmeal
       
       Packages must first be installed before renv can snapshot them.
       Consider installing these packages using `renv::install()`.
@@ -55,15 +55,8 @@
 
     Code
       snapshot()
-    Output
-      The following package(s) have unsatisfied dependencies:
-      
-      	toast requires bread (> 1.0.0), but version 1.0.0 is installed
-      
-      Consider updating the required dependencies as appropriate.
-      
     Error <simpleError>
-      aborting snapshot due to pre-flight validation failure
+      unused argument (alist())
 
 # renv reports missing packages in explicit snapshots
 
@@ -72,7 +65,7 @@
     Output
       The following required packages are not installed:
       
-      	breakfast
+      - breakfast
       
       Packages must first be installed before renv can snapshot them.
       Consider installing these packages using `renv::install()`.
@@ -87,7 +80,7 @@
     Output
       The following required packages are not installed:
       
-      	breakfast
+      - breakfast
       
       Packages must first be installed before renv can snapshot them.
       Consider installing these packages using `renv::install()`.
@@ -110,7 +103,7 @@
     Output
       The following required packages are not installed:
       
-      	toast  [required by breakfast]
+      - toast  [required by breakfast]
       
       Consider reinstalling these packages before snapshotting the lockfile.
       

--- a/tests/testthat/_snaps/status.md
+++ b/tests/testthat/_snaps/status.md
@@ -29,7 +29,7 @@
     Output
       The following packages are used in this project, but not installed:
       
-      	bread
+      - bread
       
       Consider installing these packages -- for example, with `renv::install()`.
       Use `renv::status()` afterwards to re-assess the project state.

--- a/tests/testthat/test-pretty.R
+++ b/tests/testthat/test-pretty.R
@@ -1,0 +1,12 @@
+test_that("renv_pretty_print() creates bulleted list with optional preamble/postable", {
+  expect_snapshot({
+    renv_pretty_print(letters[1:3])
+    renv_pretty_print(letters[1:3], preamble = "before")
+    renv_pretty_print(letters[1:3], postamble = "after")
+  })
+})
+
+test_that("renv_pretty_print() doesn't show pre/post amble if no values", {
+  expect_silent(renv_pretty_print(character(), "before", "after"))
+
+})


### PR DESCRIPTION
* All calls either do set `wrap = FALSE` or (IMO) should set `wrap = FALSE`
* Use `-` instead of tab to make a bulleted list
* The emitter argument didn't have any affect