### PR TITLE
Experiment: make `renv_pretty_print()` more compact

### DIFF
--- a/R/pretty.R
+++ b/R/pretty.R
@@ -12,13 +12,11 @@ renv_pretty_print <- function(values,
 
   if (!is.null(preamble)) {
     msg$push(paste(preamble, collapse = "\n"))
-    msg$push("")
   }
 
   msg$push(paste0("- ", values, collapse = "\n"))
 
   if (!is.null(postamble)) {
-    msg$push("")
     msg$push(paste(postamble, collapse = "\n"))
   }
 

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -17,9 +17,7 @@
       Installed 1 package in XXXX seconds.
       
       The following package(s) have been updated:
-      
       - bread [installed version 0.1.0 != loaded version 1.0.0]
-      
       Consider restarting the R session and loading the newly-installed packages.
       
 

--- a/tests/testthat/_snaps/preflight.md
+++ b/tests/testthat/_snaps/preflight.md
@@ -4,9 +4,7 @@
       snapshot()
     Output
       The following required packages are not installed:
-      
       - oatmeal  [required by breakfast]
-      
       Consider reinstalling these packages before snapshotting the lockfile.
       
     Error <simpleError>

--- a/tests/testthat/_snaps/pretty.md
+++ b/tests/testthat/_snaps/pretty.md
@@ -11,7 +11,6 @@
       renv_pretty_print(letters[1:3], preamble = "before")
     Output
       before
-      
       - a
       - b
       - c
@@ -22,7 +21,6 @@
       - a
       - b
       - c
-      
       after
       
 

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -4,16 +4,12 @@
       snapshot()
     Output
       The following package(s) are missing their DESCRIPTION files:
-      
       - oatmeal [<wd>/renv/library/<platform-prefix>/oatmeal]
-      
       These may be left over from a prior, failed installation attempt.
       Consider removing or reinstalling these packages.
       
       The following required packages are not installed:
-      
       - oatmeal
-      
       Packages must first be installed before renv can snapshot them.
       Consider installing these packages using `renv::install()`.
       Use `renv::dependencies()` to see where this package is used in your project.
@@ -31,15 +27,11 @@
       snapshot()
     Output
       The following package(s) have broken symlinks into the cache:
-      
       - oatmeal
-      
       Use `renv::repair()` to try and reinstall these packages.
       
       The following required packages are not installed:
-      
       - oatmeal
-      
       Packages must first be installed before renv can snapshot them.
       Consider installing these packages using `renv::install()`.
       Use `renv::dependencies()` to see where this package is used in your project.
@@ -57,9 +49,7 @@
       snapshot()
     Output
       The following package(s) have unsatisfied dependencies:
-      
       - toast requires bread (> 1.0.0), but version 1.0.0 is installed
-      
       Consider updating the required dependencies as appropriate.
       
     Error <simpleError>
@@ -71,9 +61,7 @@
       snapshot(type = "explicit")
     Output
       The following required packages are not installed:
-      
       - breakfast
-      
       Packages must first be installed before renv can snapshot them.
       Consider installing these packages using `renv::install()`.
       If these packages are no longer required, consider removing them from your DESCRIPTION file.
@@ -86,9 +74,7 @@
       snapshot()
     Output
       The following required packages are not installed:
-      
       - breakfast
-      
       Packages must first be installed before renv can snapshot them.
       Consider installing these packages using `renv::install()`.
       Use `renv::dependencies()` to see where this package is used in your project.
@@ -109,9 +95,7 @@
       snapshot()
     Output
       The following required packages are not installed:
-      
       - toast  [required by breakfast]
-      
       Consider reinstalling these packages before snapshotting the lockfile.
       
     Error <simpleError>

--- a/tests/testthat/_snaps/status.md
+++ b/tests/testthat/_snaps/status.md
@@ -28,9 +28,7 @@
       status()
     Output
       The following packages are used in this project, but not installed:
-      
       - bread
-      
       Consider installing these packages -- for example, with `renv::install()`.
       Use `renv::status()` afterwards to re-assess the project state.
       


### PR DESCRIPTION
I'm not sure how I feel about this. I like that it makes each call feel more like a related block (reserving empty lines to separate outputs) but maybe it becomes a bit too dense?