### PR TITLE
Only report slow dependency discovery for implicit type

### DIFF
--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -893,9 +893,6 @@ renv_snapshot_filter <- function(project, records, type, packages, exclude) {
   if (length(exclude))
     result <- exclude(result, exclude)
 
-  if (type %in% c("all", "explicit"))
-    return(result)
-
   result
 
 }

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -126,3 +126,12 @@
       - R   [4.1 -> 4.2]
       
 
+# useful error message if implicit dep discovery is slow
+
+    Code
+      . <- renv_snapshot_filter_implicit(getwd(), NULL)
+    Output
+      NOTE: Dependency discovery took XXXX seconds during snapshot.
+      Consider using .renvignore to ignore files or switching to explicit snapshots
+      See `?dependencies` for more information.
+

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -446,7 +446,7 @@ test_that("useful error message if implicit dep discovery is slow", {
 
   renv_tests_scope()
 
-  renv_scope_options(renv.snapshot.filter.timelimit = 0)
+  renv_scope_options(renv.snapshot.filter.timelimit = -1)
   expect_snapshot(
     . <- renv_snapshot_filter_implicit(getwd(), NULL)
   )

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -440,3 +440,15 @@ test_that("snapshot always reports on R version changes", {
     renv_snapshot_report_actions(list(), R4.1, R4.2)
   })
 })
+
+
+test_that("useful error message if implicit dep discovery is slow", {
+
+  renv_tests_scope()
+
+  renv_scope_options(renv.snapshot.filter.timelimit = 0)
+  expect_snapshot(
+    . <- renv_snapshot_filter_implicit(getwd(), NULL)
+  )
+
+})


### PR DESCRIPTION
This was motivated by #1198 where in one of the examples I noticed:

```
NOTE: Dependency discovery took 11 seconds during snapshot.
Consider using .renvignore to ignore files -- see `?dependencies` for more information.
```

That occurs because the current code includes time spent waiting for the prompt. That seemed like a potentially confusing red herring to me , so I moved the time tracking to `renv_snapshot_filter_implicit()`. I think this is correct as (a) it's the only type that's likely to be slow and (b) it's the only type affected by `.renvignore`.