### PR TITLE
Refactor dependency handling in install()

### DIFF
--- a/R/description.R
+++ b/R/description.R
@@ -145,40 +145,6 @@ renv_description_parse_field <- function(field) {
 
 }
 
-renv_description_remotes <- function(descpath) {
-
-  # read Remotes field from DESCRIPTION
-  desc <- renv_description_read(path = descpath)
-  remotes <- desc[["Remotes"]]
-  if (is.null(remotes))
-    return(NULL)
-
-  # parse each remote entry
-  entries <- strsplit(remotes, "\\s*,\\s*", perl = TRUE)[[1L]]
-  parsed <- map(entries, renv_description_remotes_parse)
-
-  # ensure named
-  names(parsed) <- map_chr(parsed, `[[`, "Package")
-
-  # and return
-  parsed
-
-}
-
-renv_description_remotes_parse <- function(entry) {
-
-  status <- catch(renv_remotes_resolve(entry))
-
-  if (inherits(status, "error")) {
-    fmt <- "failed to resolve remote '%s' from project DESCRIPTION file; skipping"
-    warningf(fmt, entry)
-    return(NULL)
-  }
-
-  status
-
-}
-
 renv_description_resolve <- function(path) {
 
   case(

--- a/R/install.R
+++ b/R/install.R
@@ -729,7 +729,6 @@ renv_install_remotes_update <- function(records, project, all = TRUE) {
     record <- records[[package]]
 
     update <- all ||
-      is.null(record) ||
       identical(record, list(Package = package, Source = "Repository"))
 
     if (update)

--- a/R/install.R
+++ b/R/install.R
@@ -719,7 +719,7 @@ renv_install_preflight <- function(project, libpaths, records) {
 
 renv_install_remotes_update <- function(records, project, all = TRUE) {
 
-  remotes <- renv_project_remotes_description(project)
+  remotes <- renv_project_remotes(project)
   if (empty(remotes))
     return(records)
 

--- a/R/project.R
+++ b/R/project.R
@@ -99,14 +99,14 @@ renv_project_type_impl <- function(path) {
 
 }
 
-renv_project_remotes_description <- function(project, fields = NULL) {
+renv_project_remotes <- function(project, fields = NULL) {
 
   descpath <- file.path(project, "DESCRIPTION")
   if (!file.exists(descpath))
     return(NULL)
 
   # first, parse remotes (if any)
-  remotes <- renv_project_remotes_description_remotes(project, descpath)
+  remotes <- renv_project_remotes_field(project, descpath)
 
   # next, find packages mentioned in the DESCRIPTION file
   fields <- fields %||% c("Depends", "Imports", "LinkingTo", "Suggests")
@@ -165,7 +165,7 @@ renv_project_remotes_description <- function(project, fields = NULL) {
 
 }
 
-renv_project_remotes_description_remotes <- function(project, descpath) {
+renv_project_remotes_field <- function(project, descpath) {
 
   desc <- renv_description_read(descpath)
 

--- a/R/project.R
+++ b/R/project.R
@@ -99,28 +99,11 @@ renv_project_type_impl <- function(path) {
 
 }
 
-renv_project_remotes <- function(project, fields = NULL) {
+renv_project_remotes_description <- function(project, fields = NULL) {
 
-  # if this project has a DESCRIPTION file, use it to provide records
   descpath <- file.path(project, "DESCRIPTION")
-  if (file.exists(descpath))
-    return(renv_project_remotes_description(project, descpath, fields))
-
-  # otherwise, use the set of (non-base) packages used in the project
-  deps <- dependencies(
-    path     = project,
-    progress = FALSE,
-    errors   = "ignored",
-    dev      = TRUE
-  )
-
-  packages <- sort(unique(deps$Package))
-  ignored <- c("renv", renv_project_ignored_packages(project))
-  setdiff(packages, ignored)
-
-}
-
-renv_project_remotes_description <- function(project, descpath, fields = NULL) {
+  if (!file.exists(descpath))
+    return(NULL)
 
   # first, parse remotes (if any)
   remotes <- renv_project_remotes_description_remotes(project, descpath)

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -18,9 +18,13 @@ test_that("requested version in DESCRIPTION file is honored", {
   )
   writeLines(desc, con = "DESCRIPTION")
 
-  install()
-
+  records <- install()
+  expect_length(records, 2L)
   expect_true(renv_package_version("bread") == "0.1.0")
+
+  # try calling install once more; nothing should happen
+  records <- install()
+  expect_length(records, 0L)
 
 })
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -18,13 +18,8 @@ test_that("requested version in DESCRIPTION file is honored", {
   )
   writeLines(desc, con = "DESCRIPTION")
 
-  records <- install()
-  expect_length(records, 2L)
+  install()
   expect_true(renv_package_version("bread") == "0.1.0")
-
-  # try calling install once more; nothing should happen
-  records <- install()
-  expect_length(records, 0L)
 
 })
 
@@ -279,10 +274,16 @@ test_that("install() installs inferred dependencies", {
   renv_tests_scope("breakfast")
 
   # try installing packages
-  install()
+  records <- install()
 
   # validate that we've installed breakfast + deps
+  expect_length(records, 2L)
   expect_true(renv_package_installed("breakfast"))
+
+  # try calling install once more; nothing should happen
+  records <- install()
+  expect_length(records, 0L)
+
 
 })
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -278,7 +278,7 @@ test_that("install() installs inferred dependencies", {
   records <- install()
 
   # validate that we've installed breakfast + deps
-  expect_length(records, 2L)
+  expect_length(records, 4L)
   expect_true(renv_package_installed("breakfast"))
 
   # try calling install once more; nothing should happen

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -19,6 +19,7 @@ test_that("requested version in DESCRIPTION file is honored", {
   writeLines(desc, con = "DESCRIPTION")
 
   install()
+
   expect_true(renv_package_version("bread") == "0.1.0")
 
 })
@@ -283,7 +284,6 @@ test_that("install() installs inferred dependencies", {
   # try calling install once more; nothing should happen
   records <- install()
   expect_length(records, 0L)
-
 
 })
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -155,7 +155,6 @@ test_that("Remotes fields in a project DESCRIPTION are respected", {
   skip_if_no_github_auth()
 
   renv_tests_scope()
-  renv_scope_options(repos = character())
   init()
 
   desc <- c(
@@ -275,20 +274,11 @@ test_that("install() installs inferred dependencies", {
   skip_on_cran()
   renv_tests_scope("breakfast")
 
-  # use dummy library path
-  templib <- renv_scope_tempfile("renv-library-")
-  ensure_directory(templib)
-  renv_scope_libpaths(templib)
-
   # try installing packages
   install()
 
   # validate that we've installed breakfast + deps
   expect_true(renv_package_installed("breakfast"))
-
-  # try calling install once more; nothing should happen
-  records <- install()
-  expect_length(records, 0L)
 
 })
 

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -115,7 +115,7 @@ test_that("profile-specific remotes are parsed", {
   ')
 
   writeLines(desc, con = "DESCRIPTION")
-  remotes <- renv_project_remotes_description(project)
+  remotes <- renv_project_remotes(project)
 
   actual <- remotes$bread
   expected <- list(Package = "bread", Version = "0.1.0", Source = "Repository")

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -115,7 +115,7 @@ test_that("profile-specific remotes are parsed", {
   ')
 
   writeLines(desc, con = "DESCRIPTION")
-  remotes <- renv_project_remotes(project)
+  remotes <- renv_project_remotes_description(project)
 
   actual <- remotes$bread
   expected <- list(Package = "bread", Version = "0.1.0", Source = "Repository")


### PR DESCRIPTION
Now we first discover all dependencies then update those generic records with specifics found in the `DESCRIPTION`.