### PR TITLE
Don't prompt when automatically installing BiocManager

### DIFF
--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -16,7 +16,7 @@ renv_bioconductor_init_biocmanager <- function(library = NULL) {
     return(TRUE)
 
   ensure_directory(library)
-  install("BiocManager", library = library)
+  install("BiocManager", library = library, prompt = FALSE)
   TRUE
 
 }


### PR DESCRIPTION
This is now needed so you don't get an additional prompt that `prompt` argument to `install()` doesn't affect. There might be a better way to handle this, but this is a quick fix to resolve the issue.