### PR TITLE
Add example for setting renv.auth per package as function

### DIFF
--- a/vignettes/package-install.Rmd
+++ b/vignettes/package-install.Rmd
@@ -299,7 +299,12 @@ options(renv.auth = list(
 ))
 
 # alternatively, set package-specific option
+# as a list
 options(renv.auth.MyPackage = list(GITHUB_PAT = "<pat>"))
+# as a function
+options(renv.auth.MyPackage = function(record) {
+   list(GITHUB_PAT = "<pat>")
+})
 ```
 
 For packages installed from Git remotes, renv will attempt to use `git` from the command line to download and restore the associated package.


### PR DESCRIPTION
`renv.auth` option for specific package could be set as a list, but also as a function with single argument record, similarly, but not exactly the same, to general renv.auth function.

I had a case where passing the option as a function was the most convenient solution, and I'd appreciate if this was explicitly listed as a viable alternative in vignette. Hope it's not some unrecommended solution or anything.