### PR TITLE
Implement dev filtering in `renv_dependencies_impl()`

### DIFF
--- a/R/checkout.R
+++ b/R/checkout.R
@@ -87,7 +87,12 @@ checkout <- function(repos = NULL,
 }
 
 renv_checkout_packages <- function(project) {
-  renv_dependencies_impl(project, progress = FALSE, field = "Package")
+  renv_dependencies_impl(
+    project,
+    progress = FALSE,
+    field = "Package",
+    dev = TRUE
+  )
 }
 
 renv_checkout_remotes <- function(packages, project) {

--- a/R/clean.R
+++ b/R/clean.R
@@ -216,7 +216,7 @@ renv_clean_unused_packages <- function(project, prompt) {
     return(ntd())
 
   # find packages used in the project and their dependencies
-  deps <- dependencies(project, progress = FALSE)
+  deps <- renv_dependencies_impl(project, progress = FALSE)
   paths <- renv_package_dependencies(deps$Package, project = project)
   packages <- names(paths)
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -174,7 +174,7 @@ dependencies <- function(
 {
   renv_scope_error_handler()
 
-  deps <- renv_dependencies_impl(
+  renv_dependencies_impl(
     path     = path,
     root     = root,
     progress = progress,
@@ -182,14 +182,6 @@ dependencies <- function(
     dev      = dev,
     ...
   )
-
-  if (empty(deps) || nrow(deps) == 0L)
-    return(renv_dependencies_list_empty())
-
-  # drop NAs, and only keep 'dev' dependencies if requested
-  deps <- deps[deps$Dev %in% c(dev, FALSE), ]
-
-  deps
 }
 
 renv_dependencies_impl <- function(
@@ -236,6 +228,13 @@ renv_dependencies_impl <- function(
   files <- renv_dependencies_find(path, root)
   deps <- renv_dependencies_discover(files, progress, errors)
   renv_dependencies_report(errors)
+
+  if (empty(deps) || nrow(deps) == 0L) {
+    deps <- renv_dependencies_list_empty()
+  } else {
+    # drop NAs, and only keep 'dev' dependencies if requested
+    deps <- deps[deps$Dev %in% c(dev, FALSE), ]
+  }
 
   take(deps, field)
 }
@@ -1667,7 +1666,7 @@ renv_dependencies_scope <- function(path, action, envir = NULL) {
   message <- paste(action, "aborted")
 
   deps <- withCallingHandlers(
-    dependencies(path, progress = FALSE, errors = errors, dev = TRUE),
+    renv_dependencies_impl(path, progress = FALSE, errors = errors, dev = TRUE),
     renv.dependencies.error = renv_dependencies_error_handler(message, errors)
   )
 

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -183,10 +183,12 @@ renv_diagnostics_packages_library <- function(project) {
 
 renv_diagnostics_packages_dependencies <- function(project) {
 
-  dependencies(project,
-               progress = FALSE,
-               errors = "reported",
-               dev = TRUE)
+  renv_dependencies_impl(
+    project,
+    progress = FALSE,
+    errors = "reported",
+    dev = TRUE
+  )
 
 }
 
@@ -210,10 +212,12 @@ renv_diagnostics_profile <- function(project) {
   if (!file.exists(userprofile))
     return(writef("[no user profile detected]"))
 
-  deps <- dependencies(userprofile,
-                       progress = FALSE,
-                       errors = "reported",
-                       dev = TRUE)
+  deps <- renv_dependencies_impl(
+    userprofile,
+    progress = FALSE,
+    errors = "reported",
+    dev = TRUE
+  )
 
   if (empty(deps))
     return(writef("[no R packages referenced in user profile"))

--- a/R/embed.R
+++ b/R/embed.R
@@ -106,7 +106,7 @@ renv_embed_create <- function(path = NULL,
   lockfile <- renv_embed_lockfile_resolve(lockfile, project)
 
   # figure out recursive package dependencies
-  deps <- dependencies(path, progress = FALSE)
+  deps <- renv_dependencies_impl(path, progress = FALSE)
   packages <- sort(unique(deps$Package))
   all <- renv_package_dependencies(packages)
 

--- a/R/graph.R
+++ b/R/graph.R
@@ -215,7 +215,7 @@ renv_graph_revdeps_impl <- function(package, envir, revdeps) {
 
 renv_graph_roots <- function(project) {
 
-  deps <- dependencies(project, quiet = TRUE)
+  deps <- renv_dependencies_impl(project, quiet = TRUE)
   sort(unique(deps$Package))
 
 }

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -867,7 +867,8 @@ renv_snapshot_dependencies <- function(project, type = NULL) {
       root     = project,
       progress = FALSE,
       field    = "Package",
-      errors   = errors
+      errors   = errors,
+      dev      = TRUE
     ),
 
     renv.dependencies.error = renv_dependencies_error_handler(message, errors)

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -1,4 +1,14 @@
 
+test_that("can select fields", {
+
+  renv_tests_scope()
+  expect_equal(renv_dependencies_impl(field = "Package"), character())
+
+  writeLines("library(utils)", "deps.R")
+  expect_equal(renv_dependencies_impl(field = "Package"), "utils")
+
+})
+
 test_that(".Rproj files requesting devtools is handled", {
   renv_tests_scope()
   writeLines("PackageUseDevtools: Yes", "project.Rproj")


### PR DESCRIPTION
* Previously the `dev` argument did nothing, but the default make it seem like dev deps would have been filtered out.

* Systematically use `renv_dependencies_impl()` instead of `dependencies()`

* Implementing `renv_dependencies_impl()` allows us to return a single field while filtering for dev deps.