### PR TITLE
Simplify handling of `Suggested` dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # renv 0.18.0  (UNRELEASED)
 
+* `dependencies()` now marks `Suggested` packages listed in `DESCRIPTION` files
+  as development dependencies regardless of whether or not they're in 
+  "package" project.
+
 * If `renv::snapshot()` finds missing packages, a new prompt allows you to 
   install them before continuing (#1198).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
   as development dependencies regardless of whether or not they're in 
   "package" project.
 
+* `settings$package.dependency.fields()` now only affects packages installed
+  directly by the user, not downstream dependencies of those packages.
+
 * If `renv::snapshot()` finds missing packages, a new prompt allows you to 
   install them before continuing (#1198).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,8 @@
 # renv 0.18.0  (UNRELEASED)
 
 * `dependencies()` now marks `Suggested` packages listed in `DESCRIPTION` files
-  as development dependencies regardless of whether or not they're in 
-  "package" project.
+  as development dependencies regardless of whether or not they're a "package" 
+  project.
 
 * `settings$package.dependency.fields()` now only affects packages installed
   directly by the user, not downstream dependencies of those packages.

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -516,7 +516,8 @@ renv_dependencies_discover_renv_lock <- function(path) {
 renv_dependencies_discover_description <- function(path,
                                                    fields = NULL,
                                                    subdir = NULL,
-                                                   project = NULL)
+                                                   project = NULL,
+                                                   include_dev = TRUE)
 {
   dcf <- catch(renv_description_read(path = path, subdir = subdir))
   if (inherits(dcf, "error"))
@@ -559,7 +560,12 @@ renv_dependencies_discover_description <- function(path,
     data <- c(data, list(renv_dependencies_list(path, "roxygen2", dev = TRUE)))
   }
 
-  bind(data)
+  out <- bind(data)
+
+  if (!is.null(out) && !include_dev) {
+    out <- out[!out$Dev, , drop = FALSE]
+  }
+  out
 
 }
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -936,6 +936,7 @@ renv_dependencies_discover_rproj <- function(path) {
   deps <- stack()
   if (identical(props$PackageUseDevtools, "Yes")) {
     deps$push("devtools")
+    deps$push("roxygen2")
   }
 
   renv_dependencies_list(path, deps$data(), dev = TRUE)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -554,14 +554,10 @@ renv_dependencies_discover_description <- function(path,
     proj_desc = proj_desc
   )
 
-  # Infer a dependency on roxygen2 and devtools if RoxygenNote present
+  # Infer a dependency on roxygen2 if RoxygenNote present
   if (!is.null(dcf$RoxygenNote)) {
-    data <- c(
-      data,
-      list(renv_dependencies_list(path, c("roxygen2", "devtools"), dev = TRUE))
-    )
+    data <- c(data, list(renv_dependencies_list(path, "roxygen2", dev = TRUE)))
   }
-
 
   bind(data)
 
@@ -934,7 +930,6 @@ renv_dependencies_discover_rproj <- function(path) {
   deps <- stack()
   if (identical(props$PackageUseDevtools, "Yes")) {
     deps$push("devtools")
-    deps$push("roxygen2")
   }
 
   renv_dependencies_list(path, deps$data(), dev = TRUE)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -516,23 +516,20 @@ renv_dependencies_discover_renv_lock <- function(path) {
 renv_dependencies_discover_description <- function(path,
                                                    fields = NULL,
                                                    subdir = NULL,
-                                                   project = NULL,
-                                                   is_dependency = FALSE)
+                                                   project = NULL)
 {
   dcf <- catch(renv_description_read(path = path, subdir = subdir))
   if (inherits(dcf, "error"))
     return(renv_dependencies_error(path, error = dcf))
 
-  if (is_dependency) {
-    fields <- c("Imports", "Depends", "LinkingTo")
-  } else {
+  if (is.null(fields)) {
     # Most callers don't pass in project so we need to get it from global state
     project <- project %||%
       renv_dependencies_state(key = "root") %||%
       renv_restore_state(key = "root") %||%
       renv_project_resolve()
 
-    fields <- fields %||% settings$package.dependency.fields(project = project)
+    fields <- settings$package.dependency.fields(project = project)
 
     # if this is the DESCRIPTION file for the active project, include
     # the dependencies for the active profile (if any) and Suggested fields.
@@ -545,6 +542,8 @@ renv_dependencies_discover_description <- function(path,
 
       fields <- c(fields, "Suggests", profile_field)
     }
+  } else {
+    fields <- renv_description_dependency_fields(fields)
   }
 
   data <- map(

--- a/R/description.R
+++ b/R/description.R
@@ -112,6 +112,28 @@ renv_description_type <- function(path = NULL, desc = NULL) {
 
 }
 
+renv_description_dependencies <- function(path, subdir = NULL, fields = NULL) {
+
+  fields <- fields %||% c("Depends", "Imports", "LinkingTo")
+
+  desc <- tryCatch(
+    renv_description_read(path = path, subdir = subdir),
+    error = function(err) renv_dependencies_error(path, error = path)
+  )
+
+  out <- bind(map(desc[fields], renv_description_parse_field))
+  if (is.null(out)) {
+    data_frame(
+      Package = character(),
+      Require = character(),
+      Version = character()
+    )
+  } else {
+    out[out$Package != "R", , drop = FALSE]
+  }
+
+}
+
 # parse the dependency requirements normally presented in
 # Depends, Imports, Suggests, and so on
 renv_description_parse_field <- function(field) {

--- a/R/description.R
+++ b/R/description.R
@@ -112,28 +112,6 @@ renv_description_type <- function(path = NULL, desc = NULL) {
 
 }
 
-renv_description_dependencies <- function(path, subdir = NULL, fields = NULL) {
-
-  fields <- fields %||% c("Depends", "Imports", "LinkingTo")
-
-  desc <- tryCatch(
-    renv_description_read(path = path, subdir = subdir),
-    error = function(err) renv_dependencies_error(path, error = path)
-  )
-
-  out <- bind(map(desc[fields], renv_description_parse_field))
-  if (is.null(out)) {
-    data_frame(
-      Package = character(),
-      Require = character(),
-      Version = character()
-    )
-  } else {
-    out[out$Package != "R", , drop = FALSE]
-  }
-
-}
-
 # parse the dependency requirements normally presented in
 # Depends, Imports, Suggests, and so on
 renv_description_parse_field <- function(field) {

--- a/R/description.R
+++ b/R/description.R
@@ -83,35 +83,6 @@ renv_description_path <- function(path) {
   path
 }
 
-renv_description_type <- function(path = NULL, desc = NULL) {
-
-  # read DESCRIPTION file when 'desc' not explicitly supplied
-  if (is.null(desc)) {
-
-    # read DESCRIPTION file
-    desc <- catch(renv_description_read(path))
-    if (inherits(desc, "error")) {
-      warning(desc)
-      return("unknown")
-    }
-
-  }
-
-  # check for explicitly recorded type
-  type <- desc$Type
-  if (!is.null(type))
-    return(tolower(type))
-
-  # infer otherwise from 'Package' field otherwise
-  package <- desc$Package
-  if (!is.null(package))
-    return("package")
-
-  # default to unknown
-  "unknown"
-
-}
-
 # parse the dependency requirements normally presented in
 # Depends, Imports, Suggests, and so on
 renv_description_parse_field <- function(field) {

--- a/R/package.R
+++ b/R/package.R
@@ -251,9 +251,6 @@ renv_package_dependencies_impl <- function(package,
                                            libpaths = NULL,
                                            fields = NULL)
 {
-  # skip the 'R' package
-  if (package == "R")
-    return()
 
   # if we've already visited this package, bail
   if (exists(package, envir = visited, inherits = FALSE))
@@ -275,16 +272,8 @@ renv_package_dependencies_impl <- function(package,
   # we know the path, so set it now
   assign(package, location, envir = visited, inherits = FALSE)
 
-  # find its dependencies from the DESCRIPTION file
-  desc <- tryCatch(
-    renv_description_read(location),
-    error = function(err) renv_dependencies_error(path, error = path)
-  )
-
-  fields <- c("Depends", "Imports", "LinkingTo")
-  deps <- bind(map(desc[fields], renv_description_parse_field))
-  subpackages <- setdiff(unique(unlist(deps$Package)), "R")
-
+  deps <- renv_description_dependencies(location)
+  subpackages <- unique(deps$Package)
   for (subpackage in subpackages)
     renv_package_dependencies_impl(subpackage, visited, libpaths, fields)
 }

--- a/R/package.R
+++ b/R/package.R
@@ -276,7 +276,7 @@ renv_package_dependencies_impl <- function(package,
   assign(package, location, envir = visited, inherits = FALSE)
 
   # find its dependencies from the DESCRIPTION file
-  deps <- renv_dependencies_discover_description(location, is_dependency = TRUE)
+  deps <- renv_dependencies_discover_description(location, fields = "strong")
   subpackages <- deps$Package
   for (subpackage in subpackages)
     renv_package_dependencies_impl(subpackage, visited, libpaths, fields)

--- a/R/package.R
+++ b/R/package.R
@@ -252,6 +252,10 @@ renv_package_dependencies_impl <- function(package,
                                            fields = NULL)
 {
 
+  # skip the 'R' package
+  if (package == "R")
+    return()
+
   # if we've already visited this package, bail
   if (exists(package, envir = visited, inherits = FALSE))
     return()

--- a/R/package.R
+++ b/R/package.R
@@ -272,8 +272,8 @@ renv_package_dependencies_impl <- function(package,
   # we know the path, so set it now
   assign(package, location, envir = visited, inherits = FALSE)
 
-  deps <- renv_description_dependencies(location)
-  subpackages <- unique(deps$Package)
+  deps <- renv_dependencies_discover_description(location, include_dev = FALSE)
+  subpackages <- deps$Package
   for (subpackage in subpackages)
     renv_package_dependencies_impl(subpackage, visited, libpaths, fields)
 }

--- a/R/package.R
+++ b/R/package.R
@@ -276,7 +276,7 @@ renv_package_dependencies_impl <- function(package,
   assign(package, location, envir = visited, inherits = FALSE)
 
   # find its dependencies from the DESCRIPTION file
-  deps <- renv_dependencies_discover_description(location, include_dev = FALSE)
+  deps <- renv_dependencies_discover_description(location, is_dependency = TRUE)
   subpackages <- deps$Package
   for (subpackage in subpackages)
     renv_package_dependencies_impl(subpackage, visited, libpaths, fields)

--- a/R/package.R
+++ b/R/package.R
@@ -251,7 +251,6 @@ renv_package_dependencies_impl <- function(package,
                                            libpaths = NULL,
                                            fields = NULL)
 {
-
   # skip the 'R' package
   if (package == "R")
     return()
@@ -276,6 +275,7 @@ renv_package_dependencies_impl <- function(package,
   # we know the path, so set it now
   assign(package, location, envir = visited, inherits = FALSE)
 
+  # find its dependencies from the DESCRIPTION file
   deps <- renv_dependencies_discover_description(location, include_dev = FALSE)
   subpackages <- deps$Package
   for (subpackage in subpackages)

--- a/R/project.R
+++ b/R/project.R
@@ -109,10 +109,8 @@ renv_project_remotes <- function(project, fields = NULL) {
   remotes <- renv_project_remotes_field(project, descpath)
 
   # next, find packages mentioned in the DESCRIPTION file
-  fields <- fields %||% c("Depends", "Imports", "LinkingTo", "Suggests")
   deps <- renv_dependencies_discover_description(
     path    = descpath,
-    fields  = fields,
     project = project
   )
 

--- a/R/project.R
+++ b/R/project.R
@@ -126,19 +126,6 @@ renv_project_remotes <- function(project, fields = NULL) {
   ignored <- renv_project_ignored_packages(project = project)
   specs <- specs[setdiff(names(specs), c("R", ignored))]
 
-  # if any Roxygen fields are included,
-  # infer a dependency on roxygen2 and devtools
-  desc <- renv_description_read(descpath)
-  if (any(grepl("^Roxygen", names(desc)))) {
-    for (package in c("devtools", "roxygen2")) {
-      if (!package %in% ignored) {
-        specs[[package]] <-
-          specs[[package]] %||%
-          renv_dependencies_list(descpath, package, dev = TRUE)
-      }
-    }
-  }
-
   # now, try to resolve the packages
   records <- enumerate(specs, function(package, spec) {
 

--- a/R/project.R
+++ b/R/project.R
@@ -126,6 +126,19 @@ renv_project_remotes <- function(project, fields = NULL) {
   ignored <- renv_project_ignored_packages(project = project)
   specs <- specs[setdiff(names(specs), c("R", ignored))]
 
+  # if any Roxygen fields are included,
+  # infer a dependency on roxygen2 and devtools
+  desc <- renv_description_read(descpath)
+  if (any(grepl("^Roxygen", names(desc)))) {
+    for (package in c("devtools", "roxygen2")) {
+      if (!package %in% ignored) {
+        specs[[package]] <-
+          specs[[package]] %||%
+          renv_dependencies_list(descpath, package, dev = TRUE)
+      }
+    }
+  }
+
   # now, try to resolve the packages
   records <- enumerate(specs, function(package, spec) {
 

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -1004,7 +1004,7 @@ renv_retrieve_successful <- function(record, path, install = TRUE) {
   deps <- renv_dependencies_discover_description(
     path,
     subdir = subdir,
-    fields = if (!record$Package %in% state$packages) "most"
+    fields = if (!record$Package %in% state$packages) "strong"
   )
   if (length(deps$Source))
     deps$Source <- record$Package

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -1004,7 +1004,7 @@ renv_retrieve_successful <- function(record, path, install = TRUE) {
   deps <- renv_dependencies_discover_description(
     path,
     subdir = subdir,
-    is_dependency = !record$Package %in% state$packages
+    fields = if (!record$Package %in% state$packages) "most"
   )
   if (length(deps$Source))
     deps$Source <- record$Package

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -1004,7 +1004,7 @@ renv_retrieve_successful <- function(record, path, install = TRUE) {
   deps <- renv_dependencies_discover_description(
     path,
     subdir = subdir,
-    include_dev = FALSE
+    is_dependency = !record$Package %in% state$packages
   )
   if (length(deps$Source))
     deps$Source <- record$Package

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -1001,7 +1001,11 @@ renv_retrieve_successful <- function(record, path, install = TRUE) {
   # record this package's requirements
   state <- renv_restore_state()
   requirements <- state$requirements
-  deps <- renv_dependencies_discover_description(path, subdir = subdir)
+  deps <- renv_dependencies_discover_description(
+    path,
+    subdir = subdir,
+    include_dev = FALSE
+  )
   if (length(deps$Source))
     deps$Source <- record$Package
 

--- a/R/settings.R
+++ b/R/settings.R
@@ -358,11 +358,10 @@ renv_settings_impl <- function(name, default, scalar, validate, coerce, update) 
 #'
 #' ## `package.dependency.fields`
 #'
-#' During dependency discovery, renv uses the fields of an installed
-#' package's `DESCRIPTION` file to determine that package's recursive
-#' dependencies. By default, the `Imports`, `Depends` and `LinkingTo` fields
-#' are used. If you'd prefer that renv also captures the `Suggests`
-#' dependencies for a package, you can set this to
+#' When explicitly installing a package with `install()`, what fields
+#' should be used to determine that packages dependencies? The default
+#' uses `Imports`, `Depends` and `LinkingTo` fields, but you also want
+#' to install `Suggests` dependencies for a package, you can set this to
 #' `c("Imports", "Depends", "LinkingTo", "Suggests")`.
 #'
 #' ## `r.version`

--- a/man/dependencies.Rd
+++ b/man/dependencies.Rd
@@ -38,10 +38,14 @@ otherwise ignored.
 \item \code{"ignored"}: errors are ignored and not reported to the user.
 }}
 
-\item{dev}{Boolean; include 'development' dependencies as well? That is,
-packages which may be required during development but are unlikely to be
-required during runtime for your project. By default, only runtime
-dependencies are returned.}
+\item{dev}{Boolean; include development dependencies? These packages are
+typically required when developing the project, but not when running it
+(i.e. you want them installed when humans are working on the project but
+not when computers are deploying it).
+
+Development dependencies include packages listed in the \code{Suggests} field
+of a \code{DESCRIPTION} found in the project root, and roxygen2 or devtools if
+their use is implied by other project metadata.}
 }
 \value{
 An \R \code{data.frame} of discovered dependencies, mapping inferred

--- a/man/settings.Rd
+++ b/man/settings.Rd
@@ -50,11 +50,10 @@ added to the lockfile, that entry in the lockfile will not be ignored.
 
 \subsection{\code{package.dependency.fields}}{
 
-During dependency discovery, renv uses the fields of an installed
-package's \code{DESCRIPTION} file to determine that package's recursive
-dependencies. By default, the \code{Imports}, \code{Depends} and \code{LinkingTo} fields
-are used. If you'd prefer that renv also captures the \code{Suggests}
-dependencies for a package, you can set this to
+When explicitly installing a package with \code{install()}, what fields
+should be used to determine that packages dependencies? The default
+uses \code{Imports}, \code{Depends} and \code{LinkingTo} fields, but you also want
+to install \code{Suggests} dependencies for a package, you can set this to
 \code{c("Imports", "Depends", "LinkingTo", "Suggests")}.
 }
 

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -210,14 +210,6 @@ test_that("Suggest dependencies are ignored by default", {
   expect_false(renv_package_installed("egg"))
 })
 
-test_that("Suggest dependencies are used when requested", {
-  renv_tests_scope("breakfast")
-  fields <- c("Imports", "Depends", "LinkingTo", "Suggests")
-  settings$package.dependency.fields(fields)
-  install("breakfast")
-  expect_true(renv_package_installed("egg"))
-})
-
 test_that("a call to geom_hex() implies a dependency on ggplot2", {
 
   file <- renv_test_code({

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -170,19 +170,6 @@ test_that("Suggests are dev. deps for all projects", {
 
 })
 
-test_that("roxygen2 is dev dep if needed", {
-
-  renv_tests_scope()
-
-  writeLines(c("RoxygenNote: 7.0.0"), con = "DESCRIPTION")
-  deps <- dependencies(dev = TRUE)
-  expect_equal(
-    deps[c("Package", "Dev")],
-    data.frame(Package = "roxygen2", Dev = TRUE, stringsAsFactors = FALSE)
-  )
-
-})
-
 test_that("packages referenced by modules::import() are discovered", {
   deps <- dependencies("resources/modules.R")
   expect_setequal(deps$Package, c("A", "B", "C", "D", "G", "H", "modules"))

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -150,22 +150,24 @@ test_that("no warnings are produced when crawling dependencies", {
 
 })
 
-test_that("Suggests are dev. deps for non-package projects", {
+test_that("Suggests are dev. deps for all projects", {
+
   renv_tests_scope()
+
+  expected <- data.frame(
+    Package = "bread",
+    Dev = TRUE,
+    stringsAsFactors = FALSE
+  )
+
   writeLines(c("Type: Project", "Suggests: bread"), con = "DESCRIPTION")
   deps <- dependencies(dev = TRUE)
-  expect_true(nrow(deps) == 1)
-  expect_true(deps$Package == "bread")
-  expect_true(deps$Dev)
-})
+  expect_equal(deps[c("Package", "Dev")], expected)
 
-test_that("Suggests are _not_ dev. deps for package projects", {
-  renv_tests_scope()
   writeLines(c("Type: Package", "Suggests: bread"), con = "DESCRIPTION")
-  deps <- dependencies(dev = FALSE)
-  expect_true(nrow(deps) == 1)
-  expect_true(deps$Package == "bread")
-  expect_false(deps$Dev)
+  deps <- dependencies(dev = TRUE)
+  expect_equal(deps[c("Package", "Dev")], expected)
+
 })
 
 test_that("packages referenced by modules::import() are discovered", {

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -4,7 +4,7 @@ test_that(".Rproj files requesting devtools is handled", {
   writeLines("PackageUseDevtools: Yes", "project.Rproj")
   deps <- dependencies(dev = TRUE)
   packages <- deps$Package
-  expect_setequal(packages, c("devtools", "roxygen2"))
+  expect_setequal(packages, "devtools")
 })
 
 test_that("usages of library, etc. are properly handled", {
@@ -167,6 +167,19 @@ test_that("Suggests are dev. deps for all projects", {
   writeLines(c("Type: Package", "Suggests: bread"), con = "DESCRIPTION")
   deps <- dependencies(dev = TRUE)
   expect_equal(deps[c("Package", "Dev")], expected)
+
+})
+
+test_that("roxygen2 is dev dep if needed", {
+
+  renv_tests_scope()
+
+  writeLines(c("RoxygenNote: 7.0.0"), con = "DESCRIPTION")
+  deps <- dependencies(dev = TRUE)
+  expect_equal(
+    deps[c("Package", "Dev")],
+    data.frame(Package = "roxygen2", Dev = TRUE, stringsAsFactors = FALSE)
+  )
 
 })
 

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -4,7 +4,7 @@ test_that(".Rproj files requesting devtools is handled", {
   writeLines("PackageUseDevtools: Yes", "project.Rproj")
   deps <- dependencies(dev = TRUE)
   packages <- deps$Package
-  expect_setequal(packages, "devtools")
+  expect_setequal(packages, c("devtools", "roxygen2"))
 })
 
 test_that("usages of library, etc. are properly handled", {

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -468,6 +468,16 @@ test_that("repositories containing multiple packages can be installed", {
 
 })
 
+test_that("Suggest dependencies are used when requested", {
+
+  renv_tests_scope("breakfast")
+  fields <- c("Imports", "Depends", "LinkingTo", "Suggests")
+  settings$package.dependency.fields(fields)
+  install("breakfast")
+  expect_true(renv_package_installed("egg"))
+
+})
+
 test_that("custom dependency fields in install are supported", {
 
   skip_on_cran()


### PR DESCRIPTION
* Top-level `DESCRIPTION` is now treated the same way regardless of whether it's a "Package" or not.
* `settings$package.dependency.fields()` no longer affects transitive dependencies.
* Document how "development dependencies" are found in `dependencies()`
