### PR TITLE
Sort missing packages in status()

### DIFF
--- a/R/status.R
+++ b/R/status.R
@@ -200,7 +200,7 @@ renv_status_check_synchronized <- function(project,
     }
 
     renv_pretty_print(
-      missing,
+      sort(missing),
       preamble  = usedmsg,
       postamble = postamble
     )


### PR DESCRIPTION
The others are already sorted because they use `renv_pretty_print_records()`