### PR TITLE
Tweak header() formatting

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -328,15 +328,15 @@ remap <- function(x, map) {
 
 header <- function(label,
                    prefix = "#",
-                   suffix = "=",
-                   n = 38L)
+                   suffix = "-",
+                   n = min(getOption("width"), 78))
 {
   n <- n - nchar(label) - nchar(prefix) - 2L
   if (n <= 0)
     return(paste(prefix, label))
 
   tail <- paste(rep.int(suffix, n), collapse = "")
-  paste(prefix, label, tail)
+  paste0(prefix, " ", label, " ", tail)
 
 }
 

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -3,7 +3,7 @@
     Code
       install("bread@0.1.0")
     Output
-      # Downloading packages ===============
+      # Downloading packages -------------------------------------------------------
       [no downloads required]
       
       # Installing packages into "<tempdir>/<renv-library>"
@@ -26,7 +26,7 @@
     Code
       install()
     Output
-      # Downloading packages ===============
+      # Downloading packages -------------------------------------------------------
       [no downloads required]
       
       # Installing packages into "<tempdir>/<renv-library>"

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -27,7 +27,7 @@
       
       The following package(s) will be updated in the lockfile:
       
-      # CRAN ===============================
+      # CRAN -----------------------------------------------------------------------
       - oatmeal   [1.0.0 -> *]
       
       * Lockfile written to '<wd>/renv.lock'.
@@ -60,7 +60,7 @@
       
       The following package(s) will be updated in the lockfile:
       
-      # CRAN ===============================
+      # CRAN -----------------------------------------------------------------------
       - oatmeal   [1.0.0 -> *]
       
       * Lockfile written to '<wd>/renv.lock'.
@@ -123,7 +123,7 @@
       
       The following package(s) will be updated in the lockfile:
       
-      # CRAN ===============================
+      # CRAN -----------------------------------------------------------------------
       - bread       [1.0.0 -> *]
       - breakfast   [1.0.0 -> *]
       - oatmeal     [1.0.0 -> *]
@@ -174,7 +174,7 @@
       
       Selection: 2
       
-      # Downloading packages ===============
+      # Downloading packages -------------------------------------------------------
       Retrieving '<test-repo>/src/contrib/egg_1.0.0.tar.gz' ...
       	OK [downloaded XXXX bytes in XXXX seconds]
       
@@ -188,7 +188,7 @@
       Installed 1 package in XXXX seconds.
       The following package(s) will be updated in the lockfile:
       
-      # CRAN ===============================
+      # CRAN -----------------------------------------------------------------------
       - egg   [* -> 1.0.0]
       
       The version of R recorded in the lockfile will be updated:

--- a/tests/testthat/_snaps/status.md
+++ b/tests/testthat/_snaps/status.md
@@ -66,7 +66,7 @@
     Output
       The following package(s) are out of sync [lockfile -> library]:
       
-      # CRAN ===============================
+      # CRAN -----------------------------------------------------------------------
       - egg       [repo: * -> CRAN; ver: 2.0.0 -> 1.0.0]
       - oatmeal   [repo: * -> CRAN; ver: 0.9.0 -> 1.0.0]
       


### PR DESCRIPTION
* Use - instead of =
* Use console width (up to 78 characters)