### PR TITLE
Only add BiocManager as dep when used

### DIFF
--- a/R/status.R
+++ b/R/status.R
@@ -160,11 +160,11 @@ renv_status_check_synchronized <- function(project,
                                            library,
                                            packages)
 {
-  # projects will implicitly depend on BiocManager if any Bioconductor
-  # packages are in use
-  sources <- extract_chr(library, "Source")
+  # projects will implicitly depend on BiocManager & BiocVersion if any
+  # Bioconductor packages are in use
+  sources <- extract_chr(library[packages], "Source")
   if ("Bioconductor" %in% sources)
-    packages <- unique(c(packages, "BiocManager"))
+    packages <- union(packages, "BiocManager")
 
   # missing dependencies -------------------------------------------------------
   # Must return early because `packages` will be incomplete making later

--- a/R/status.R
+++ b/R/status.R
@@ -162,7 +162,7 @@ renv_status_check_synchronized <- function(project,
 {
   # projects will implicitly depend on BiocManager & BiocVersion if any
   # Bioconductor packages are in use
-  sources <- extract_chr(library[packages], "Source")
+  sources <- extract_chr(keep(library, packages), "Source")
   if ("Bioconductor" %in% sources)
     packages <- union(packages, "BiocManager")
 

--- a/tests/testthat/_snaps/bioconductor.md
+++ b/tests/testthat/_snaps/bioconductor.md
@@ -1,0 +1,20 @@
+# Bioconductor packages add BiocManager as a dependency
+
+    Code
+      status()
+    Output
+      The following package(s) are installed, but not recorded in the lockfile:
+      
+      - BiocGenerics [<version>]
+      - BiocManager  [<version>]
+      
+      Use `renv::snapshot()` to add these packages to the lockfile.
+      
+
+---
+
+    Code
+      status()
+    Output
+      * The project is already synchronized with the lockfile.
+

--- a/tests/testthat/helper-scope.R
+++ b/tests/testthat/helper-scope.R
@@ -57,3 +57,10 @@ renv_tests_scope_repos <- function(envir = parent.frame()) {
   )
 
 }
+
+renv_tests_scope_system_cache <- function(envir = parent.frame()) {
+  skip_on_cran()
+
+  renv_scope_options(repos = c(CRAN = "https://cloud.r-project.org"), envir = envir)
+  renv_scope_envvars(RENV_PATHS_ROOT = renv_paths_root_default_impl(), envir = envir)
+}

--- a/tests/testthat/helper-snapshot.R
+++ b/tests/testthat/helper-snapshot.R
@@ -1,7 +1,7 @@
-expect_snapshot <- function(...) {
+expect_snapshot <- function(..., transform = strip_dirs) {
   renv_scope_options(renv.verbose = TRUE)
 
-  testthat::expect_snapshot(..., transform = strip_dirs)
+  testthat::expect_snapshot(..., transform = transform)
 }
 
 strip_dirs <- function(x) {


### PR DESCRIPTION
Includes new `renv_tests_scope_system_cache()` to make it easier to install packages from the system cache to speed up performance in tests.

Fixes #1356