### PR TITLE
Only use PPM for binary installs

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -129,6 +129,7 @@ install <- function(packages = NULL,
   libpaths <- renv_libpaths_resolve(library)
   renv_scope_libpaths(libpaths)
 
+  is_binary <- !identical(type, "source")
   type <- type %||% getOption("pkgType")
   renv_scope_options(pkgType = type)
 
@@ -185,7 +186,7 @@ install <- function(packages = NULL,
   )
 
   # retrieve packages
-  records <- retrieve(names(remotes))
+  records <- retrieve(names(remotes), is_binary = is_binary)
   if (empty(records)) {
     writef("* There are no packages to install.")
     return(invisible(list()))

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -4,7 +4,7 @@
 # this routine retrieves a package + its dependencies, and as a side
 # effect populates the restore state's `retrieved` member with a
 # list of package records which can later be used for install
-retrieve <- function(packages) {
+retrieve <- function(packages, is_binary = TRUE) {
 
   # confirm that we have restore state set up
   state <- renv_restore_state()
@@ -15,7 +15,7 @@ retrieve <- function(packages) {
   options(repos = renv_repos_normalize())
 
   # transform repository URLs for PPM
-  if (renv_ppm_enabled()) {
+  if (is_binary && renv_ppm_enabled()) {
     repos <- getOption("repos")
     renv_scope_options(repos = renv_ppm_transform(repos))
   }


### PR DESCRIPTION
Fixes #927

An alternative fix would be to change the default for `pkgType` to "both" (or maybe binary?). But I'm not sure what the implications of that would be on linux.  