### PR TITLE
vendor: default version and trapped download failures

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -356,7 +356,7 @@ renv_bootstrap_download_github <- function(version) {
     on.exit(do.call(base::options, saved), add = TRUE)
   }
 
-  catf("* Downloading from GitHub ... ", appendLF = FALSE)
+  catf("* Downloading version %s from GitHub ... ", version, appendLF = FALSE)
 
   url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
   name <- sprintf("renv_%s.tar.gz", version)

--- a/R/vendor.R
+++ b/R/vendor.R
@@ -44,7 +44,7 @@ vendor <- function(version    = NULL,
   }
 
   # get renv sources
-  sources <- sources %||% renv_vendor_sources(version)
+  sources <- sources %||% renv_vendor_sources(version %||% renv_metadata_version())
 
   # re-compute renv version from sources
   version <- renv_description_read(path = sources, field = "Version")

--- a/R/vendor.R
+++ b/R/vendor.R
@@ -20,9 +20,10 @@
 #' need to rely on renv internal functions, we strongly recommend testing
 #' your usages of these functions to avoid potential breakage.
 #'
-#' @param version The version of renv to vendor. If `NULL` (the default),
-#'   the current version of renv will be used. Ignored if `sources`
-#'   is non-`NULL`.
+#' @param version The version of renv to vendor. A Git tag targets a CRAN
+#'   version and "main" references the latest development version of renv. Use
+#'   a Git branch name or commit SHA to target other versions. Ignored when
+#'   `sources` is non-`NULL`.
 #'
 #' @param sources The path to local renv sources to be vendored.
 #'
@@ -44,7 +45,12 @@ vendor <- function(version    = NULL,
   }
 
   # get renv sources
-  sources <- sources %||% renv_vendor_sources(version %||% renv_metadata_version())
+  if (is.null(sources)) {
+    if (is.null(version)) {
+      stop("Specify an renv version or a path to renv sources")
+    }
+    sources <- renv_vendor_sources(version)
+  }
 
   # re-compute renv version from sources
   version <- renv_description_read(path = sources, field = "Version")
@@ -146,7 +152,7 @@ renv_vendor_imports <- function() {
 
 }
 
-renv_vendor_sources <- function(version = renv_metadata_version()) {
+renv_vendor_sources <- function(version) {
 
   tarball <- renv_bootstrap_download_github(version)
   if (!is.character(tarball) || !file.exists(tarball)) {

--- a/R/vendor.R
+++ b/R/vendor.R
@@ -149,6 +149,9 @@ renv_vendor_imports <- function() {
 renv_vendor_sources <- function(version = renv_metadata_version()) {
 
   tarball <- renv_bootstrap_download_github(version)
+  if (!is.character(tarball) || !file.exists(tarball)) {
+    stop("Download failed")
+  }
   defer(unlink(tarball))
 
   untarred <- tempfile("renv-vendor-")

--- a/tests/testthat/_snaps/bootstrap.md
+++ b/tests/testthat/_snaps/bootstrap.md
@@ -20,7 +20,7 @@
       bootstrap(version = "1.0.0.1", library = library)
     Output
       Bootstrapping renv 1.0.0.1:
-      * Downloading from GitHub ... OK
+      * Downloading version 1.0.0.1 from GitHub ... OK
       * Installing ... OK
       
       
@@ -48,7 +48,7 @@
       bootstrap(version = "1.0.0.1", library = library)
     Output
       Bootstrapping renv 1.0.0.1:
-      * Downloading from GitHub ... FAILED
+      * Downloading version 1.0.0.1 from GitHub ... FAILED
     Error <simpleError>
       failed to download:
       All download methods failed
@@ -59,7 +59,7 @@
       bootstrap(version = "1.0.0.1", library = library)
     Output
       Bootstrapping renv 1.0.0.1:
-      * Downloading from GitHub ... OK
+      * Downloading version 1.0.0.1 from GitHub ... OK
       * Installing ... FAILED
       Error installing renv:
       ======================


### PR DESCRIPTION
Traps download failures, as we were attempting to `untar(FALSE)` before. Default the vendor version to the current renv version. Print the version when downloading from GitHub.

This lets me successfully:

```
remotes::install_github("rstudio/renv", "aron-vendor-untar-fix")
renv:::vendor()
```

Feel free to discard/reimplement if the intent was some other interaction with `vendor`.

Fixes #1418

Note: Rooted on https://github.com/rstudio/renv/pull/1407 because that's the change I wanted to use.