### PR TITLE
Refactor `renv_package_checking()`

### DIFF
--- a/R/memoize.R
+++ b/R/memoize.R
@@ -3,7 +3,7 @@
 
 memo <- function(value, scope = NULL) {
   scope <- scope %||% stringify(sys.call(sys.parent())[[1L]])
-  `_renv_memoize`[[scope]] <- `_renv_memoize`[[scope]] %||% value
+  (`_renv_memoize`[[scope]] <- `_renv_memoize`[[scope]] %||% value)
 }
 
 memoize <- function(key, value, scope = NULL) {

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -63,10 +63,6 @@ migrate <- function(
   project <- renv_project_resolve(project)
   renv_project_lock(project = project)
 
-  # for jetpack
-  if (renv_package_checking())
-    renv_patch_repos()
-
   project <- renv_path_normalize(project, mustWork = TRUE)
   if (file.exists(file.path(project, "packrat/packrat.lock"))) {
     packrat <- match.arg(packrat, several.ok = TRUE)

--- a/R/package.R
+++ b/R/package.R
@@ -396,11 +396,6 @@ renv_package_checking <- function() {
 
 renv_package_checking_impl <- function() {
 
-  # check for devtools
-  calls <- sys.calls()
-  if (identical(calls[[1L]], quote(devtools::test())))
-    return(TRUE)
-
   # otherwise, check other things
   is_testing() ||
     "CheckExEnv" %in% search()

--- a/R/package.R
+++ b/R/package.R
@@ -398,7 +398,7 @@ renv_package_checking_impl <- function() {
 
   # otherwise, check other things
   is_testing() ||
-    "CheckExEnv" %in% search()
+    "CheckExEnv" %in% search() ||
     renv_envvar_exists("_R_CHECK_PACKAGE_NAME_") ||
     renv_envvar_exists("_R_CHECK_SIZE_OF_TARBALL_")
 }

--- a/R/package.R
+++ b/R/package.R
@@ -391,12 +391,6 @@ renv_package_built <- function(path) {
 }
 
 renv_package_checking <- function() {
-  memo(renv_package_checking_impl())
-}
-
-renv_package_checking_impl <- function() {
-
-  # otherwise, check other things
   is_testing() ||
     "CheckExEnv" %in% search() ||
     renv_envvar_exists("_R_CHECK_PACKAGE_NAME_") ||

--- a/R/paths.R
+++ b/R/paths.R
@@ -186,7 +186,7 @@ renv_paths_root <- function(...) {
 # nocov start
 renv_paths_root_default <- function() {
 
-  `_renv_root` <<- `_renv_root` %||% {
+  (`_renv_root` <<- `_renv_root` %||% {
 
     # use tempdir for cache when running tests
     # this check is necessary here to support packages which might use renv
@@ -199,7 +199,7 @@ renv_paths_root_default <- function() {
     else
       renv_paths_root_default_impl()
 
-  }
+  })
 
 }
 

--- a/R/restore.R
+++ b/R/restore.R
@@ -53,9 +53,6 @@ restore <- function(project  = NULL,
 
   renv_activate_prompt("restore", library, prompt, project)
 
-  if (renv_package_checking())
-    renv_patch_repos()
-
   # resolve library, lockfile arguments
   libpaths <- renv_libpaths_resolve(library)
   lockfile <- lockfile %||% renv_lockfile_load(project = project)

--- a/tests/testthat/helper-setup.R
+++ b/tests/testthat/helper-setup.R
@@ -38,8 +38,6 @@ renv_tests_setup_envvars <- function(envir = parent.frame()) {
   root <- ensure_directory(renv_scope_tempfile(envir = envir))
 
   renv_scope_envvars(
-    # simulate running in R CMD check
-    "_R_CHECK_PACKAGE_NAME_" = "renv",
     # disable locking in this scope
     RENV_CONFIG_LOCKING_ENABLED = FALSE,
     RENV_PATHS_ROOT = root,


### PR DESCRIPTION
To verify everything looks ok, I created https://github.com/hadley/renvdep, which errors with `renv:::renv_paths_root()` in both an example and a test. That confirms the root path uses the temp directory, which I think should be enough to close #1298.