### PR TITLE
use abort for system errors

### DIFF
--- a/R/abort.R
+++ b/R/abort.R
@@ -1,0 +1,29 @@
+
+abort <- function(message, ..., details = NULL, class = NULL) {
+
+  # create condition object
+  cnd <- if (is.character(message)) {
+    cnd <- list(message = cnd, details = details, ...)
+    class(cnd) <- c(class, "error", "condition")
+  } else if (inherits(message, "condition")) {
+    message
+  } else {
+    stop("internal error: abort called with unexpected message")
+  }
+
+  # signal the condition, giving calling handlers a chance to run first
+  signalCondition(cnd)
+
+  # if we get here, the condition wasn't handled -- handle printing of
+  # the error ourselves, and then stop with a fallback condition
+  if (length(cnd$details))
+    writeLines(c(cnd$details, ""))
+
+  # create the fallback, but 'dodge' the existing error handlers
+  fallback <- cnd
+  class(fallback) <- "condition"
+
+  # now throw the error
+  stop(fallback)
+
+}

--- a/R/abort.R
+++ b/R/abort.R
@@ -3,8 +3,8 @@ abort <- function(message, ..., details = NULL, class = NULL) {
 
   # create condition object
   cnd <- if (is.character(message)) {
-    cnd <- list(message = cnd, details = details, ...)
-    class(cnd) <- c(class, "error", "condition")
+    data <- list(message = message, details = details, ...)
+    structure(data, class = c(class, "error", "condition"))
   } else if (inherits(message, "condition")) {
     message
   } else {

--- a/R/install.R
+++ b/R/install.R
@@ -376,10 +376,7 @@ renv_install_package <- function(record) {
   before <- Sys.time()
   withCallingHandlers(
     renv_install_package_impl(record),
-    error = function(e) {
-      writef(" FAILED")
-      writef(e$output)
-    }
+    error = function(e) writef("FAILED")
   )
   after <- Sys.time()
 

--- a/R/r.R
+++ b/R/r.R
@@ -44,9 +44,10 @@ r_exec_error <- function(package, output, label, extra) {
     paste(renv_path_pretty(extra), "does not exist")
 
   # stop with an error
-  message <- sprintf("%s of package '%s' failed [%s]", label, package, extra)
-  error <- simpleError(message = message)
-  error$output <- all
+  abort(
+    message = sprintf("%s of package '%s' failed [%s]", label, package, extra),
+    detail = all
+  )
   stop(error)
 
 }

--- a/R/system.R
+++ b/R/system.R
@@ -7,7 +7,7 @@ renv_system_exec <- function(command,
                              quiet   = NULL)
 {
   # be quiet when running tests by default
-  quiet <- quiet %||% renv_tests_running()
+  quiet <- quiet %||% FALSE
 
   # handle 'stream' specially
   if (stream) {
@@ -52,25 +52,26 @@ renv_system_exec <- function(command,
     return(output)
 
   # otherwise, notify the user that things went wrong
-  if (!quiet) {
+  message <- sprintf("error %s [error code %i]", action, status)
+  details <- if (!quiet) renv_system_exec_details(command, args, output)
 
-    cmdline <- paste(command, paste(args, collapse = " "))
-    underline <- paste(rep.int("=", min(80L, nchar(cmdline))), collapse = "")
-    header <- c(cmdline, underline)
+  abort(message, details = details)
 
-    # truncate output (avoid overwhelming console)
-    body <- if (length(output) > 200L)
-      c(head(output, n = 100L), "< ... >", tail(output, n = 100L))
-    else
-      output
-
-    # write to stderr
-    writef(c(header, "", body))
-
-  }
-
-  # throw error
-  fmt <- "error %s [error code %i]"
-  stopf(fmt, action, status)
 }
 
+renv_system_exec_details <- function(command, args, output) {
+
+  # get header, giving the command that was run
+  cmdline <- paste(command, paste(args, collapse = " "))
+  underline <- paste(rep.int("=", min(80L, nchar(cmdline))), collapse = "")
+  header <- c(cmdline, underline)
+
+  # truncate output (avoid overwhelming console)
+  body <- if (length(output) > 200L)
+    c(head(output, n = 100L), "< ... >", tail(output, n = 100L))
+  else
+    output
+
+  c(header, "", body)
+
+}

--- a/R/system.R
+++ b/R/system.R
@@ -7,7 +7,7 @@ renv_system_exec <- function(command,
                              quiet   = NULL)
 {
   # be quiet when running tests by default
-  quiet <- quiet %||% FALSE
+  quiet <- quiet %||% renv_tests_running()
 
   # handle 'stream' specially
   if (stream) {


### PR DESCRIPTION
This draws inspiration from `rlang::abort()`, and seeks to enhance how `renv` handles errors in a few locations.

In particular, this gives us a way for callers to catch and silence errors from `renv_system_exec()`, or to allow those messages to be emitted if required.