### PR TITLE
dont check repos in synchronized check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # renv 0.18.0  (UNRELEASED)
 
+* `renv` no longer attempts to query package repositories when checking
+  if a project is synchronzied on startup. (#812)
 
 * `update()` can now update packages installed from GitLab (#136) and 
   BitBucket (#1194).

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -952,7 +952,7 @@ renv_dependencies_discover_r <- function(path = NULL,
   # update current path
   state <- renv_dependencies_state()
   if (!is.null(state))
-    renv_scope_binding(state, "path", path)
+    renv_scope_binding("path", path, frame = state)
 
   methods <- c(
     renv_dependencies_discover_r_methods,

--- a/R/download.R
+++ b/R/download.R
@@ -232,9 +232,9 @@ renv_download_default_agent_scope_impl <- function(headers, envir = parent.frame
   all <- c("User-Agent" = agent, headers)
   headertext <- paste0(names(all), ": ", all, "\r\n", collapse = "")
 
-  renv_scope_binding(utils, "makeUserAgent", function(format = TRUE) {
+  renv_scope_binding("makeUserAgent", function(format = TRUE) {
     if (format) headertext else agent
-  }, frame = envir)
+  }, frame = utils, envir = envir)
 
   return(TRUE)
 

--- a/R/project.R
+++ b/R/project.R
@@ -3,6 +3,9 @@
 # NULL when no project is currently loaded.
 `_renv_project_path` <- NULL
 
+# Flag indicating whether we're checking if the project is synchronized.
+`_renv_project_synchronized_check_running` <- FALSE
+
 #' Retrieve the active project
 #'
 #' Retrieve the path to the active project (if any).
@@ -248,6 +251,9 @@ renv_project_synchronized_check <- function(project = NULL, lockfile = NULL) {
 
   project  <- renv_project_resolve(project)
   lockfile <- lockfile %||% renv_lockfile_load(project)
+
+  # signal that we're running synchronization checks
+  renv_scope_binding("_renv_project_synchronized_check_running", TRUE)
 
   # be quiet when checking for dependencies in this scope
   # https://github.com/rstudio/renv/issues/1181

--- a/R/scope.R
+++ b/R/scope.R
@@ -329,13 +329,13 @@ renv_scope_trace <- function(what, tracer, envir = parent.frame()) {
 }
 
 
-renv_scope_binding <- function(envir, symbol, replacement, frame = parent.frame()) {
-  if (exists(symbol, envir, inherits = FALSE)) {
-    old <- renv_binding_replace(symbol, replacement, envir)
-    defer(renv_binding_replace(symbol, old, envir), envir = frame)
+renv_scope_binding <- function(symbol, replacement, frame = renv_envir_self(), envir = parent.frame()) {
+  if (exists(symbol, frame, inherits = FALSE)) {
+    old <- renv_binding_replace(symbol, replacement, frame)
+    defer(renv_binding_replace(symbol, old, frame), envir = envir)
   } else {
-    assign(symbol, replacement, envir = envir)
-    defer(rm(list = symbol, envir = envir, inherits = FALSE), envir = frame)
+    assign(symbol, replacement, frame)
+    defer(rm(list = symbol, envir = frame, inherits = FALSE), envir = envir)
   }
 }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -766,6 +766,11 @@ renv_snapshot_description_source <- function(dcf) {
   if (is.null(package))
     return(list(Source = "unknown"))
 
+  # if this is running as part of the synchronization check, skip CRAN queries
+  # https://github.com/rstudio/renv/issues/812
+  if (`_renv_project_synchronized_check_running`)
+    return(list(Source = "unknown"))
+
   # NOTE: this is sort of a hack that allows renv to declare packages which
   # appear to be installed from sources, but are actually available on the
   # active R package repositories, as though they were retrieved from that

--- a/R/update.R
+++ b/R/update.R
@@ -283,7 +283,7 @@ update <- function(packages = NULL,
   }
 
   # get package records
-  renv_scope_binding(renv_envir_self(), "_renv_snapshot_hash", FALSE)
+  renv_scope_binding("_renv_snapshot_hash", FALSE, frame = renv_envir_self())
   records <- renv_snapshot_libpaths(libpaths = libpaths, project = project)
   packages <- packages %||% names(records)
 

--- a/tests/testthat/test-scope.R
+++ b/tests/testthat/test-scope.R
@@ -89,11 +89,11 @@ test_that("renv_scope_trace works", {
 })
 
 test_that("can temporarily replace binding", {
-  env <- environment()
+  frame <- environment()
   x <- 10
 
   local({
-    renv_scope_binding(env, "x", 20)
+    renv_scope_binding("x", 20, frame = frame)
     expect_equal(x, 20)
   })
 
@@ -101,10 +101,10 @@ test_that("can temporarily replace binding", {
 })
 
 test_that("can temporarily create binding", {
-  env <- environment()
+  frame <- environment()
 
   local({
-    renv_scope_binding(env, "x", 20)
+    renv_scope_binding("x", 20, frame = frame)
     expect_equal(x, 20)
   })
 
@@ -114,8 +114,9 @@ test_that("can temporarily create binding", {
 test_that("can temporarily replace locked binding", {
   original <- utils::adist
 
+  utils <- asNamespace("utils")
   local({
-    renv_scope_binding(asNamespace("utils"), "adist", 20)
+    renv_scope_binding("adist", 20, frame = utils)
     expect_equal(utils::adist, 20)
   })
 


### PR DESCRIPTION
Closes https://github.com/rstudio/renv/issues/812.

Also flips around the arguments in `renv_scope_binding()` -- I think you might have advocated for this previously?