### PR TITLE
Rework dependency prompting and init caching

### DIFF
--- a/R/clean.R
+++ b/R/clean.R
@@ -80,8 +80,6 @@ clean <- function(project = NULL,
 
   renv_activate_prompt("clean", NULL, prompt, project)
 
-  renv_dependencies_scope(project, action = "clean")
-
   actions <- actions %||% renv_clean_actions(prompt)
 
   all <- list(
@@ -216,7 +214,7 @@ renv_clean_unused_packages <- function(project, prompt) {
     return(ntd())
 
   # find packages used in the project and their dependencies
-  deps <- renv_dependencies_impl(project, progress = FALSE)
+  deps <- renv_dependencies_confirm("clean", project, dev = TRUE)
   paths <- renv_package_dependencies(deps$Package, project = project)
   packages <- names(paths)
 

--- a/R/condition.R
+++ b/R/condition.R
@@ -4,7 +4,3 @@ renv_condition_signal <- function(class = NULL, data = NULL) {
   class(condition) <- c(class, "renv.condition", "condition")
   signalCondition(condition)
 }
-
-renv_condition_data <- function(condition) {
-  condition$data
-}

--- a/R/hydrate.R
+++ b/R/hydrate.R
@@ -205,7 +205,7 @@ renv_hydrate_packages_rprofile <- function() {
 
 renv_hydrate_packages <- function(project) {
 
-  deps <- dependencies(project, quiet = TRUE, dev = TRUE)
+  deps <- the$init_dependencies %||% dependencies(project, quiet = TRUE, dev = TRUE)
 
   profdeps <- renv_hydrate_packages_rprofile()
   if (length(deps) && length(profdeps))

--- a/R/init.R
+++ b/R/init.R
@@ -120,8 +120,9 @@ init <- function(project = NULL,
   if (bare)
     return(renv_init_fini(project, profile, restart, quiet))
 
-  # collect dependencies
-  renv_dependencies_scope(project, action = "init")
+  # compute and cache dependencies to (a) reveal problems early and (b) compute once
+  the$init_dependencies <- renv_dependencies_confirm("init", path = project, dev = TRUE)
+  defer(the$init_dependencies <- NULL)
 
   # determine appropriate action
   action <- renv_init_action(project, library, lockfile, bioconductor)

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -852,10 +852,11 @@ renv_snapshot_report_actions <- function(actions, old, new) {
 
 renv_snapshot_dependencies <- function(project, type = NULL, dev = FALSE) {
 
-  type <- type %||% settings$snapshot.type(project = project)
+  if (!is.null(the$init_dependencies)) {
+    return(the$init_dependencies$Package)
+  }
 
-  message <- "snapshot aborted"
-  errors <- config$dependency.errors()
+  type <- type %||% settings$snapshot.type(project = project)
 
   if (type %in% "all")
     return(installed_packages(field = "Package"))
@@ -874,19 +875,12 @@ renv_snapshot_dependencies <- function(project, type = NULL, dev = FALSE) {
     }
   )
 
-  withCallingHandlers(
-
-    renv_dependencies_impl(
-      path     = path,
-      root     = project,
-      progress = FALSE,
-      field    = "Package",
-      errors   = errors,
-      dev      = dev
-    ),
-
-    renv.dependencies.error = renv_dependencies_error_handler(message, errors)
-
+  renv_dependencies_confirm(
+    "snapshot",
+    path = path,
+    root = project,
+    field = "Package",
+    dev = dev
   )
 
 }


### PR DESCRIPTION
* Instead of `renv_dependency_scope()` we now have `renv_dependency_confirm()`
* Only `init()` caches dependency computation, and it's now explicit