### PR TITLE
support optional pretty print emitter

### DIFF
--- a/R/pretty.R
+++ b/R/pretty.R
@@ -23,9 +23,15 @@ renv_pretty_print <- function(values,
   }
 
   msg$push("")
-  text <- paste(as.character(msg$data()), collapse = "\n")
 
-  # NOTE: Used by vetiver, so is part of the API
+  text <- paste(as.character(msg$data()), collapse = "\n")
+  renv_pretty_print_impl(text)
+
+}
+
+renv_pretty_print_impl <- function(text) {
+
+  # NOTE: Used by vetiver, so perhaps is part of the API
   # https://github.com/rstudio/renv/issues/1413
   emitter <- getOption("renv.pretty.print.emitter", default = writef)
   emitter(text)
@@ -60,12 +66,7 @@ renv_pretty_print_records <- function(records,
     postamble, if (length(postamble)) ""
   )
 
-  # NOTE: Used by vetiver, so is part of the API
-  # https://github.com/rstudio/renv/issues/1413
-  emitter <- getOption("renv.pretty.print.emitter", default = writef)
-  emitter(all)
-
-  invisible(NULL)
+  renv_pretty_print_impl(all)
 }
 
 renv_pretty_print_records_pair <- function(old,
@@ -82,12 +83,7 @@ renv_pretty_print_records_pair <- function(old,
     if (length(postamble)) c(postamble, "")
   )
 
-  # NOTE: Used by vetiver, so is part of the API
-  # https://github.com/rstudio/renv/issues/1413
-  emitter <- getOption("renv.pretty.print.emitter", default = writef)
-  emitter(all)
-
-  invisible(NULL)
+  renv_pretty_print_impl(all)
 }
 
 renv_pretty_print_records_pair_impl <- function(old, new, formatter) {

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -30,6 +30,8 @@ renv_pretty_print <- function(values,
   emitter <- getOption("renv.pretty.print.emitter", default = writef)
   emitter(text)
 
+  invisible(NULL)
+
 }
 
 renv_pretty_print_records <- function(records,

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -25,7 +25,11 @@ renv_pretty_print <- function(values,
   msg$push("")
   text <- paste(as.character(msg$data()), collapse = "\n")
 
-  writef(text)
+  # NOTE: Used by vetiver, so is part of the API
+  # https://github.com/rstudio/renv/issues/1413
+  emitter <- getOption("renv.pretty.print.emitter", default = writef)
+  emitter(text)
+
 }
 
 renv_pretty_print_records <- function(records,
@@ -38,10 +42,10 @@ renv_pretty_print_records <- function(records,
   if (!renv_verbose())
     return(invisible(NULL))
 
-  names(records) <- names(records) %||% map_chr(records, `[[`, "Package")
   # NOTE: use 'sort()' rather than 'csort()' here so that
   # printed output is sorted in the expected way in the users locale
   # https://github.com/rstudio/renv/issues/1289
+  names(records) <- names(records) %||% map_chr(records, `[[`, "Package")
   records <- records[sort(names(records))]
   packages <- names(records)
   descs <- map_chr(records, renv_record_format_short)
@@ -54,7 +58,10 @@ renv_pretty_print_records <- function(records,
     postamble, if (length(postamble)) ""
   )
 
-  writef(all)
+  # NOTE: Used by vetiver, so is part of the API
+  # https://github.com/rstudio/renv/issues/1413
+  emitter <- getOption("renv.pretty.print.emitter", default = writef)
+  emitter(all)
 
   invisible(NULL)
 }
@@ -73,7 +80,10 @@ renv_pretty_print_records_pair <- function(old,
     if (length(postamble)) c(postamble, "")
   )
 
-  writef(all)
+  # NOTE: Used by vetiver, so is part of the API
+  # https://github.com/rstudio/renv/issues/1413
+  emitter <- getOption("renv.pretty.print.emitter", default = writef)
+  emitter(all)
 
   invisible(NULL)
 }

--- a/tests/testthat/test-pretty.R
+++ b/tests/testthat/test-pretty.R
@@ -1,3 +1,4 @@
+
 test_that("renv_pretty_print() creates bulleted list with optional preamble/postable", {
   expect_snapshot({
     renv_pretty_print(letters[1:3])
@@ -8,5 +9,28 @@ test_that("renv_pretty_print() creates bulleted list with optional preamble/post
 
 test_that("renv_pretty_print() doesn't show pre/post amble if no values", {
   expect_silent(renv_pretty_print(character(), "before", "after"))
+})
+
+test_that("options(renv.pretty.print.emitter) is respected", {
+
+  skip_on_cran()
+  project <- renv_tests_scope("bread")
+  init()
+
+  cls <- "renv.pretty.print.emitter"
+  emitter <- function(text) renv_condition_signal(cls)
+  renv_scope_options(renv.pretty.print.emitter = emitter)
+  renv_scope_options(renv.verbose = TRUE)
+
+  # regular pretty printer
+  expect_condition(renv_pretty_print(1), class = cls)
+
+  # record printer
+  lockfile <- renv_lockfile_create(project = getwd())
+  records <- renv_lockfile_records(lockfile)
+  expect_condition(renv_pretty_print_records(records), class = cls)
+
+  # diff printer
+  expect_condition(renv_pretty_print_records_pair(records, records))
 
 })


### PR DESCRIPTION
Closes https://github.com/rstudio/renv/issues/1413.

@hadley @juliasilge: this PR brings back the previous behavior; do you think this is sufficient or should we consider an alternate mechanism for customizing how messages are printed?