### PR TITLE
Cache dependencies per file

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -466,13 +466,13 @@ renv_dependencies_discover_impl <- function(path) {
     warningf(fmt, renv_path_pretty(path))
   }
 
-  result <- catch(callback(path))
-  if (inherits(result, "error")) {
-    warning(result)
-    return(NULL)
-  }
-
-  result
+  tryCatch(
+    filebacked("dependencies", path, callback),
+    error = function(cnd) {
+      warning(cnd)
+      NULL
+    }
+  )
 
 }
 


### PR DESCRIPTION
This takes the run-time of `renv::dependencies()` on renv its from 3s down to 0.1s, where ~75% of the remaining time is from `file.info()`.

There is one possible drawback to the current implementation. Because problems are emitted as a side-effect, they're not replaced by the cache so you'll only see them the first time the file is processed. But OTOH, it's nice to only be warned about problems once per session, rather than every time.

If you want me to fix this, I think it'll require that the individual `renv_dependencies_discover_*` callbacks return a list of dependencies and problems.