### PR TITLE
extra spacing in installation output

### DIFF
--- a/R/difftime.R
+++ b/R/difftime.R
@@ -1,9 +1,8 @@
 
 renv_difftime_format <- function(time, digits = 2L) {
 
-  if (is_testing()) {
-    return ("XXXX seconds")
-  }
+  if (is_testing())
+    return("XXXX seconds")
 
   units <- attr(time, "units") %||% ""
   if (units == "secs" && time < 0.1) {
@@ -49,13 +48,12 @@ renv_difftime_format_short <- function(time, digits = 2L) {
 }
 
 renv_difftime_format_slow <- function(time, prefix = "", threshold = 1) {
-  if (renv_tests_running()) {
-    return("")
-  }
 
-  if (as.difftime(time, units = "secs") < threshold) {
+  if (renv_tests_running())
     return("")
-  }
+
+  if (as.difftime(time, units = "secs") < threshold)
+    return("")
 
   paste0(prefix, renv_difftime_format(time))
 }

--- a/R/difftime.R
+++ b/R/difftime.R
@@ -30,6 +30,9 @@ renv_difftime_format <- function(time, digits = 2L) {
 
 renv_difftime_format_short <- function(time, digits = 2L) {
 
+  if (is_testing())
+    return("XXs")
+
   elapsed <- signif(time, digits = digits)
   if (nchar(elapsed) == 1L)
     elapsed <- paste(elapsed, ".0", sep = "")

--- a/R/download.R
+++ b/R/download.R
@@ -4,8 +4,13 @@
 # what form of authentication is appropriate; the 'quiet'
 # argument is used to display / suppress output. use 'headers'
 # (as a named character vector) to supply additional headers
-download <- function(url, destfile, type = NULL, quiet = FALSE, headers = NULL) {
-
+download <- function(url,
+                     destfile,
+                     preamble = NULL,
+                     type = NULL,
+                     quiet = FALSE,
+                     headers = NULL)
+{
   # allow for user-defined overrides
   override <- getOption("renv.download.override")
   if (is.function(override)) {
@@ -39,7 +44,8 @@ download <- function(url, destfile, type = NULL, quiet = FALSE, headers = NULL) 
   destfile <- chartr("\\", "/", destfile)
 
   # notify user we're about to try downloading
-  writef("Retrieving '%s' ...", url)
+  preamble <- preamble %||% sprintf("- Downloading '%s' ... ", url)
+  printf(preamble)
 
   # add custom headers as appropriate for the URL
   headers <- c(headers, renv_download_custom_headers(url))
@@ -57,7 +63,7 @@ download <- function(url, destfile, type = NULL, quiet = FALSE, headers = NULL) 
   if (identical(info$isdir, FALSE)) {
     size <- renv_download_size(url, type, headers)
     if (info$size == size) {
-      writef("\tOK [file is up to date]")
+      writef("OK [file is up to date]")
       return(destfile)
     }
   }
@@ -113,7 +119,6 @@ download <- function(url, destfile, type = NULL, quiet = FALSE, headers = NULL) 
 
   # and return path to successfully retrieved file
   destfile
-
 }
 
 # NOTE: only 'GET' and 'HEAD' are supported
@@ -643,15 +648,13 @@ renv_download_report <- function(elapsed, file) {
     return()
 
   info <- renv_file_info(file)
-  if (renv_tests_running()) {
-    size <- "XXXX bytes"
-  } else {
-    size <- structure(info$size, class = "object_size")
-  }
+  size <- if (renv_tests_running())
+    "XXXX bytes"
+  else
+    structure(info$size, class = "object_size")
 
-
-  fmt <- "\tOK [downloaded %s in %s]"
-  writef(fmt, format(size, units = "auto"), renv_difftime_format(elapsed))
+  fmt <- "OK [%s in %s]"
+  writef(fmt, format(size, units = "auto"), renv_difftime_format_short(elapsed))
 
 }
 

--- a/R/imbue.R
+++ b/R/imbue.R
@@ -67,12 +67,12 @@ renv_imbue_impl <- function(project, version = NULL, force = FALSE) {
   ensure_directory(library)
   renv_scope_libpaths(library)
 
-  writef("Installing renv [%s] ...", version)
+  printf("- Installing renv [%s] ... ", version)
   before <- Sys.time()
   with(record, r_cmd_install(Package, Path, library))
   after <- Sys.time()
   elapsed <- difftime(after, before, units = "auto")
-  writef("\tOK [built source in %s]", renv_difftime_format(elapsed))
+  writef("OK [built source in %s]", renv_difftime_format(elapsed))
 
   invisible(record)
 

--- a/R/install.R
+++ b/R/install.R
@@ -341,7 +341,7 @@ renv_install_default <- function(records) {
   handler <- state$handler
 
   width <- max(nchar(map_chr(records, function(x) x$Package)), 1)
-  renv_scope_binding(the, "package_width", width)
+  renv_scope_binding(the, "package_format_width", width)
 
   for (record in records) {
     package <- record$Package
@@ -803,7 +803,7 @@ renv_install_step_start <- function(action, package) {
   printf(
     "- %s %s ... ",
     format(action, width = nchar(action)),
-    format(package, width = the$package_width %||% 12)
+    format(package, width = the$package_format_width %||% 12)
   )
 }
 

--- a/R/install.R
+++ b/R/install.R
@@ -1,4 +1,6 @@
 
+the$install_step_width <- 48L
+
 #' Install packages
 #'
 #' @description
@@ -193,8 +195,6 @@ install <- function(packages = NULL,
   if (prompt || renv_verbose()) {
     renv_install_report(records, library = renv_libpaths_active())
     cancel_if(prompt && !proceed())
-    if (prompt && interactive())
-      writef("")
   }
 
   # install retrieved records
@@ -340,8 +340,8 @@ renv_install_default <- function(records) {
   state <- renv_restore_state()
   handler <- state$handler
 
-  width <- max(nchar(map_chr(records, function(x) x$Package)), 1)
-  renv_scope_binding(the, "package_format_width", width)
+  # width <- max(nchar(map_chr(records, function(x) x$Package)), 1)
+  # renv_scope_binding(the, "package_format_width", width)
 
   for (record in records) {
     package <- record$Package
@@ -800,11 +800,8 @@ renv_install_report <- function(records, library) {
 }
 
 renv_install_step_start <- function(action, package) {
-  printf(
-    "- %s %s ... ",
-    format(action, width = nchar(action)),
-    format(package, width = the$package_format_width %||% 12)
-  )
+  message <- sprintf("- %s %s ... ", action, package)
+  printf(format(message, width = the$install_step_width))
 }
 
 renv_install_step_ok <- function(..., time = NULL) {

--- a/R/install.R
+++ b/R/install.R
@@ -197,13 +197,15 @@ install <- function(packages = NULL,
   cancel_if(prompt && !proceed())
 
   # install retrieved records
+  writef("")
   before <- Sys.time()
   renv_install_impl(records)
   after <- Sys.time()
+  writef("")
 
   time <- renv_difftime_format(difftime(after, before))
   n <- length(records)
-  writef("Installed %s in %s.", nplural("package", n), time)
+  writef("Successfully installed %s in %s.", nplural("package", n), time)
 
   # check loaded packages and inform user if out-of-sync
   renv_install_postamble(names(records))

--- a/R/restore.R
+++ b/R/restore.R
@@ -288,11 +288,11 @@ renv_restore_report_actions <- function(actions, current, lockfile) {
 renv_restore_remove <- function(project, package, lockfile) {
   records <- renv_lockfile_records(lockfile)
   record <- records[[package]]
-  writef("Removing %s [%s] ...", package, record$Version)
+  printf("- Removing %s [%s] ... ", package, record$Version)
   paths <- renv_paths_library(project = project, package)
   recursive <- renv_file_type(paths) == "directory"
   unlink(paths, recursive = recursive)
-  writef("\tOK [removed from library]")
+  writef("OK [removed from library]")
   TRUE
 }
 

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -29,7 +29,6 @@ retrieve <- function(packages) {
   renv_scope_options(HTTPUserAgent = agent)
 
   writef(header("Downloading packages"))
-  # TODO: parallel?
   handler <- state$handler
   for (package in packages)
     handler(package, renv_retrieve_impl(package))

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -811,13 +811,7 @@ renv_snapshot_description_infer <- function(dcf) {
   if (renv_version_lt(inferred[["Version"]], dcf[["Version"]]))
     return(dcf)
 
-  # notify the user if we inferred a different package remote
-  if (!identical(dcf, inferred)) {
-    package <- dcf[["Package"]]
-    remote <- renv_record_format_remote(inferred)
-    writef("* '%s' inferred to have been installed from remote '%s'.", package, remote)
-  }
-
+  # use the inferred record
   inferred
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -331,7 +331,7 @@ header <- function(label,
                    suffix = "-",
                    n = min(getOption("width"), 78))
 {
-  n <- max(n - nchar(label) - nchar(prefix) - 2L, 3)
+  n <- max(n - nchar(label) - nchar(prefix) - 2L, 8L)
   if (n <= 0)
     return(paste(prefix, label))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -141,12 +141,16 @@ ask <- function(question, default = FALSE) {
       return(default)
 
     # check for 'yes' responses
-    if (response %in% c("y", "yes"))
+    if (response %in% c("y", "yes")) {
+      writef("")
       return(TRUE)
+    }
 
     # check for 'no' responses
-    if (response %in% c("n", "no"))
+    if (response %in% c("n", "no")) {
+      writef("")
       return(FALSE)
+    }
 
     # ask the user again
     writef("* Unrecognized response: please enter 'y' or 'n', or type Ctrl + C to cancel.")

--- a/tests/testthat/_snaps/bioconductor.md
+++ b/tests/testthat/_snaps/bioconductor.md
@@ -26,13 +26,15 @@
       # Downloading packages ---
       [no downloads required]
       
-      # Installing packages into "<tempdir>/<renv-library>" ---
       The following package(s) will be installed:
       
       - BiocGenerics [<version>]
       
+      These packages will be installed into "<tempdir>/<renv-library>".
       
-      Installing BiocGenerics ... OK [copied from cache]
+      # Installing packages ---
+      
+      - Installing BiocGenerics ... OK [copied from cache]
       
       Successfully installed 1 package in XXXX seconds.
 

--- a/tests/testthat/_snaps/bioconductor.md
+++ b/tests/testthat/_snaps/bioconductor.md
@@ -34,7 +34,7 @@
       
       # Installing packages ---
       
-      - Installing BiocGenerics ... OK [copied from cache]
+      - Installing BiocGenerics ...                   OK [copied from cache]
       
       Successfully installed 1 package in XXXX seconds.
 

--- a/tests/testthat/_snaps/bioconductor.md
+++ b/tests/testthat/_snaps/bioconductor.md
@@ -31,6 +31,8 @@
       
       - BiocGenerics [<version>]
       
+      
       Installing BiocGenerics ... OK [copied from cache]
-      Installed 1 package in XXXX seconds.
+      
+      Successfully installed 1 package in XXXX seconds.
 

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -14,7 +14,7 @@
       
       # Installing packages ---
       
-      - Installing bread ... OK [copied from cache]
+      - Installing bread ...                          OK [copied from cache]
       
       Successfully installed 1 package in XXXX seconds.
       
@@ -31,14 +31,11 @@
       install()
     Output
       # Downloading packages ---
-      Retrieving '<test-repo>/src/contrib/breakfast_1.0.0.tar.gz' ...
-      	OK [downloaded XXXX bytes in XXXX seconds]
-      Retrieving '<test-repo>/src/contrib/oatmeal_1.0.0.tar.gz' ...
-      	OK [downloaded XXXX bytes in XXXX seconds]
-      Retrieving '<test-repo>/src/contrib/toast_1.0.0.tar.gz' ...
-      	OK [downloaded XXXX bytes in XXXX seconds]
-      Retrieving '<test-repo>/src/contrib/bread_1.0.0.tar.gz' ...
-      	OK [downloaded XXXX bytes in XXXX seconds]
+      
+      - Downloading breakfast from CRAN ...           OK [XXXX bytes in 0.0023s]
+      - Downloading oatmeal from CRAN ...             OK [XXXX bytes in 0.002s]
+      - Downloading toast from CRAN ...               OK [XXXX bytes in 0.002s]
+      - Downloading bread from CRAN ...               OK [XXXX bytes in 0.002s]
       
       The following package(s) will be installed:
       
@@ -51,10 +48,10 @@
       
       # Installing packages ---
       
-      - Installing oatmeal   ... OK [built from source and cached]
-      - Installing bread     ... OK [built from source and cached]
-      - Installing toast     ... OK [built from source and cached]
-      - Installing breakfast ... OK [built from source and cached]
+      - Installing oatmeal ...                        OK [built from source and cached]
+      - Installing bread ...                          OK [built from source and cached]
+      - Installing toast ...                          OK [built from source and cached]
+      - Installing breakfast ...                      OK [built from source and cached]
       
       Successfully installed 4 packages in XXXX seconds.
 
@@ -77,10 +74,10 @@
       
       # Installing packages ---
       
-      - Installing oatmeal   ... OK [copied from cache]
-      - Installing bread     ... OK [copied from cache]
-      - Installing toast     ... OK [copied from cache]
-      - Installing breakfast ... OK [copied from cache]
+      - Installing oatmeal ...                        OK [copied from cache]
+      - Installing bread ...                          OK [copied from cache]
+      - Installing toast ...                          OK [copied from cache]
+      - Installing breakfast ...                      OK [copied from cache]
       
       Successfully installed 4 packages in XXXX seconds.
 

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -51,10 +51,10 @@
       
       # Installing packages ---
       
-      Installing oatmeal   ... OK [built from source and cached]
-      Installing bread     ... OK [built from source and cached]
-      Installing toast     ... OK [built from source and cached]
-      Installing breakfast ... OK [built from source and cached]
+      - Installing oatmeal   ... OK [built from source and cached]
+      - Installing bread     ... OK [built from source and cached]
+      - Installing toast     ... OK [built from source and cached]
+      - Installing breakfast ... OK [built from source and cached]
       
       Successfully installed 4 packages in XXXX seconds.
 

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -32,10 +32,10 @@
     Output
       # Downloading packages ---
       
-      - Downloading breakfast from CRAN ...           OK [XXXX bytes in 0.0023s]
-      - Downloading oatmeal from CRAN ...             OK [XXXX bytes in 0.002s]
-      - Downloading toast from CRAN ...               OK [XXXX bytes in 0.002s]
-      - Downloading bread from CRAN ...               OK [XXXX bytes in 0.002s]
+      - Downloading breakfast from CRAN ...           OK [XXXX bytes in XXs]
+      - Downloading oatmeal from CRAN ...             OK [XXXX bytes in XXs]
+      - Downloading toast from CRAN ...               OK [XXXX bytes in XXs]
+      - Downloading bread from CRAN ...               OK [XXXX bytes in XXs]
       
       The following package(s) will be installed:
       

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -11,8 +11,10 @@
       
       - bread [0.1.0]
       
+      
       Installing bread ... OK [copied from cache]
-      Installed 1 package in XXXX seconds.
+      
+      Successfully installed 1 package in XXXX seconds.
       
       The following loaded package(s) have been updated:
       
@@ -44,11 +46,13 @@
       - oatmeal   [1.0.0]
       - toast     [1.0.0]
       
+      
       Installing oatmeal   ... OK [built from source and cached]
       Installing bread     ... OK [built from source and cached]
       Installing toast     ... OK [built from source and cached]
       Installing breakfast ... OK [built from source and cached]
-      Installed 4 packages in XXXX seconds.
+      
+      Successfully installed 4 packages in XXXX seconds.
 
 ---
 
@@ -66,9 +70,11 @@
       - oatmeal   [1.0.0]
       - toast     [1.0.0]
       
+      
       Installing oatmeal   ... OK [copied from cache]
       Installing bread     ... OK [copied from cache]
       Installing toast     ... OK [copied from cache]
       Installing breakfast ... OK [copied from cache]
-      Installed 4 packages in XXXX seconds.
+      
+      Successfully installed 4 packages in XXXX seconds.
 

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -6,13 +6,15 @@
       # Downloading packages ---
       [no downloads required]
       
-      # Installing packages into "<tempdir>/<renv-library>" ---
       The following package(s) will be installed:
       
       - bread [0.1.0]
       
+      These packages will be installed into "<tempdir>/<renv-library>".
       
-      Installing bread ... OK [copied from cache]
+      # Installing packages ---
+      
+      - Installing bread ... OK [copied from cache]
       
       Successfully installed 1 package in XXXX seconds.
       
@@ -38,7 +40,6 @@
       Retrieving '<test-repo>/src/contrib/bread_1.0.0.tar.gz' ...
       	OK [downloaded XXXX bytes in XXXX seconds]
       
-      # Installing packages into "<tempdir>/<renv-library>" ---
       The following package(s) will be installed:
       
       - bread     [1.0.0]
@@ -46,6 +47,9 @@
       - oatmeal   [1.0.0]
       - toast     [1.0.0]
       
+      These packages will be installed into "<tempdir>/<renv-library>".
+      
+      # Installing packages ---
       
       Installing oatmeal   ... OK [built from source and cached]
       Installing bread     ... OK [built from source and cached]
@@ -62,7 +66,6 @@
       # Downloading packages ---
       [no downloads required]
       
-      # Installing packages into "<tempdir>/<renv-library>" ---
       The following package(s) will be installed:
       
       - bread     [1.0.0]
@@ -70,11 +73,14 @@
       - oatmeal   [1.0.0]
       - toast     [1.0.0]
       
+      These packages will be installed into "<tempdir>/<renv-library>".
       
-      Installing oatmeal   ... OK [copied from cache]
-      Installing bread     ... OK [copied from cache]
-      Installing toast     ... OK [copied from cache]
-      Installing breakfast ... OK [copied from cache]
+      # Installing packages ---
+      
+      - Installing oatmeal   ... OK [copied from cache]
+      - Installing bread     ... OK [copied from cache]
+      - Installing toast     ... OK [copied from cache]
+      - Installing breakfast ... OK [copied from cache]
       
       Successfully installed 4 packages in XXXX seconds.
 

--- a/tests/testthat/_snaps/lockfile-read.md
+++ b/tests/testthat/_snaps/lockfile-read.md
@@ -6,5 +6,5 @@
       Failed to parse 'renv.lock':
       parse error: premature EOF
                                              {
-                           (right here) ---^
+                           (right here) ------^
 

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -175,8 +175,8 @@
       Selection: 2
       
       # Downloading packages ---
-      Retrieving '<test-repo>/src/contrib/egg_1.0.0.tar.gz' ...
-      	OK [downloaded XXXX bytes in XXXX seconds]
+      
+      - Downloading egg from CRAN ...                 OK [XXXX bytes in 0.0012s]
       
       The following package(s) will be installed:
       
@@ -186,7 +186,7 @@
       
       # Installing packages ---
       
-      - Installing egg ... OK [built from source and cached]
+      - Installing egg ...                            OK [built from source and cached]
       
       Successfully installed 1 package in XXXX seconds.
       The following package(s) will be updated in the lockfile:
@@ -219,6 +219,4 @@
 
     Code
       . <- renv_snapshot_description(path = descfile)
-    Output
-      * 'renv' inferred to have been installed from remote 'rstudio/renv@main'.
 

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -176,7 +176,7 @@
       
       # Downloading packages ---
       
-      - Downloading egg from CRAN ...                 OK [XXXX bytes in 0.0012s]
+      - Downloading egg from CRAN ...                 OK [XXXX bytes in XXs]
       
       The following package(s) will be installed:
       

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -183,8 +183,10 @@
       
       - egg [1.0.0]
       
+      
       Installing egg ... OK [built from source and cached]
-      Installed 1 package in XXXX seconds.
+      
+      Successfully installed 1 package in XXXX seconds.
       The following package(s) will be updated in the lockfile:
       
       # CRAN ---

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -178,11 +178,13 @@
       Retrieving '<test-repo>/src/contrib/egg_1.0.0.tar.gz' ...
       	OK [downloaded XXXX bytes in XXXX seconds]
       
-      # Installing packages into "<tempdir>/<renv-library>" ---
       The following package(s) will be installed:
       
       - egg [1.0.0]
       
+      These packages will be installed into "<tempdir>/<renv-library>".
+      
+      # Installing packages ---
       
       Installing egg ... OK [built from source and cached]
       

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -186,7 +186,7 @@
       
       # Installing packages ---
       
-      Installing egg ... OK [built from source and cached]
+      - Installing egg ... OK [built from source and cached]
       
       Successfully installed 1 package in XXXX seconds.
       The following package(s) will be updated in the lockfile:

--- a/tests/testthat/helper-snapshot.R
+++ b/tests/testthat/helper-snapshot.R
@@ -25,14 +25,14 @@ strip_dirs <- function(x) {
   # note also that order matters for snapshot tests; the least-specific
   # paths should go at the end of this list
   filters <- list(
+    "<R>"               = file.path(R.home("bin"), "R"),
     "<cache>"           = renv_paths_cache(),
     "<platform-prefix>" = renv_platform_prefix(),
     "<r-version>"       = getRversion(),
     "<test-repo>"       = getOption("repos")[[1L]],
     "<root>"            = renv_path_normalize(renv_paths_root()),
     "<wd>"              = renv_path_normalize(getwd()),
-    "<tempdir>"         = renv_path_normalize(tempdir()),
-    "<R>"               = file.path(R.home("bin"), "R")
+    "<tempdir>"         = renv_path_normalize(tempdir())
   )
 
   # apply filters
@@ -46,7 +46,7 @@ strip_dirs <- function(x) {
   x <- gsub(renv_path_aliased(tempdir()), "<tempdir>", x, fixed = TRUE)
 
   # Standardise the dashes produced by header()
-  x <- gsub("-{3,}", "---", x, perl = TRUE)
+  x <- gsub("-{3,}\\s*$", "---", x, perl = TRUE)
 
   x
 

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -151,7 +151,6 @@ test_that("we use an external library path for package projects", {
   # check for external library path
   library <- renv_libpaths_active()
 
-
   expect_true(
     object = renv_path_within(library, userdir),
     info = sprintf("- %s\n- %s\n", library, userdir)


### PR DESCRIPTION
IMHO the extra spacing makes things a bit cleaner, and matches the spacing we use in "standard" pretty print outputs.

```
> renv::install(c("tidyverse", "dplyr"))
# Downloading packages -------------------------------------------------------
[no downloads required]

# Installing packages into "~/Library/R/arm64/4.3/library" -------------------
The following package(s) will be installed:

- dplyr     [1.1.2]
- tidyverse [2.0.0]

Do you want to proceed? [Y/n]: y

Installing dplyr     ... OK [copied from cache]
Installing tidyverse ... OK [copied from cache]

Successfully installed 2 packages in 0.13 seconds.
```