### PR TITLE
Call post-load user feedback functions directly

### DIFF
--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -24,10 +24,6 @@ renv_rstudio_initialize <- function(project) {
 
 }
 
-renv_rstudio_loading <- function() {
-  renv_rstudio_available() && !identical(.Platform$GUI, "RStudio")
-}
-
 renv_rstudio_fixup <- function() {
 
   # if RStudio's tools are on the search path, we should try


### PR DESCRIPTION
Since the entire bootstrapping operation is now called inside a `sessionInit` hook when needed.