### PR TITLE
tweaks to bootstrap output display

### DIFF
--- a/R/activate.R
+++ b/R/activate.R
@@ -63,7 +63,7 @@ activate <- function(project = NULL, profile = NULL) {
 
 renv_activate_impl <- function(project,
                                profile,
-                               version,
+                               version = NULL,
                                restart = TRUE)
 {
   # prepare renv infrastructure

--- a/R/activate.R
+++ b/R/activate.R
@@ -138,8 +138,10 @@ renv_activate_version_lockfile <- function(project) {
 
 }
 
+# TODO: can we unravel this, and just record the metadata structure
+# into the activate script?
 renv_activate_version_default <- function(project) {
-  renv_metadata_version()
+  the$metadata$sha %||% the$metadata$version
 }
 
 renv_activate_prompt <- function(action, library, prompt, project) {

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -39,9 +39,9 @@ bootstrap <- function(version, library) {
   # load failed; inform user we're about to bootstrap
   friendly <- version
   if (nchar(friendly) >= 40)
-    friendly <- sprintf("rstudio/renv@%s", substring(version, 1L, 7L))
+    friendly <- sprintf("[rstudio/renv@%s]", substring(version, 1L, 7L))
 
-  section <- header(paste("Bootstrapping renv", friendly))
+  section <- header(sprintf("Bootstrapping renv %s", friendly))
   catf(section)
 
   # attempt to download renv

--- a/R/init.R
+++ b/R/init.R
@@ -147,7 +147,7 @@ renv_init_fini <- function(project, profile, restart) {
   renv_activate_impl(
     project = project,
     profile = profile,
-    version = renv_metadata_version(),
+    version = the$metadata$sha %||% the$metadata$version,
     restart = restart
   )
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -1,28 +1,39 @@
 
-renv_metadata_version <- function() {
-  the$metadata$sha %||% the$metadata$version
-}
-
-renv_metadata_version_friendly <- function(metadata = the$metadata) {
-  ver <- metadata$version
-
-  if (renv_metadata_is_dev(metadata)) {
-    ver <- paste0(ver, "; rstudio/renv@", substr(metadata$sha, 1, 7))
-  }
-
-  ver
-}
-
-renv_metadata_is_dev <- function(metadata = the$metadata) {
-  if (!is.null(metadata$sha)) {
-    TRUE
-  } else {
-    renv_version_length(metadata$version) != 3L
-  }
-}
+# NOTE: 'the$metadata' is initialized either in 'renv_metadata_init()', for
+# stand-alone installations of renv, or via an embedded initialize script for
+# vendored copies of renv.
 
 renv_metadata_embedded <- function() {
   the$metadata$embedded
+}
+
+renv_metadata_version <- function() {
+  the$metadata$version
+}
+
+renv_metadata_sha <- function() {
+  the$metadata$sha
+}
+
+renv_metadata_remote <- function(metadata = the$metadata) {
+
+  if (!is.null(metadata$sha))
+    paste("rstudio/renv", metadata$sha, sep = "@")
+  else
+    paste("renv", metadata$version, sep = "@")
+
+}
+
+renv_metadata_version_friendly <- function(metadata = the$metadata) {
+
+  version <- metadata$version
+
+  sha <- metadata$sha
+  if (!is.null(sha))
+    version <- sprintf("%s; rstudio/renv@%s", version, substring(sha, 1L, 7L))
+
+  version
+
 }
 
 renv_metadata_init <- function() {

--- a/R/patch.R
+++ b/R/patch.R
@@ -172,7 +172,7 @@ renv_patch_repos <- function() {
 
   # presumably this will never happen when the dev version of renv is
   # installed, so we skip to avoid parsing a sha as version
-  if (renv_metadata_is_dev())
+  if (!is.null(the$metadata$sha))
     return()
 
   # nothing to do if this version of 'renv' is already available

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -1207,11 +1207,7 @@ renv_snapshot_fixup_renv <- function(records) {
     return(records)
 
   # no valid record available; construct a synthetic one
-  version <- renv_metadata_version()
-  remote <- if (renv_metadata_is_dev())
-    paste("rstudio/renv", version, sep = "@")
-  else
-    paste("renv", version, sep = "@")
+  remote <- renv_metadata_remote()
 
   # add it to the set of records
   records$renv <- renv_remotes_resolve(remote)

--- a/R/utils.R
+++ b/R/utils.R
@@ -334,20 +334,6 @@ remap <- function(x, map) {
 
 }
 
-header <- function(label,
-                   prefix = "#",
-                   suffix = "-",
-                   n = min(getOption("width"), 78))
-{
-  n <- max(n - nchar(label) - nchar(prefix) - 2L, 8L)
-  if (n <= 0)
-    return(paste(prefix, label))
-
-  tail <- paste(rep.int(suffix, n), collapse = "")
-  paste0(prefix, " ", label, " ", tail)
-
-}
-
 keep <- function(x, keys) {
   x[intersect(keys, names(x))]
 }

--- a/inst/resources/activate.R
+++ b/inst/resources/activate.R
@@ -59,10 +59,6 @@ local({
     unloadNamespace("renv")
 
   # load bootstrap tools   
-  startswith <- function(string, prefix) {
-    substring(string, 1, nchar(prefix)) == prefix
-  }
-  
   `%||%` <- function(x, y) {
     if (is.null(x)) y else x
   }
@@ -80,27 +76,56 @@ local({
   
   }
   
+  header <- function(label,
+                     prefix = "#",
+                     suffix = "-",
+                     n = min(getOption("width"), 78))
+  {
+    n <- max(n - nchar(label) - nchar(prefix) - 2L, 8L)
+    if (n <= 0)
+      return(paste(prefix, label))
+  
+    tail <- paste(rep.int(suffix, n), collapse = "")
+    paste0(prefix, " ", label, " ", tail)
+  
+  }
+  
+  startswith <- function(string, prefix) {
+    substring(string, 1, nchar(prefix)) == prefix
+  }
+  
   bootstrap <- function(version, library) {
   
     # load failed; inform user we're about to bootstrap
-    catf("Bootstrapping renv %s:", version)
+    friendly <- version
+    if (nchar(friendly) >= 40)
+      friendly <- sprintf("rstudio/renv@%s", substring(version, 1L, 7L))
+  
+    section <- header(paste("Bootstrapping renv", friendly))
+    catf(section)
   
     # attempt to download renv
+    catf("- Downloading renv ... ", appendLF = FALSE)
     withCallingHandlers(
       tarball <- renv_bootstrap_download(version),
       error = function(err) {
+        catf("FAILED")
         stop("failed to download:\n", conditionMessage(err))
       }
     )
+    catf("OK")
     on.exit(unlink(tarball), add = TRUE)
   
     # now attempt to install
+    catf("- Installing renv  ... ", appendLF = FALSE)
     withCallingHandlers(
       status <- renv_bootstrap_install(version, tarball, library),
       error = function(err) {
+        catf("FAILED")
         stop("failed to install:\n", conditionMessage(err))
       }
     )
+    catf("OK")
   
     # add empty line to break up bootstrapping from normal output
     catf("")
@@ -260,8 +285,6 @@ local({
     type  <- spec$type
     repos <- spec$repos
   
-    catf("* Downloading %s from <%s> ... ", type, repos, appendLF = FALSE)
-  
     baseurl <- utils::contrib.url(repos = repos, type = type)
     ext <- if (identical(type, "source"))
       ".tar.gz"
@@ -278,13 +301,10 @@ local({
       condition = identity
     )
   
-    if (inherits(status, "condition")) {
-      catf("FAILED")
+    if (inherits(status, "condition"))
       return(FALSE)
-    }
   
     # report success and return
-    catf("OK")
     destfile
   
   }
@@ -341,8 +361,6 @@ local({
     urls <- file.path(repos, "src/contrib/Archive/renv", name)
     destfile <- file.path(tempdir(), name)
   
-    catf("* Downloading from archive ... ", appendLF = FALSE)
-  
     for (url in urls) {
   
       status <- tryCatch(
@@ -350,14 +368,11 @@ local({
         condition = identity
       )
   
-      if (identical(status, 0L)) {
-        catf("OK")
+      if (identical(status, 0L))
         return(destfile)
-      }
   
     }
   
-    catf("FAILED")
     return(FALSE)
   
   }
@@ -389,7 +404,7 @@ local({
   
     }
   
-    catf("* Using local tarball '%s'", tarball)
+    catf("- Using local tarball '%s'.", tarball)
     tarball
   
   }
@@ -416,8 +431,6 @@ local({
       on.exit(do.call(base::options, saved), add = TRUE)
     }
   
-    catf("* Downloading version %s from GitHub ... ", version, appendLF = FALSE)
-  
     url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
     name <- sprintf("renv_%s.tar.gz", version)
     destfile <- file.path(tempdir(), name)
@@ -427,14 +440,11 @@ local({
       condition = identity
     )
   
-    if (!identical(status, 0L)) {
-      catf("FAILED")
+    if (!identical(status, 0L))
       return(FALSE)
-    }
   
     renv_bootstrap_download_augment(destfile)
   
-    catf("OK")
     return(destfile)
   
   }
@@ -507,34 +517,28 @@ local({
   renv_bootstrap_install <- function(version, tarball, library) {
   
     # attempt to install it into project library
-    catf("* Installing ... ", appendLF = FALSE)
     dir.create(library, showWarnings = FALSE, recursive = TRUE)
-  
     output <- renv_bootstrap_install_impl(library, tarball)
   
     # check for successful install
     status <- attr(output, "status")
-    if (is.numeric(status) && !identical(status, 0L)) {
-      catf("FAILED")
+    if (is.null(status) || identical(status, 0L))
+      return(status)
   
-      header <- "Error installing renv:"
-      lines <- paste(rep.int("=", nchar(header)), collapse = "")
-      text <- c(header, lines, output)
-      writeLines(text, con = stdout())
-      stop("Failed")
-    } else {
-      catf("OK")
-    }
-  
-    status
+    # an error occurred; report it
+    header <- "installation of renv failed"
+    lines <- paste(rep.int("=", nchar(header)), collapse = "")
+    text <- paste(c(header, lines, output), collapse = "\n")
+    stop(text)
   
   }
   
   renv_bootstrap_install_impl <- function(library, tarball) {
+  
     # invoke using system2 so we can capture and report output
     bin <- R.home("bin")
     exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
-    r <- file.path(bin, exe)
+    R <- file.path(bin, exe)
   
     args <- c(
       "--vanilla", "CMD", "INSTALL", "--no-multiarch",
@@ -542,7 +546,7 @@ local({
       shQuote(path.expand(tarball))
     )
   
-    system2(r, args, stdout = TRUE, stderr = TRUE)
+    system2(R, args, stdout = TRUE, stderr = TRUE)
   
   }
   

--- a/inst/resources/activate.R
+++ b/inst/resources/activate.R
@@ -99,9 +99,9 @@ local({
     # load failed; inform user we're about to bootstrap
     friendly <- version
     if (nchar(friendly) >= 40)
-      friendly <- sprintf("rstudio/renv@%s", substring(version, 1L, 7L))
+      friendly <- sprintf("[rstudio/renv@%s]", substring(version, 1L, 7L))
   
-    section <- header(paste("Bootstrapping renv", friendly))
+    section <- header(sprintf("Bootstrapping renv %s", friendly))
     catf(section)
   
     # attempt to download renv

--- a/tests/testthat/_snaps/bootstrap.md
+++ b/tests/testthat/_snaps/bootstrap.md
@@ -3,23 +3,23 @@
     Code
       bootstrap(version = "0.9.0", library = library)
     Output
-      Bootstrapping renv 0.9.0:
-      * Downloading binary from <https://cran.rstudio.com> ... OK
-      * Installing ... OK
+      # Bootstrapping renv 0.9.0 ---
+      - Downloading renv ... OK
+      - Installing renv  ... OK
       
     Code
       bootstrap(version = "1.0.0", library = library)
     Output
-      Bootstrapping renv 1.0.0:
-      * Downloading from archive ... OK
-      * Installing ... OK
+      # Bootstrapping renv 1.0.0 ---
+      - Downloading renv ... OK
+      - Installing renv  ... OK
       
     Code
       bootstrap(version = "1.0.0.1", library = library)
     Output
-      Bootstrapping renv 1.0.0.1:
-      * Downloading version 1.0.0.1 from GitHub ... OK
-      * Installing ... OK
+      # Bootstrapping renv 1.0.0.1 ---
+      - Downloading renv ... OK
+      - Installing renv  ... OK
       
 
 # bootstrapping gives informative output when download fails
@@ -27,25 +27,24 @@
     Code
       bootstrap(version = "0.9.0", library = library)
     Output
-      Bootstrapping renv 0.9.0:
-      * Downloading binary from <https://cran.rstudio.com> ... FAILED
-      * Downloading from archive ... FAILED
+      # Bootstrapping renv 0.9.0 ---
+      - Downloading renv ... FAILED
     Error <simpleError>
       failed to download:
       All download methods failed
     Code
       bootstrap(version = "1.0.0", library = library)
     Output
-      Bootstrapping renv 1.0.0:
-      * Downloading from archive ... FAILED
+      # Bootstrapping renv 1.0.0 ---
+      - Downloading renv ... FAILED
     Error <simpleError>
       failed to download:
       All download methods failed
     Code
       bootstrap(version = "1.0.0.1", library = library)
     Output
-      Bootstrapping renv 1.0.0.1:
-      * Downloading version 1.0.0.1 from GitHub ... FAILED
+      # Bootstrapping renv 1.0.0.1 ---
+      - Downloading renv ... FAILED
     Error <simpleError>
       failed to download:
       All download methods failed
@@ -55,15 +54,14 @@
     Code
       bootstrap(version = "1.0.0.1", library = library)
     Output
-      Bootstrapping renv 1.0.0.1:
-      * Downloading version 1.0.0.1 from GitHub ... OK
-      * Installing ... FAILED
-      Error installing renv:
-      ======================
-      test failure
+      # Bootstrapping renv 1.0.0.1 ---
+      - Downloading renv ... OK
+      - Installing renv  ... FAILED
     Error <simpleError>
       failed to install:
-      Failed
+      installation of renv failed
+      ===========================
+      test failure
 
 # renv_boostrap_version_validate() gives good warnings
 

--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -93,7 +93,7 @@ test_that("bootstrapping functions standalone", {
   # get all bootstrap APIs in package
   renv <- asNamespace("renv")
   keys <- ls(envir = renv, pattern = "^renv_bootstrap_", all.names = TRUE)
-  vals <- mget(c("catf", "%||%", "bootstrap", keys), envir = renv)
+  vals <- mget(c("catf", "%||%", "header", "bootstrap", keys), envir = renv)
 
   # put those into a separate environment inheriting only from base, and
   # re-mark those as inheriting from base (so they only 'see' each-other)

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -1,8 +1,3 @@
-test_that("renv_metadata_is_dev works as expected", {
-  expect_true(renv_metadata_is_dev(list(sha = "abc")))
-  expect_true(renv_metadata_is_dev(list(version = "1.1.1.1")))
-  expect_false(renv_metadata_is_dev(list(version = "1.1.1")))
-})
 
 test_that("renv_metadata_version_friendly gives user friendly output", {
 
@@ -10,6 +5,7 @@ test_that("renv_metadata_version_friendly gives user friendly output", {
     renv_metadata_version_friendly(list(version = "1.0.0")),
     "1.0.0"
   )
+
   expect_equal(
     renv_metadata_version_friendly(list(version = "1.0.0", sha = "abcd1234")),
     "1.0.0; rstudio/renv@abcd123"


### PR DESCRIPTION
Also removes `renv_metadata_is_dev()` as we should be consistently setting both `version` and `sha` in the `renv` metadata. We still need the bootstrap equivalents; I'd like to get rid of that requirement but that's hard to unravel.