### PR TITLE
Tweak GitHub auth

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -508,9 +508,16 @@ renv_download_auth_bitbucket <- function() {
 
 renv_download_auth_github <- function() {
 
-  pat <- Sys.getenv("GITHUB_PAT", unset = NA)
-  if (is.na(pat))
-    return(character())
+  if (renv_envvar_exists("GITHUB_PAT")) {
+    pat <- Sys.getenv("GITHUB_PAT")
+  } else {
+    token <- tryCatch(gitcreds::gitcreds_get(), error = function(e) NULL)
+    if (is.null(token)) {
+      return(character())
+    }
+
+    pat <- token$password
+  }
 
   c("Authorization" = paste("token", pat))
 

--- a/R/remotes.R
+++ b/R/remotes.R
@@ -556,7 +556,10 @@ renv_remotes_resolve_github_description <- function(host, user, repo, subdir, sh
   renv_scope_auth(repo)
 
   # add headers
-  headers <- c(Accept = "application/vnd.github.raw")
+  headers <- c(
+    Accept = "application/vnd.github.raw",
+    renv_download_auth_github()
+  )
 
   # get the DESCRIPTION contents
   fmt <- "%s/repos/%s/%s/contents/%s?ref=%s"

--- a/tests/testthat/helper-setup.R
+++ b/tests/testthat/helper-setup.R
@@ -54,13 +54,6 @@ renv_tests_setup_envvars <- function(scope = parent.frame()) {
     scope = scope
   )
 
-  if (!renv_envvar_exists("GITHUB_PAT")) {
-    token <- tryCatch(gitcreds::gitcreds_get(), error = function(e) NULL)
-    if (!is.null(token)) {
-      renv_scope_envvars(GITHUB_PAT = token$password, scope = scope)
-    }
-  }
-
   envvars <- Sys.getenv()
   configvars <- grep("^RENV_CONFIG_", names(envvars), value = TRUE)
   renv_scope_envvars(


### PR DESCRIPTION
* Do it as required (so it's when calling renv from other packages)
* Use it when retrieving DESCRIPTION