### PR TITLE
replace default RStudio mirrors with PPM

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -303,17 +303,21 @@ renv_init_repos <- function() {
   }
 
   # otherwise, check for some common 'default' CRAN settings
-  cran <- sub("/*$", "", repos[["CRAN"]] %||% "@CRAN@")
-  defaults <- c(
-    "@CRAN@",
-    "https://cloud.R-project.org",
-    "https://cran.rstudio.com",
-    "https://cran.rstudio.org"
-  )
+  cran <- repos[["CRAN"]]
+  if (is.character(cran) && length(cran) == 1L) {
+    cran <- sub("/*$", "", cran)
+    defaults <- c(
+      "@CRAN@",
+      "https://cloud.R-project.org",
+      "https://cran.rstudio.com",
+      "https://cran.rstudio.org"
+    )
 
-  if (tolower(cran) %in% tolower(defaults)) {
-    repos[["CRAN"]] <- config$ppm.url()
-    return(repos)
+    if (tolower(cran) %in% tolower(defaults)) {
+      repos[["CRAN"]] <- config$ppm.url()
+      return(repos)
+    }
+
   }
 
   # repos appears to have been configured separately; just use it

--- a/R/init.R
+++ b/R/init.R
@@ -302,9 +302,19 @@ renv_init_repos <- function() {
     return(repos)
   }
 
-  # if no repository was set, use PPM
-  if (identical(repos, list(CRAN = "@CRAN@")))
-    return(config$ppm.url())
+  # otherwise, check for some common 'default' CRAN settings
+  cran <- sub("/*$", "", repos[["CRAN"]] %||% "@CRAN@")
+  defaults <- c(
+    "@CRAN@",
+    "https://cloud.R-project.org",
+    "https://cran.rstudio.com",
+    "https://cran.rstudio.org"
+  )
+
+  if (tolower(cran) %in% tolower(defaults)) {
+    repos[["CRAN"]] <- config$ppm.url()
+    return(repos)
+  }
 
   # repos appears to have been configured separately; just use it
   repos

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -214,7 +214,7 @@ test_that("init() uses PPM by default", {
   # simulate "fresh" R session with unset repositories
   renv_scope_options(repos = c(CRAN = "@CRAN@"))
   repos <- renv_init_repos()
-  expect_equal(repos, "https://packagemanager.posit.co/cran/latest")
+  expect_equal(repos[["CRAN"]], "https://packagemanager.posit.co/cran/latest")
 
 })
 


### PR DESCRIPTION
Since some R installations (from the default Linux OS package manager) might set a default R repository for the user.