### PR TITLE
checkout actions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # renv 0.18.0  (UNRELEASED)
 
+* `renv::checkout()` gains the `actions` argument, allowing you choose whether
+  a lockfile is generated from the provided repositories ("snapshot"), or
+  whether packages are installed from the provided repositories ("restore").
+
 * `renv::status()` gets new, more compact, display when packages have some
   inconsistent combination of being installed, used, and recorded.
 

--- a/R/checkout.R
+++ b/R/checkout.R
@@ -38,6 +38,13 @@
 #'   [Package Manager](https://packagemanager.rstudio.com/) instance will be
 #'   used. Ignored if `repos` is non-`NULL`.
 #'
+#' @param actions The action(s) to perform with the requested repositories.
+#'   This can either be "snapshot", in which `renv` will generate a lockfile
+#'   based on the latest versions of the packages available from `repos`, or
+#'   "restore" if you'd like to install those packages. You can use
+#'   `c("snapshot", "restore")` if you'd like to generate a lockfile and
+#'   install those packages in the same step.
+#'
 #' @examples
 #' \dontrun{
 #'
@@ -57,6 +64,7 @@ checkout <- function(repos = NULL,
                      packages = NULL,
                      date     = NULL,
                      clean    = FALSE,
+                     actions  = "restore",
                      project  = NULL)
 {
   renv_consent_check()
@@ -85,8 +93,16 @@ checkout <- function(repos = NULL,
   lockfile <- renv_lockfile_init(project)
   lockfile$Packages <- records
 
-  # restore from that lockfile
-  restore(lockfile = lockfile, clean = clean)
+  # perform requested actions
+  for (action in actions) {
+    case(
+      action == "snapshot" ~ renv_lockfile_write(lockfile, file = renv_lockfile_path(project)),
+      action == "restore"  ~ restore(lockfile = lockfile, clean = clean),
+      ~ stopf("unrecognized action '%s'")
+    )
+  }
+
+  invisible(lockfile)
 
 }
 

--- a/R/checkout.R
+++ b/R/checkout.R
@@ -1,7 +1,7 @@
 
 #' Checkout a repository
 #'
-#' `renv::checkout()` can be used to install the latest packages available from
+#' `renv::checkout()` can be used to retrieve the latest-availabe packages from
 #' a (set of) package repositories.
 #'
 #' `renv::checkout()` is most useful with services like the Posit's
@@ -18,11 +18,6 @@
 #' be a concern if your project uses \R packages from GitHub whose name matches
 #' that of an existing CRAN package, but is otherwise unrelated to the package
 #' on CRAN.
-#'
-#' Note that `renv::checkout()` does not update the project lockfile; it only
-#' installs the packages from the provided repository. You should call
-#' [snapshot()] after you've confirmed that the installed packages function as
-#' expected in your project.
 #'
 #' @inheritParams renv-params
 #'

--- a/R/checkout.R
+++ b/R/checkout.R
@@ -212,7 +212,7 @@ renv_checkout_repos <- function(date) {
   root <- dirname(config$ppm.url())
   url <- file.path(root, date)
   if (renv_download_available(file.path(url, "src/contrib/PACKAGES")))
-    return(url)
+    return(c(PPM = url))
 
   # requested date not available; try to search a bit
   candidate <- date
@@ -222,7 +222,7 @@ renv_checkout_repos <- function(date) {
     if (renv_download_available(file.path(url, "src/contrib/PACKAGES"))) {
       fmt <- "- Snapshot date '%s' not available; using '%s' instead"
       printf(fmt, date, candidate)
-      return(url)
+      return(c(PPM = url))
     }
   }
 

--- a/R/lockfile-write.R
+++ b/R/lockfile-write.R
@@ -59,7 +59,12 @@ renv_lockfile_write <- function(lockfile, file = stdout()) {
   }
 
   lockfile <- renv_lockfile_sort(lockfile)
-  renv_lockfile_write_json(lockfile, file)
+  result <- renv_lockfile_write_json(lockfile, file)
+
+  if (is.character(file))
+    writef("- Lockfile written to '%s'.", renv_path_aliased(file))
+
+  result
 
 }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -225,7 +225,6 @@ snapshot <- function(project  = NULL,
   # write it out
   ensure_parent_directory(lockfile)
   renv_lockfile_write(new, file = lockfile)
-  writef("- Lockfile written to '%s'.", renv_path_aliased(lockfile))
 
   # ensure the lockfile is .Rbuildignore-d
   renv_infrastructure_write_rbuildignore(project)

--- a/man/checkout.Rd
+++ b/man/checkout.Rd
@@ -46,7 +46,7 @@ be used. If no project is currently active, then the current working
 directory is used instead.}
 }
 \description{
-\code{renv::checkout()} can be used to install the latest packages available from
+\code{renv::checkout()} can be used to retrieve the latest-availabe packages from
 a (set of) package repositories.
 }
 \details{
@@ -64,11 +64,6 @@ replaced with the version provided by the requested repositories. This could
 be a concern if your project uses \R packages from GitHub whose name matches
 that of an existing CRAN package, but is otherwise unrelated to the package
 on CRAN.
-
-Note that \code{renv::checkout()} does not update the project lockfile; it only
-installs the packages from the provided repository. You should call
-\code{\link[=snapshot]{snapshot()}} after you've confirmed that the installed packages function as
-expected in your project.
 }
 \examples{
 \dontrun{

--- a/man/checkout.Rd
+++ b/man/checkout.Rd
@@ -10,6 +10,7 @@ checkout(
   packages = NULL,
   date = NULL,
   clean = FALSE,
+  actions = "restore",
   project = NULL
 )
 }
@@ -32,6 +33,13 @@ used. Ignored if \code{repos} is non-\code{NULL}.}
 \item{clean}{Boolean; remove packages not recorded in the lockfile from
 the target library? Use \code{clean = TRUE} if you'd like the library state
 to exactly reflect the lockfile contents after \code{restore()}.}
+
+\item{actions}{The action(s) to perform with the requested repositories.
+This can either be "snapshot", in which \code{renv} will generate a lockfile
+based on the latest versions of the packages available from \code{repos}, or
+"restore" if you'd like to install those packages. You can use
+\code{c("snapshot", "restore")} if you'd like to generate a lockfile and
+install those packages in the same step.}
 
 \item{project}{The project directory. If \code{NULL}, then the active project will
 be used. If no project is currently active, then the current working


### PR DESCRIPTION
This makes it easier to create an `renv` lockfile directly from some repository + some set of packages, without needing to install those packages first. (The downside is you don't get the package hashes in the lockfile.)