### PR TITLE
Discover python with reticulate, fix PATH order

### DIFF
--- a/R/python.R
+++ b/R/python.R
@@ -278,6 +278,10 @@ renv_python_discover <- function() {
     "~/opt/python",
     file.path(renv_pyenv_root(), "versions")
   )
+  reticulate <- Sys.getenv("RETICULATE_PYTHON")
+  if (length(reticulate)) {
+    roots <- c(roots, reticulate)
+  }
 
   for (root in roots) {
     versions <- sort(list.files(root, full.names = TRUE), decreasing = TRUE)
@@ -340,7 +344,7 @@ renv_python_discover <- function() {
   # find Python installations on the PATH
   path <- Sys.getenv("PATH", unset = "")
   splat <- strsplit(path, .Platform$path.sep, fixed = TRUE)[[1L]]
-  for (entry in splat) {
+  for (entry in rev(splat)) {
     for (exe in c("python3", "python")) {
       python <- Sys.which(file.path(entry, exe))
       if (nzchar(python))

--- a/R/python.R
+++ b/R/python.R
@@ -279,7 +279,7 @@ renv_python_discover <- function() {
     file.path(renv_pyenv_root(), "versions")
   )
   reticulate <- Sys.getenv("RETICULATE_PYTHON")
-  if (length(reticulate)) {
+  if (nzchar(reticulate)) {
     roots <- c(roots, reticulate)
   }
 


### PR DESCRIPTION
I encountered 2 problems with `renv_python_discover` function:

1. It ignores `RETICULATE_PYTHON` environment variable, which is confusing, because after virtualenv is setup, this variable controls the python executable
2. It goes over `PATH` components in forward order, but puts pythons discovered from there into a stack, so the actual python picked from `PATH` is from the last, not the first encountered directory.

This pull request corrects both things. I did not test this