### PR TITLE
allow cancel of auto snapshot

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -72,8 +72,8 @@ load <- function(project = NULL, quiet = FALSE) {
   renv_scope_options(renv.load.running = TRUE)
 
   # avoid suppressing the next auto snapshot
-  the$snapshot_running <- TRUE
-  defer(the$snapshot_running <- FALSE)
+  the$auto_snapshot_running <- TRUE
+  defer(the$auto_snapshot_running <- FALSE)
 
   # if load is being called via the autoloader,
   # then ensure RENV_PROJECT is unset

--- a/R/report.R
+++ b/R/report.R
@@ -1,16 +1,12 @@
 
-renv_report_ok <- function(message, elapsed = NULL) {
-
-  # keep snapshot messages stable
-  if (is_testing())
-    return(writef("OK [%s in %s]", message, renv_difftime_format_short(elapsed)))
+renv_report_ok <- function(message, elapsed = 0) {
 
   # treat 'quick' times specially
-  if (is.null(elapsed) || elapsed < 0.1)
+  if (!is_testing() && elapsed < 0.1)
     return(writef("OK [%s]", message))
 
   # otherwise, report step with elapsed time
   fmt <- "OK [%s in %s]"
-  writef(fmt, message, )
+  writef(fmt, message, renv_difftime_format_short(elapsed))
 
 }

--- a/R/snapshot-auto.R
+++ b/R/snapshot-auto.R
@@ -25,7 +25,7 @@ renv_snapshot_auto <- function(project) {
       error = function(err) FALSE
     ),
 
-    cancel = function() { FALSE }
+    cancel = function() FALSE
 
   )
 

--- a/R/snapshot-auto.R
+++ b/R/snapshot-auto.R
@@ -1,22 +1,34 @@
 
 the$library_info <- NULL
 
-the$snapshot_failed <- FALSE
-the$snapshot_running <- FALSE
-the$snapshot_suppressed <- FALSE
+# did the last attempt at an automatic snapshot fail?
+the$auto_snapshot_failed <- FALSE
+
+# are we currently running an automatic snapshot?
+the$auto_snapshot_running <- FALSE
+
+# is the next automatic snapshot suppressed?
+the$auto_snapshot_suppressed <- FALSE
 
 # nocov start
 renv_snapshot_auto <- function(project) {
 
   # set some state so we know we're running
-  the$snapshot_running <- TRUE
-  defer(the$snapshot_running <- FALSE)
+  the$auto_snapshot_running <- TRUE
+  defer(the$auto_snapshot_running <- FALSE)
 
   # passed pre-flight checks; snapshot the library
-  updated <- tryCatch(
-    renv_snapshot_auto_impl(project),
-    error = function(err) FALSE
+  updated <- withCallingHandlers(
+
+    tryCatch(
+      renv_snapshot_auto_impl(project),
+      error = function(err) FALSE
+    ),
+
+    cancel = function() { FALSE }
+
   )
+
 
   if (updated) {
     lockfile <- renv_path_aliased(renv_lockfile_path(project))
@@ -102,8 +114,8 @@ renv_snapshot_auto_update <- function(project = renv_project_get() ) {
   the$library_info <- new
 
   # if we've suppressed the next automatic snapshot, bail here
-  if (the$snapshot_suppressed) {
-    the$snapshot_suppressed <- FALSE
+  if (the$auto_snapshot_suppressed) {
+    the$auto_snapshot_suppressed <- FALSE
     return(FALSE)
   }
 
@@ -115,7 +127,7 @@ renv_snapshot_auto_update <- function(project = renv_project_get() ) {
 renv_snapshot_task <- function() {
 
   # if the previous snapshot attempt failed, do nothing
-  if (the$snapshot_failed)
+  if (the$auto_snapshot_failed)
     return(FALSE)
 
   # treat warnings as errors in this scope
@@ -127,7 +139,7 @@ renv_snapshot_task <- function() {
     error = function(cnd) {
       writef("Error generating automatic snapshot: %s", conditionMessage(cnd))
       writef("Automatic snapshots will be disabled. Use `renv::snapshot()` to manually update the lockfile.")
-      the$snapshot_failed <- TRUE
+      the$auto_snapshot_failed <- TRUE
     }
   )
 
@@ -153,11 +165,11 @@ renv_snapshot_task_impl <- function() {
 renv_snapshot_auto_suppress_next <- function() {
 
   # if we're currently running an automatic snapshot, then nothing to do
-  if (the$snapshot_running)
+  if (the$auto_snapshot_running)
     return()
 
   # otherwise, set the suppressed flag
-  the$snapshot_suppressed <- TRUE
+  the$auto_snapshot_suppressed <- TRUE
 
 }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -1,7 +1,7 @@
 
 # controls whether hashes are computed when computing a snapshot
 # can be scoped to FALSE when hashing is not necessary
-the$snapshot_hash <- TRUE
+the$auto_snapshot_hash <- TRUE
 
 #' Record current state of the project library in the lockfile
 #'
@@ -793,7 +793,7 @@ renv_snapshot_description_impl <- function(dcf, path = NULL) {
   }
 
   # generate a hash if we can
-  dcf[["Hash"]] <- if (the$snapshot_hash) {
+  dcf[["Hash"]] <- if (the$auto_snapshot_hash) {
     if (is.null(path))
       renv_hash_description_impl(dcf)
     else
@@ -1072,6 +1072,10 @@ renv_snapshot_report_missing <- function(missing, type) {
   if (empty(missing))
     return(TRUE)
 
+  # if we get here during an automatic snapshot, we cannot proceed
+  if (the$auto_snapshot_running)
+    invokeRestart("cancel")
+
   preamble <- "The following required packages are not installed:"
 
   postamble <- c(
@@ -1195,7 +1199,7 @@ renv_snapshot_reprex <- function(lockfile) {
 renv_snapshot_successful <- function(records, prompt, project) {
 
   # update snapshot flag
-  the$snapshot_failed <- FALSE
+  the$auto_snapshot_failed <- FALSE
 
   # perform python snapshot on success
   renv_python_snapshot(project, prompt)

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -534,9 +534,9 @@ test_that("failures in automatic snapshots disable automatic snapshots", {
   })
 
   the$library_info <- list()
-  expect_false(the$snapshot_failed)
+  expect_false(the$auto_snapshot_failed)
   expect_snapshot(renv_snapshot_task())
-  expect_true(the$snapshot_failed)
+  expect_true(the$auto_snapshot_failed)
 
   the$library_info <- list()
   expect_silent(renv_snapshot_task())


### PR DESCRIPTION
Closes https://github.com/rstudio/renv/issues/1536. In essence, if an automatic snapshot would have prompted the user for installation of missing packages, we just cancel the automatic snapshot.

This might warrant some more consideration of when it's safe to perform an automatic snapshot.