### PR TITLE
try compact output

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -232,14 +232,11 @@ renv_install_impl <- function(records) {
   staged <- renv_config_install_staged()
 
   writef(header("Installing packages"))
-  writef("")
 
   if (staged)
     renv_install_staged(records)
   else
     renv_install_default(records)
-
-  writef("")
 
   invisible(TRUE)
 

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -6,12 +6,10 @@ renv_pretty_print <- function(preamble, values, postamble = NULL) {
 
   msg <- stack()
   msg$push(paste(preamble, collapse = "\n"))
-  msg$push("")
 
   msg$push(paste0("- ", values, collapse = "\n"))
 
   if (!is.null(postamble)) {
-    msg$push("")
     msg$push(paste(postamble, collapse = "\n"))
   }
 
@@ -52,8 +50,8 @@ renv_pretty_print_records <- function(preamble, records, postamble = NULL)
   text <- sprintf("- %s [%s]", format(packages), descs)
 
   all <- c(
-    preamble, "",
-    text, "",
+    preamble,
+    text,
     postamble, if (length(postamble)) ""
   )
 

--- a/R/restore.R
+++ b/R/restore.R
@@ -257,7 +257,10 @@ renv_restore_begin <- function(project = NULL,
 
     # a collection of the requirements imposed on dependent packages
     # as they are discovered
-    requirements = new.env(parent = emptyenv())
+    requirements = new.env(parent = emptyenv()),
+
+    # the number of packages that were downloaded
+    downloaded = 0L
 
   )
 

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -28,13 +28,19 @@ retrieve <- function(packages) {
   }
   renv_scope_options(HTTPUserAgent = agent)
 
+  before <- Sys.time()
   handler <- state$handler
   for (package in packages)
     handler(package, renv_retrieve_impl(package))
+  after <- Sys.time()
 
   state <- renv_restore_state()
-  if (identical(state$downloaded, TRUE))
+  count <- state$downloaded
+  if (count) {
+    elapsed <- difftime(after, before, units = "secs")
+    writef("Successfully retrieved %s in %s.", nplural("package", count), renv_difftime_format(elapsed))
     writef("")
+  }
 
   data <- state$install$data()
   names(data) <- extract_chr(data, "Package")
@@ -207,10 +213,9 @@ renv_retrieve_impl <- function(package) {
 
   }
 
-  if (!identical(state$downloaded, TRUE)) {
+  state$downloaded <- state$downloaded + 1L
+  if (state$downloaded == 1L)
     writef(header("Downloading packages"))
-    state$downloaded <- TRUE
-  }
 
   # time to retrieve -- delegate based on previously-determined source
   switch(source,
@@ -919,12 +924,6 @@ renv_retrieve_repos_impl <- function(record,
 
 
 renv_retrieve_package <- function(record, url, path) {
-
-  state <- renv_restore_state()
-  count <- state$retrieve_package_count %||% 0L
-  state$retrieve_package_count <- count + 1L
-  if (count == 0L)
-    writef("")
 
   ensure_parent_directory(path)
   type <- renv_record_source(record)

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -38,7 +38,7 @@ retrieve <- function(packages) {
   count <- state$downloaded
   if (count) {
     elapsed <- difftime(after, before, units = "secs")
-    writef("Successfully retrieved %s in %s.", nplural("package", count), renv_difftime_format(elapsed))
+    writef("Successfully downloaded %s in %s.", nplural("package", count), renv_difftime_format(elapsed))
     writef("")
   }
 

--- a/tests/testthat/_snaps/bioconductor.md
+++ b/tests/testthat/_snaps/bioconductor.md
@@ -25,16 +25,12 @@
       install("bioc::BiocGenerics")
     Output
       The following package(s) will be installed:
-      
       - BiocGenerics [<version>]
       - BiocVersion  [<version>]
-      
       These packages will be installed into "<tempdir>/<renv-library>".
       
       # Installing packages ---
-      
       - Installing BiocVersion ...                    OK [copied from cache in XXs]
       - Installing BiocGenerics ...                   OK [copied from cache in XXs]
-      
       Successfully installed 2 packages in XXXX seconds.
 

--- a/tests/testthat/_snaps/init.md
+++ b/tests/testthat/_snaps/init.md
@@ -15,9 +15,7 @@
       
       - Resolving missing dependencies ... 
       # Installing packages ---
-      
       - Installing bread ...                          OK [linked from cache in XXs]
-      
       The following package(s) will be updated in the lockfile:
       
       # CRAN ---

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -26,7 +26,7 @@
       - Downloading oatmeal from CRAN ...             OK [XXXX bytes in XXs]
       - Downloading toast from CRAN ...               OK [XXXX bytes in XXs]
       - Downloading bread from CRAN ...               OK [XXXX bytes in XXs]
-      Successfully retrieved 4 packages in XXXX seconds.
+      Successfully downloaded 4 packages in XXXX seconds.
       
       The following package(s) will be installed:
       - bread     [1.0.0]

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -4,21 +4,15 @@
       install("bread@0.1.0")
     Output
       The following package(s) will be installed:
-      
       - bread [0.1.0]
-      
       These packages will be installed into "<tempdir>/<renv-library>".
       
       # Installing packages ---
-      
       - Installing bread ...                          OK [copied from cache in XXs]
-      
       Successfully installed 1 package in XXXX seconds.
       
       The following loaded package(s) have been updated:
-      
       - bread
-      
       Restart your R session to use the new versions.
       
 
@@ -28,28 +22,24 @@
       install()
     Output
       # Downloading packages ---
-      
       - Downloading breakfast from CRAN ...           OK [XXXX bytes in XXs]
       - Downloading oatmeal from CRAN ...             OK [XXXX bytes in XXs]
       - Downloading toast from CRAN ...               OK [XXXX bytes in XXs]
       - Downloading bread from CRAN ...               OK [XXXX bytes in XXs]
+      Successfully retrieved 4 packages in XXXX seconds.
       
       The following package(s) will be installed:
-      
       - bread     [1.0.0]
       - breakfast [1.0.0]
       - oatmeal   [1.0.0]
       - toast     [1.0.0]
-      
       These packages will be installed into "<tempdir>/<renv-library>".
       
       # Installing packages ---
-      
       - Installing oatmeal ...                        OK [built from source and cached in XXs]
       - Installing bread ...                          OK [built from source and cached in XXs]
       - Installing toast ...                          OK [built from source and cached in XXs]
       - Installing breakfast ...                      OK [built from source and cached in XXs]
-      
       Successfully installed 4 packages in XXXX seconds.
 
 ---
@@ -58,20 +48,16 @@
       install()
     Output
       The following package(s) will be installed:
-      
       - bread     [1.0.0]
       - breakfast [1.0.0]
       - oatmeal   [1.0.0]
       - toast     [1.0.0]
-      
       These packages will be installed into "<tempdir>/<renv-library>".
       
       # Installing packages ---
-      
       - Installing oatmeal ...                        OK [copied from cache in XXs]
       - Installing bread ...                          OK [copied from cache in XXs]
       - Installing toast ...                          OK [copied from cache in XXs]
       - Installing breakfast ...                      OK [copied from cache in XXs]
-      
       Successfully installed 4 packages in XXXX seconds.
 

--- a/tests/testthat/_snaps/load.md
+++ b/tests/testthat/_snaps/load.md
@@ -15,12 +15,10 @@
       - toast       [* -> 1.0.0]
       
       # Installing packages ---
-      
       - Installing bread ...                          OK [linked from cache in XXs]
       - Installing oatmeal ...                        OK [linked from cache in XXs]
       - Installing toast ...                          OK [linked from cache in XXs]
       - Installing breakfast ...                      OK [linked from cache in XXs]
-      
 
 # load() reports on problems
 

--- a/tests/testthat/_snaps/preflight.md
+++ b/tests/testthat/_snaps/preflight.md
@@ -4,9 +4,7 @@
       snapshot()
     Output
       The following required packages are not installed:
-      
       - oatmeal  [required by breakfast]
-      
       Consider reinstalling these packages before snapshotting the lockfile.
       
     Error <simpleError>

--- a/tests/testthat/_snaps/pretty.md
+++ b/tests/testthat/_snaps/pretty.md
@@ -4,7 +4,6 @@
       renv_pretty_print("preamble", letters[1:3])
     Output
       preamble
-      
       - a
       - b
       - c
@@ -13,11 +12,9 @@
       renv_pretty_print("preamble", letters[1:3], postamble = "after")
     Output
       preamble
-      
       - a
       - b
       - c
-      
       after
       
 

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -158,7 +158,7 @@
       
       # Downloading packages ---
       - Downloading egg from CRAN ...                 OK [XXXX bytes in XXs]
-      Successfully retrieved 1 package in XXXX seconds.
+      Successfully downloaded 1 package in XXXX seconds.
       
       The following package(s) will be installed:
       - egg [1.0.0]

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -4,16 +4,12 @@
       snapshot()
     Output
       The following package(s) are missing their DESCRIPTION files:
-      
       - oatmeal [<wd>/renv/library/<platform-prefix>/oatmeal]
-      
       These may be left over from a prior, failed installation attempt.
       Consider removing or reinstalling these packages.
       
       The following required packages are not installed:
-      
       - oatmeal
-      
       Packages must first be installed before renv can snapshot them.
       Use `renv::dependencies()` to see where this package is used in your project.
       
@@ -38,15 +34,11 @@
       snapshot()
     Output
       The following package(s) have broken symlinks into the cache:
-      
       - oatmeal
-      
       Use `renv::repair()` to try and reinstall these packages.
       
       The following required packages are not installed:
-      
       - oatmeal
-      
       Packages must first be installed before renv can snapshot them.
       Use `renv::dependencies()` to see where this package is used in your project.
       
@@ -71,9 +63,7 @@
       snapshot()
     Output
       The following package(s) have unsatisfied dependencies:
-      
       - toast requires bread (> 1.0.0), but version 1.0.0 is installed
-      
       Consider updating the required dependencies as appropriate.
       
     Error <simpleError>
@@ -85,9 +75,7 @@
       snapshot(type = "explicit")
     Output
       The following required packages are not installed:
-      
       - breakfast
-      
       Packages must first be installed before renv can snapshot them.
       If these packages are no longer required, consider removing them from your DESCRIPTION file.
       
@@ -107,9 +95,7 @@
       snapshot()
     Output
       The following required packages are not installed:
-      
       - breakfast
-      
       Packages must first be installed before renv can snapshot them.
       Use `renv::dependencies()` to see where this package is used in your project.
       
@@ -137,9 +123,7 @@
       snapshot()
     Output
       The following required packages are not installed:
-      
       - toast  [required by breakfast]
-      
       Consider reinstalling these packages before snapshotting the lockfile.
       
     Error <simpleError>
@@ -160,9 +144,7 @@
       snapshot()
     Output
       The following required packages are not installed:
-      
       - egg
-      
       Packages must first be installed before renv can snapshot them.
       Use `renv::dependencies()` to see where this package is used in your project.
       
@@ -175,19 +157,15 @@
       Selection: 2
       
       # Downloading packages ---
-      
       - Downloading egg from CRAN ...                 OK [XXXX bytes in XXs]
+      Successfully retrieved 1 package in XXXX seconds.
       
       The following package(s) will be installed:
-      
       - egg [1.0.0]
-      
       These packages will be installed into "<tempdir>/<renv-library>".
       
       # Installing packages ---
-      
       - Installing egg ...                            OK [built from source and cached in XXs]
-      
       Successfully installed 1 package in XXXX seconds.
       The following package(s) will be updated in the lockfile:
       


### PR DESCRIPTION
I ended up changing my mind 🙃  I think having compact output gives a natural separation between the "stages" of installation.

```
> renv::install(c("tidyverse", "dplyr"))
# Downloading packages -------------------------------------------------------
- Downloading tidyverse from CRAN ...           OK [418.4 Kb]
- Downloading dplyr from CRAN ...               OK [1.5 Mb]
Successfully retrieved 2 packages in 1.7 seconds.

The following package(s) will be installed:
- dplyr     [1.1.2]
- tidyverse [2.0.0]
These packages will be installed into "~/Library/R/arm64/4.3/library".

# Installing packages --------------------------------------------------------
- Installing dplyr ...                          OK [installed binary and cached in 0.57s]
- Installing tidyverse ...                      OK [installed binary and cached in 0.51s]
Successfully installed 2 packages in 1.2 seconds.
```