### PR TITLE
tweak handling of dependencies

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -523,6 +523,29 @@ renv_dependencies_discover_renv_lock <- function(path) {
   renv_dependencies_list(path, "renv")
 }
 
+renv_dependencies_discover_description_fields <- function(path, project = NULL) {
+
+  # most callers don't pass in project so we need to get it from global state
+  project <- project %||%
+    renv_dependencies_state(key = "root") %||%
+    renv_restore_state(key = "root") %||%
+    renv_project_resolve()
+
+  # by default, respect fields defined in settings
+  fields <- settings$package.dependency.fields(project = project)
+
+  # if this appears to be the DESCRIPTION associated with the active project,
+  # and an explicit set of dependencies was provided in install, then use those
+  if (renv_path_same(file.path(project, "DESCRIPTION"), path)) {
+    default <- the$install_dependency_fields %||% c(fields, "Suggests")
+    profile <- sprintf("Config/renv/profiles/%s/dependencies", renv_profile_get())
+    fields <- c(default, profile)
+  }
+
+  fields
+
+}
+
 renv_dependencies_discover_description <- function(path,
                                                    fields = NULL,
                                                    subdir = NULL,
@@ -532,42 +555,11 @@ renv_dependencies_discover_description <- function(path,
   if (inherits(dcf, "error"))
     return(renv_dependencies_error(path, error = dcf))
 
-  fields <- fields %||% {
-
-    # most callers don't pass in project so we need to get it from global state
-    project <- project %||%
-      renv_dependencies_state(key = "root") %||%
-      renv_restore_state(key = "root") %||%
-      renv_project_resolve()
-
-    # if this appears to be the DESCRIPTION associated with the active project,
-    # and an explicit set of dependencies was provided in install, then use those
-    primary <- renv_path_same(file.path(project, "DESCRIPTION"), path)
-
-    # by default, respect fields defined in settings
-    fields <- settings$package.dependency.fields(project = project)
-
-    # check for overrides if this is the project's own DESCRIPTION file
-    if (primary) {
-      default <- the$install_dependency_fields %||% c(fields, "Suggests")
-      profile <- sprintf("Config/renv/profiles/%s/dependencies", renv_profile_get())
-      fields <- c(default, profile)
-    }
-
-    # return computed fields
-    fields
-
-  }
+  # resolve the dependency fields to be used
+  fields <- fields %||% renv_dependencies_discover_description_fields(path, project)
 
   # make sure dependency fields are expanded
   fields <- renv_description_dependency_fields_expand(fields)
-
-  # propagate 'extra' dependency fields if requested in install
-  if (!is.null(the$install_dependency_fields)) {
-    default <- c("Depends", "Imports", "Suggests", "LinkingTo")
-    extra <- setdiff(the$install_dependency_fields, default)
-    fields <- unique(c(fields, extra))
-  }
 
   data <- map(
     fields,

--- a/R/install.R
+++ b/R/install.R
@@ -2,6 +2,9 @@
 # an explicitly-requested package type in a call to 'install()'
 the$install_pkg_type <- NULL
 
+# an explicitly-requested dependencies field in a call to 'install()'
+the$install_dependency_fields <- NULL
+
 # the formatted width of installation steps printed to the console
 the$install_step_width <- 48L
 
@@ -128,7 +131,7 @@ install <- function(packages = NULL,
   # handle 'dependencies'
   if (!is.null(dependencies)) {
     fields <- renv_description_dependency_fields(dependencies, project = project)
-    renv_scope_options(renv.settings.package.dependency.fields = fields)
+    renv_scope_binding(the, "install_dependency_fields", fields)
   }
 
   # set up library paths

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -1027,11 +1027,12 @@ renv_retrieve_successful <- function(record, path, install = TRUE) {
   # record this package's requirements
   state <- renv_restore_state()
   requirements <- state$requirements
-  deps <- renv_dependencies_discover_description(
-    path,
-    subdir = subdir,
-    fields = if (!record$Package %in% state$packages) "strong"
-  )
+
+  # figure out the dependency fields to use -- if the user explicitly requested
+  # this package be installed, but also provided a 'dependencies' argument in
+  # the call to 'install()', then we want to use those
+  fields <- if (record$Package %in% state$packages) the$install_dependency_fields else "strong"
+  deps <- renv_dependencies_discover_description(path, subdir = subdir, fields = fields)
   if (length(deps$Source))
     deps$Source <- record$Package
 

--- a/tests/testthat/packages/bread/DESCRIPTION
+++ b/tests/testthat/packages/bread/DESCRIPTION
@@ -7,5 +7,5 @@ Description: renv test package
 Title: renv test package
 Author: Anonymous Person <Anonymous@rstudio.org>
 Maintainer: Anonymous Person <Anonymous@rstudio.org>
-
+Config/Needs/protein: egg
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -492,19 +492,6 @@ test_that("custom dependency fields in install are supported", {
   expect_true(renv_package_installed("egg"))
 })
 
-test_that("recursive custom dependency fields in install are supported", {
-
-  skip_on_cran()
-  skip_on_windows()
-
-  renv_tests_scope()
-
-  # toast depends on bread
-  # bread has Config/Needs/protein: egg
-  install("toast", dependencies = c("strong", "Config/Needs/protein"))
-  expect_true(renv_package_installed("egg"))
-})
-
 test_that("install has user-friendly output", {
 
   renv_scope_libpaths()

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -626,4 +626,6 @@ test_that("install() respects dependencies argument", {
   install(dependencies = "Imports")
 
   expect_true(renv_package_installed("bread"))
+  expect_false(renv_package_installed("coffee"))
+  expect_false(renv_package_installed("muffin"))
 })

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -490,7 +490,19 @@ test_that("custom dependency fields in install are supported", {
 
   install("breakfast", dependencies = c("strong", "Config/Needs/protein"))
   expect_true(renv_package_installed("egg"))
+})
 
+test_that("recursive custom dependency fields in install are supported", {
+
+  skip_on_cran()
+  skip_on_windows()
+
+  renv_tests_scope()
+
+  # toast depends on bread
+  # bread has Config/Needs/protein: egg
+  install("toast", dependencies = c("strong", "Config/Needs/protein"))
+  expect_true(renv_package_installed("egg"))
 })
 
 test_that("install has user-friendly output", {
@@ -596,4 +608,22 @@ test_that("install() reports failure when a 'bad' binary is installed", {
   expect_error(renv_namespace_load(bread))
   remove("bread")
 
+})
+
+test_that("install() respects dependencies argument", {
+  skip_on_cran()
+  project <- renv_tests_scope()
+  init()
+
+  contents <- heredoc("
+    Type: Project
+    Depends: coffee
+    Imports: bread
+    Suggests: muffin
+  ")
+
+  writeLines(contents, con = "DESCRIPTION")
+  install(dependencies = "Imports")
+
+  expect_true(renv_package_installed("bread"))
 })


### PR DESCRIPTION
Closes https://github.com/rstudio/renv/issues/1336.

It seems like 'dependencies' can be used for two different meanings:

1. Controlling which subset of packages get installed from the package DESCRIPTION file;
2. Controlling which (custom) fields are used when installing packages and their dependencies.

For (1), if you specify `renv::install(dependencies = "Imports")`, I think we should only take the Imports of the top-level DESCRIPTION file, but still use `c("Depends", "Imports", "LinkingTo")` for the dependencies of those packages.

For (2), I think we should propagate the "custom" dependency fields. So, for example, if you use:

```
renv::install("toast", dependencies = "Config/Needs/protein")
```

And we have this dependency graph:

```
toast -> bread -> [Config/Needs/protein: egg]
```

then we should install `egg`. Is that reasonable? Or should the `dependencies` argument only apply when scanning the top-level DESCRIPTION file?