### PR TITLE
tweak how missing packages / unknown sources are reported

### DIFF
--- a/R/activate.R
+++ b/R/activate.R
@@ -78,10 +78,9 @@ renv_activate_impl <- function(project,
     renv_imbue_self(project)
 
   # restart session if requested
-  if (restart && !is_testing())
-    return(renv_restart_request(project, reason = "renv activated"))
-
-  if (renv_rstudio_available())
+  if (restart)
+    renv_restart_request(project, reason = "renv activated")
+  else if (renv_rstudio_available())
     renv_rstudio_initialize(project)
 
   # try to load the project

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -217,7 +217,7 @@ renv_lockfile_create_impl <- function(project, type, libpaths, packages, exclude
   if (length(missing) && the$auto_snapshot_running)
     invokeRestart("cancel")
 
-  if (identical(apex(), snapshot)) {
+  if (identical(topfun(), snapshot)) {
 
     # give user a chance to handle missing packages, if any
     renv_snapshot_report_missing(missing, type)

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -212,11 +212,11 @@ renv_lockfile_create_impl <- function(project, type, libpaths, packages, exclude
   # warn if some required packages are missing
   ignored <- c(renv_project_ignored_packages(project), renv_packages_base(), exclude)
   missing <- setdiff(packages, c(names(records), ignored))
-
-  # TODO: we likely need a better way to distinguish between top-level snapshot
-  # calls, versus snapshot calls that renv is using internally.
-  if (!the$status_running && !the$init_running && !the$restore_running)
+  if (identical(apex(), snapshot))
     renv_snapshot_report_missing(missing, type)
+
+  # report if some records had unknown sources
+  renv_snapshot_preflight_check_sources(project, libpaths[[1L]], names(records))
 
   records <- renv_snapshot_fixup(records)
   renv_lockfile_records(lockfile) <- records

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -212,11 +212,10 @@ renv_lockfile_create_impl <- function(project, type, libpaths, packages, exclude
   # warn if some required packages are missing
   ignored <- c(renv_project_ignored_packages(project), renv_packages_base(), exclude)
   missing <- setdiff(packages, c(names(records), ignored))
-  if (identical(apex(), snapshot))
+  if (identical(apex(), snapshot)) {
     renv_snapshot_report_missing(missing, type)
-
-  # report if some records had unknown sources
-  renv_snapshot_preflight_check_sources(project, libpaths[[1L]], names(records))
+    renv_snapshot_preflight_check_sources(project, libpaths[[1L]], names(records))
+  }
 
   records <- renv_snapshot_fixup(records)
   renv_lockfile_records(lockfile) <- records

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -1071,11 +1071,7 @@ renv_snapshot_report_missing <- function(missing, type) {
 
   missing <- setdiff(missing, "renv")
   if (empty(missing))
-    return(TRUE)
-
-  # if we get here during an automatic snapshot, we cannot proceed
-  if (the$auto_snapshot_running)
-    invokeRestart("cancel")
+    return(invisible())
 
   preamble <- "The following required packages are not installed:"
 
@@ -1095,12 +1091,13 @@ renv_snapshot_report_missing <- function(missing, type) {
 
   # only prompt the user to install if a restart is available
   restart <- findRestart("renv_recompute_records")
+  if (is.null(restart))
+    return(invisible())
 
   choices <- c(
     snapshot = "Snapshot, just using the currently installed packages.",
-    install = if (isRestart(restart))
-      "Install the packages, then snapshot.",
-    cancel = "Cancel, and resolve the situation on your own."
+    install  = "Install the packages, then snapshot.",
+    cancel   = "Cancel, and resolve the situation on your own."
   )
 
   choice <- menu(choices, title = "What do you want to do?")
@@ -1114,7 +1111,8 @@ renv_snapshot_report_missing <- function(missing, type) {
     cancel()
   }
 
-  TRUE
+  invisible()
+
 }
 
 renv_snapshot_filter_custom_resolve <- function() {

--- a/R/utils.R
+++ b/R/utils.R
@@ -563,7 +563,7 @@ overlay <- function(lhs, rhs) {
 }
 
 # the 'top' renv function in the call stack
-apex <- function() {
+topfun <- function() {
 
   self <- renv_envir_self()
   frames <- sys.frames()

--- a/R/utils.R
+++ b/R/utils.R
@@ -561,3 +561,15 @@ assert <- function(...) stopifnot(...)
 overlay <- function(lhs, rhs) {
   modifyList(as.list(lhs), as.list(rhs))
 }
+
+# the 'top' renv function in the call stack
+apex <- function() {
+
+  self <- renv_envir_self()
+  frames <- sys.frames()
+
+  for (i in seq_along(frames))
+    if (identical(self, parent.env(frames[[i]])))
+      return(sys.function(i))
+
+}

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -472,7 +472,7 @@ test_that("automatic snapshot works as expected", {
   renv_scope_options(renv.config.auto.snapshot = TRUE)
   defer(the$library_info <- NULL)
 
-  renv_tests_scope("oatmeal")
+  project <- renv_tests_scope("oatmeal")
   init()
   expect_silent(renv_snapshot_task())
 


### PR DESCRIPTION
Closes https://github.com/rstudio/renv/issues/1559.

This PR tweaks when and how we report packages with unknown sources. In particular, we now only report those sources when creating a lockfile via a top-level call to `snapshot()`.

Honestly though, I'm starting to think it's not worth it for us to try and "fix" the remote source for packages installed from local sources like this.