### PR TITLE
ensure renv unloaded on devtools::load_all()

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,1 +1,3 @@
+
+# global variables
 the <- new.env(parent = emptyenv())

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,6 +26,13 @@
 
 }
 
+# NOTE: required for devtools::load_all()
+.onDetach <- function(libpath) {
+  package <- Sys.getenv("DEVTOOLS_LOAD", unset = NA)
+  if (identical(package, .packageName))
+    .onUnload(libpath)
+}
+
 renv_zzz_load <- function() {
 
   # NOTE: needs to be visible to embedded instances of renv as well


### PR DESCRIPTION
Fixes an issue where the R session could crash on restart if `devtools::load_all()` were called multiple times.