### PR TITLE
avoid leaking flush_console definition

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -927,7 +927,7 @@ renv_bootstrap_version_friendly <- function(version, shafmt = NULL, sha = NULL) 
   paste(parts, collapse = "")
 }
 
-renv_bootstrap_load_and_bootstrap <- function(project, libpath, version) {
+renv_bootstrap_exec <- function(project, libpath, version) {
   if (renv_bootstrap_load(project, libpath, version))
     return()
 
@@ -961,4 +961,12 @@ renv_bootstrap_run <- function(version, libpath) {
 
 renv_bootstrap_in_rstudio <- function() {
   commandArgs()[[1]] == "RStudio"
+}
+
+# Used to work around buglet in RStudio if hook uses readline
+renv_bootstrap_flush_console <- function() {
+  tryCatch({
+    tools <- as.environment("tools:rstudio")
+    tools$.rs.api.sendToConsole("", echo = FALSE, focus = FALSE)
+  }, error = function(cnd) {})
 }

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -928,10 +928,8 @@ renv_bootstrap_version_friendly <- function(version, shafmt = NULL, sha = NULL) 
 }
 
 renv_bootstrap_exec <- function(project, libpath, version) {
-  if (renv_bootstrap_load(project, libpath, version))
-    return()
-
-  renv_bootstrap_run(version, libpath)
+  if (!renv_bootstrap_load(project, libpath, version))
+    renv_bootstrap_run(version, libpath)
 }
 
 renv_bootstrap_run <- function(version, libpath) {

--- a/inst/resources/activate.R
+++ b/inst/resources/activate.R
@@ -1004,10 +1004,8 @@ local({
   }
   
   renv_bootstrap_exec <- function(project, libpath, version) {
-    if (renv_bootstrap_load(project, libpath, version))
-      return()
-  
-    renv_bootstrap_run(version, libpath)
+    if (!renv_bootstrap_load(project, libpath, version))
+      renv_bootstrap_run(version, libpath)
   }
   
   renv_bootstrap_run <- function(version, libpath) {

--- a/templates/template-activate.R
+++ b/templates/template-activate.R
@@ -92,24 +92,13 @@ local({
     # RStudio only updates console once .Rprofile is finished, so
     # instead run code on sessionInit
     setHook("rstudio.sessionInit", function(...) {
-      renv_bootstrap_load_and_bootstrap(project, libpath, version)
-      # Work around buglet in RStudio if hook uses readline
-      flush_console()
+      renv_bootstrap_exec(project, libpath, version)
+      renv_bootstrap_flush_console()
     })
   } else {
-    renv_bootstrap_load_and_bootstrap(project, libpath, version)
+    renv_bootstrap_exec(project, libpath, version)
   }
 
   invisible()
 
 })
-
-flush_console <- function() {
-  tryCatch(
-    {
-      tools <- as.environment("tools:rstudio")
-      tools$.rs.api.sendToConsole("", echo = FALSE, focus = FALSE)
-    },
-    error = function(cnd) {}
-  )
-}


### PR DESCRIPTION
Since right now, in an `renv` project:

```
$ R -s -e 'ls()'
[1] "flush_console"
```