### PR TITLE
avoid duplicating auth headers with libcurl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # renv 1.1.0  (UNRELEASED)
 
+* Fixed an issue where authentication headers could be duplicated when
+  using the `libcurl` download method. (#1605)
+
 * `renv::use()` now defaults to setting `isolate = TRUE` when `sandbox = TRUE`.
 
 * Fixed an issue where the renv watchdog could fail to load when not installed

--- a/R/download.R
+++ b/R/download.R
@@ -48,7 +48,8 @@ download <- function(url,
   printf(preamble)
 
   # add custom headers as appropriate for the URL
-  headers <- c(headers, renv_download_custom_headers(url))
+  custom <- renv_download_custom_headers(url)
+  headers[names(custom)] <- custom
 
   # handle local files by just copying the file
   if (renv_download_local(url, destfile, headers))
@@ -173,7 +174,8 @@ renv_download_default <- function(url, destfile, type, request, headers) {
     stopf("the default downloader does not support %s requests", request)
 
   # try and ensure headers are set for older versions of R
-  headers <- c(headers, renv_download_auth(url, type))
+  auth <- renv_download_auth(url, type)
+  headers[names(auth)] <- auth
   renv_download_default_agent_scope(headers)
 
   # on Windows, prefer 'wininet' as most users will have already configured
@@ -312,7 +314,7 @@ renv_download_curl <- function(url, destfile, type, request, headers) {
   # https://github.com/wch/r-source/commit/f1ec503e986593bced6720a5e9099df58a4162e7
   if (Sys.getenv("R_LIBCURL_SSL_REVOKE_BEST_EFFORT") %in% c("T", "t", "TRUE", "true"))
     args$push("--ssl-revoke-best-effort")
-  
+
   # add in any user configuration files
   userconfig <- getOption(
     "renv.curl.config",

--- a/tests/testthat/helper-setup.R
+++ b/tests/testthat/helper-setup.R
@@ -46,6 +46,7 @@ renv_tests_setup_envvars <- function(scope = parent.frame()) {
   renv_scope_envvars(
     RENV_AUTOLOAD_ENABLED = FALSE,
     RENV_CONFIG_LOCKING_ENABLED = FALSE,
+    RENV_DOWNLOAD_METHOD = NULL,
     RENV_PATHS_ROOT = root,
     RENV_PATHS_LIBRARY = NULL,
     RENV_PATHS_LIBRARY_ROOT = NULL,

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -628,3 +628,11 @@ test_that("install() succeeds even some repositories cannot be queried", {
   install("bread")
   expect_true(renv_package_installed("bread"))
 })
+
+test_that("install() doesn't duplicate authentication headers", {
+  renv_scope_envvars(RENV_DOWNLOAD_METHOD = "libcurl")
+  project <- renv_tests_scope()
+  init()
+  install("kevinushey/skeleton")
+  expect_true(renv_package_installed("skeleton"))
+})


### PR DESCRIPTION
Closes https://github.com/rstudio/renv/issues/1605.