### PR TITLE
Explicit snapshot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: renv
 Type: Package
 Title: Project Environments
-Version: 1.0.0.9000
+Version: 1.0.0.9001
 Authors@R: c(
     person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com",
            comment = c(ORCID = "0000-0003-2880-7407")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 #### ✨ features and improvements
 
+  * add `dev` argument to `snapshot` and `status` to be able to capture packages
+    from *Suggests* with `type="explicit"`; this provides an option to have
+    a similar behavior of `renv` as before the update to v1.0.0
+  
 #### 🐛 bug fixes
 
 #### 💬 documentation etc

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# renv 1.0.0.9001 (2023-08-10)
+
+#### ✨ features and improvements
+
+#### 🐛 bug fixes
+
+#### 💬 documentation etc
+
+#### 🍬 miscellaneous
+
+
 
 # renv 1.1.0  (UNRELEASED)
 

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -176,22 +176,23 @@ renv_lockfile_create <- function(project,
                                  packages = NULL,
                                  exclude = NULL,
                                  prompt = NULL,
-                                 force = NULL)
+                                 force = NULL,
+                                 dev = FALSE)
 {
   libpaths <- libpaths %||% renv_libpaths_all()
   type <- type %||% settings$snapshot.type(project = project)
 
   # use a restart, so we can allow the user to install packages before snapshot
   lockfile <- withRestarts(
-    renv_lockfile_create_impl(project, type, libpaths, packages, exclude, prompt, force),
+    renv_lockfile_create_impl(project, type, libpaths, packages, exclude, prompt, force, dev = dev),
     renv_recompute_records = function() {
       renv_dynamic_reset()
-      renv_lockfile_create_impl(project, type, libpaths, packages, exclude, prompt, force)
+      renv_lockfile_create_impl(project, type, libpaths, packages, exclude, prompt, force, dev = dev)
     }
   )
 }
 
-renv_lockfile_create_impl <- function(project, type, libpaths, packages, exclude, prompt, force) {
+renv_lockfile_create_impl <- function(project, type, libpaths, packages, exclude, prompt, force, dev = FALSE) {
 
   lockfile <- renv_lockfile_init(project)
 
@@ -199,7 +200,7 @@ renv_lockfile_create_impl <- function(project, type, libpaths, packages, exclude
   packages <- packages %||% renv_snapshot_dependencies(
     project = project,
     type = type,
-    dev = FALSE
+    dev = dev
   )
 
   # expand the recursive dependencies of these packages

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -91,8 +91,7 @@ the$auto_snapshot_hash <- TRUE
 #'   to the currently active package repositories, as retrieved by
 #'   `getOption("repos")`.
 #'
-#' @param dev Boolean; should development dependencies be captured
-#'   (for type `"explicit"`)?
+#' @inheritParams dependencies
 #'
 #' @param packages A vector of packages to be included in the lockfile. When
 #'   `NULL` (the default), all packages relevant for the type of snapshot being

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -124,6 +124,7 @@ snapshot <- function(project  = NULL,
                      lockfile = paths$lockfile(project = project),
                      type     = settings$snapshot.type(project = project),
                      repos    = getOption("repos"),
+                     dev      = FALSE,
                      packages = NULL,
                      exclude  = NULL,
                      prompt   = interactive(),
@@ -171,7 +172,8 @@ snapshot <- function(project  = NULL,
     packages = packages,
     exclude  = exclude,
     prompt   = prompt,
-    force    = force
+    force    = force,
+    dev      = dev
   )
 
   if (is.null(lockfile))

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -87,11 +87,12 @@ the$auto_snapshot_hash <- TRUE
 #'
 #'   See **Snapshot type** below for more details.
 #'
+#' @inheritParams dependencies
+#'
 #' @param repos The \R repositories to be recorded in the lockfile. Defaults
 #'   to the currently active package repositories, as retrieved by
 #'   `getOption("repos")`.
 #'
-#' @inheritParams dependencies
 #'
 #' @param packages A vector of packages to be included in the lockfile. When
 #'   `NULL` (the default), all packages relevant for the type of snapshot being
@@ -115,6 +116,8 @@ the$auto_snapshot_hash <- TRUE
 #' @return The generated lockfile, as an \R object (invisibly). Note that
 #'   this function is normally called for its side effects.
 #'
+#'
+#' @seealso More on handling package [dependencies()]
 #' @family reproducibility
 #'
 #' @export
@@ -125,8 +128,8 @@ snapshot <- function(project  = NULL,
                      library  = NULL,
                      lockfile = paths$lockfile(project = project),
                      type     = settings$snapshot.type(project = project),
-                     repos    = getOption("repos"),
                      dev      = FALSE,
+                     repos    = getOption("repos"),
                      packages = NULL,
                      exclude  = NULL,
                      prompt   = interactive(),

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -91,6 +91,9 @@ the$auto_snapshot_hash <- TRUE
 #'   to the currently active package repositories, as retrieved by
 #'   `getOption("repos")`.
 #'
+#' @param dev Boolean; should development dependencies be captured
+#'   (for type `"explicit"`)?
+#'
 #' @param packages A vector of packages to be included in the lockfile. When
 #'   `NULL` (the default), all packages relevant for the type of snapshot being
 #'   performed will be included. When set, the `type` argument is ignored.

--- a/R/status.R
+++ b/R/status.R
@@ -86,7 +86,7 @@ the$status_running <- FALSE
 #'   cache are installed at the expected + proper locations, and validate the
 #'   hashes used for those storage locations.
 #'
-#' @param dev Boolean; should development dependencies be considered?
+#' @inheritParams dependencies
 #'
 #' @return This function is normally called for its side effects, but
 #'   it invisibly returns a list containing the following components:

--- a/R/status.R
+++ b/R/status.R
@@ -18,7 +18,7 @@ the$status_running <- FALSE
 #'
 #' # Missing packages
 #'
-#' `status()` first checks that all packages used by the project are installed. 
+#' `status()` first checks that all packages used by the project are installed.
 #' This must be done first because if any packages are missing we can't tell for
 #' sure that a package isn't used; it might be a dependency that we don't know
 #' about. Once you have resolve any installation issues, you'll need to run
@@ -101,7 +101,8 @@ status <- function(project = NULL,
                    library = NULL,
                    lockfile = NULL,
                    sources = TRUE,
-                   cache = FALSE)
+                   cache = FALSE,
+                   dev = FALSE)
 {
   renv_scope_error_handler()
   renv_dots_check(...)
@@ -129,7 +130,7 @@ status <- function(project = NULL,
   lockpath <- lockfile %||% renv_paths_lockfile(project = project)
 
   # get all dependencies, including transitive
-  dependencies <- renv_snapshot_dependencies(project, dev = FALSE)
+  dependencies <- renv_snapshot_dependencies(project, dev = dev)
   packages <- sort(union(dependencies, "renv"))
   paths <- renv_package_dependencies(packages, libpaths = libpaths, project = project)
   packages <- as.character(names(paths))

--- a/R/status.R
+++ b/R/status.R
@@ -86,6 +86,8 @@ the$status_running <- FALSE
 #'   cache are installed at the expected + proper locations, and validate the
 #'   hashes used for those storage locations.
 #'
+#' @param dev Boolean; should development dependencies be considered?
+#'
 #' @return This function is normally called for its side effects, but
 #'   it invisibly returns a list containing the following components:
 #'

--- a/man/snapshot.Rd
+++ b/man/snapshot.Rd
@@ -10,8 +10,8 @@ snapshot(
   library = NULL,
   lockfile = paths$lockfile(project = project),
   type = settings$snapshot.type(project = project),
-  repos = getOption("repos"),
   dev = FALSE,
+  repos = getOption("repos"),
   packages = NULL,
   exclude = NULL,
   prompt = interactive(),
@@ -46,10 +46,6 @@ directly instead.}
 
 See \strong{Snapshot type} below for more details.}
 
-\item{repos}{The \R repositories to be recorded in the lockfile. Defaults
-to the currently active package repositories, as retrieved by
-\code{getOption("repos")}.}
-
 \item{dev}{Boolean; include development dependencies? These packages are
 typically required when developing the project, but not when running it
 (i.e. you want them installed when humans are working on the project but
@@ -59,6 +55,10 @@ Development dependencies include packages listed in the \code{Suggests} field
 of a \code{DESCRIPTION} found in the project root, and roxygen2 or devtools if
 their use is implied by other project metadata. They also include packages
 used in \verb{~/.Rprofile} if \code{config$user.profile()} is \code{TRUE}.}
+
+\item{repos}{The \R repositories to be recorded in the lockfile. Defaults
+to the currently active package repositories, as retrieved by
+\code{getOption("repos")}.}
 
 \item{packages}{A vector of packages to be included in the lockfile. When
 \code{NULL} (the default), all packages relevant for the type of snapshot being
@@ -181,6 +181,8 @@ options(renv.config.auto.snapshot = auto.snapshot)
 }
 }
 \seealso{
+More on handling package \code{\link[=dependencies]{dependencies()}}
+
 Other reproducibility: 
 \code{\link{lockfiles}},
 \code{\link{restore}()}

--- a/man/snapshot.Rd
+++ b/man/snapshot.Rd
@@ -11,6 +11,7 @@ snapshot(
   lockfile = paths$lockfile(project = project),
   type = settings$snapshot.type(project = project),
   repos = getOption("repos"),
+  dev = FALSE,
   packages = NULL,
   exclude = NULL,
   prompt = interactive(),
@@ -48,6 +49,16 @@ See \strong{Snapshot type} below for more details.}
 \item{repos}{The \R repositories to be recorded in the lockfile. Defaults
 to the currently active package repositories, as retrieved by
 \code{getOption("repos")}.}
+
+\item{dev}{Boolean; include development dependencies? These packages are
+typically required when developing the project, but not when running it
+(i.e. you want them installed when humans are working on the project but
+not when computers are deploying it).
+
+Development dependencies include packages listed in the \code{Suggests} field
+of a \code{DESCRIPTION} found in the project root, and roxygen2 or devtools if
+their use is implied by other project metadata. They also include packages
+used in \verb{~/.Rprofile} if \code{config$user.profile()} is \code{TRUE}.}
 
 \item{packages}{A vector of packages to be included in the lockfile. When
 \code{NULL} (the default), all packages relevant for the type of snapshot being

--- a/man/status.Rd
+++ b/man/status.Rd
@@ -10,7 +10,8 @@ status(
   library = NULL,
   lockfile = NULL,
   sources = TRUE,
-  cache = FALSE
+  cache = FALSE,
+  dev = FALSE
 )
 }
 \arguments{
@@ -35,6 +36,16 @@ may be unable to restore it.}
 When \code{TRUE}, renv will validate that the packages installed into the
 cache are installed at the expected + proper locations, and validate the
 hashes used for those storage locations.}
+
+\item{dev}{Boolean; include development dependencies? These packages are
+typically required when developing the project, but not when running it
+(i.e. you want them installed when humans are working on the project but
+not when computers are deploying it).
+
+Development dependencies include packages listed in the \code{Suggests} field
+of a \code{DESCRIPTION} found in the project root, and roxygen2 or devtools if
+their use is implied by other project metadata. They also include packages
+used in \verb{~/.Rprofile} if \code{config$user.profile()} is \code{TRUE}.}
 }
 \value{
 This function is normally called for its side effects, but


### PR DESCRIPTION
Hi,

we used to use `renv::snapshot(type = "explicit")` to capture all dependencies stated in the DESCRIPTION file for package development. We put all packages we need for CICD to *Suggests*, as they are not required for a working package API.
During CICD pipelines, we used `renv::restore()` for installing all packages we need.

After the recent update to v1.0.0 we basically ran into the same issue as described here:
https://github.com/rstudio/renv/issues/1019#issuecomment-1644266879

We don't like the idea of putting all CICD required packages into *Imports*. Instead, we propose to expose the option to  record *dev* dependencies in the snapshot (and to consider them in checking the project status with `renv::status()`).

Please have a look. Thanks.