### PR TITLE
watchdog: fix path to renv's Meta/package.rds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # renv (development version)
 
+* Corrected logic that counteracted the previous release's fix for a watchdog
+  loading issue. (#1640)
 
 # renv 1.0.1
 

--- a/R/watchdog.R
+++ b/R/watchdog.R
@@ -88,9 +88,11 @@ renv_watchdog_start_impl <- function() {
   script <- renv_scope_tempfile("renv-watchdog-", fileext = ".R")
 
   # figure out library path -- need to dodge devtools::load_all()
-  library <- dirname(renv_namespace_path(.packageName))
-  if (!file.exists(file.path(library, "Meta/package.rds")))
-    library <- renv_libpaths_default()
+  renv_path <- renv_namespace_path(.packageName)
+  library <- if (file.exists(file.path(renv_path, "Meta/package.rds")))
+    dirname(renv_path)
+  else
+    renv_libpaths_default()
 
   # for R CMD check
   name <- .packageName


### PR DESCRIPTION
renv_watchdog_start_impl() specifies the library so that the subprocess can find renv.  If renv appears to be loaded by devtools, it falls back to setting the library to the result of renv_libpaths_default().

As of f05df6748 (fix bad refactor; tweaks, 2023-08-07), a missing Meta/package.rds is taken as an indication that renv was loaded by devtools.  However, this check incorrectly looks in the _parent_ directory of the renv package.

As a result, f05df6748 resurfaced the problem resolved by 43a3fcdbf (set library path when loading renv in watchdog process (#1618), 2023-08-01).  The launched process fails 1) if renv is not in the renv_libpaths_default() paths or 2) if those paths contain an older renv without the required watchdog functionality.

Point the check to the correct location.