### PR TITLE
Return early if there are zero remotes to restore

### DIFF
--- a/R/pak.R
+++ b/R/pak.R
@@ -125,6 +125,11 @@ renv_pak_restore <- function(lockfile,
   # not to install the package if a newer version was available. Hence, we need
   # to preserve the exact remote we wish to install here.
 
+  # return early if there are zero remotes to restore 
+  if (length(remotes) == 0L) {
+    return(invisible(TRUE))
+  }
+
   # perform installation
   pak$pkg_install(remotes)
 }


### PR DESCRIPTION
If there are no remotes to restore, then `pak$pkg_install(remotes)` hangs. We simply return early now if that is the case.

You can reproduce the bug as follows:
1. Create a codespace using the `rocker-no_bioc` branch in `MiguelRodo/TestRenv` (`pak` enabled, `BioConductor` reference removed from lock file and no other dependencies).
2. Run `R` in the terminal.
3. Agree to restore. `pak` will be installed, and then you will get `Subprocess is busy or cannot start` error.
4. Now in regular R terminal, run `renv::restore()`. It will hang, and show that it's installing `0/0` packages.

Stepping through `renv_pak_restore` showed that this happened when the `remotes` variable passed to `pak$pak_install` was empty. We now check for the length of `remotes`, and return `invisible(TRUE)` if it's length 0.