### PR TITLE
Add closing double quote in a helpfile option

### DIFF
--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -83,7 +83,7 @@ the$auto_snapshot_hash <- TRUE
 #'   * `"implict"`, (the default), uses all packages captured by [dependencies()].
 #'   * `"explicit"` uses packages recorded in `DESCRIPTION`.
 #'   * `"all"` uses all packages in the project library.
-#'   * `"custom` uses a custom filter.
+#'   * `"custom"` uses a custom filter.
 #'
 #'   See **Snapshot type** below for more details.
 #'

--- a/man/lockfiles.Rd
+++ b/man/lockfiles.Rd
@@ -37,7 +37,7 @@ lockfile_modify(
 \item \code{"implict"}, (the default), uses all packages captured by \code{\link[=dependencies]{dependencies()}}.
 \item \code{"explicit"} uses packages recorded in \code{DESCRIPTION}.
 \item \code{"all"} uses all packages in the project library.
-\item \verb{"custom} uses a custom filter.
+\item \code{"custom"} uses a custom filter.
 }
 
 See \strong{Snapshot type} below for more details.}

--- a/man/snapshot.Rd
+++ b/man/snapshot.Rd
@@ -41,7 +41,7 @@ directly instead.}
 \item \code{"implict"}, (the default), uses all packages captured by \code{\link[=dependencies]{dependencies()}}.
 \item \code{"explicit"} uses packages recorded in \code{DESCRIPTION}.
 \item \code{"all"} uses all packages in the project library.
-\item \verb{"custom} uses a custom filter.
+\item \code{"custom"} uses a custom filter.
 }
 
 See \strong{Snapshot type} below for more details.}


### PR DESCRIPTION
Thanks for such a great package.

This just adds the missing double quote to the end of the `"custom"` `type` in the `snapshot()` helpfile code. I also reran `devtools::document()`.