### PR TITLE
Reattempt package install by pak upon subprocess error

### DIFF
--- a/R/pak.R
+++ b/R/pak.R
@@ -82,10 +82,14 @@ renv_pak_install <- function(packages, library, project) {
   else
     as.character(packages)
 
-  if (length(packages) == 0L)
-    return(pak$local_install_dev_deps(root = project, lib = lib))
-
   env <- new.env()
+
+  if (length(packages) == 0L)
+    return(renv_pak_retry(
+      pak$local_install_dev_deps(root = project, lib = lib),
+      env = env
+    ))
+  
   renv_pak_retry(
     pak$pkg_install(
       pkg     = packages,


### PR DESCRIPTION
After installing pak by renv, using pak via renv to install new packages (whether from the lock file or not) leads to the `Subprocess is busy or cannot start error`. However, this only occurs upon the first (and perhaps second) attempted install - subsequent installs work fine.

So, we reattempt the install if the first attempt fails due to a subprocess error. Other errors are not reattempted (e.g. can't find package from the remote). Up to three reattempts are attempted, after which the subprocess error is returned if it persisted.

This is implemented by a new function `renv_pak_retry`, which is called by `renv_pak_restore` and `renv_pak_restore` (which themselves are called by `restore`, `update` and `install`). The function takes the pak install call and the calling environment as arguments, and evaluates the call in the calling environment as many times as required up until three times.

The errors pass by pretty quickly, and I can't say I notice them at all.

In the code itself, I'm sure you could definitely replace `env <- new.env()` with just passing `parent.frame(n = <something>` directly to `renv_pak_retry`, but I didn't get it right and so left it.