### PR TITLE
Make `renv_file_copy_dir_cp` not preserve permissions

### DIFF
--- a/R/files.R
+++ b/R/files.R
@@ -81,7 +81,7 @@ renv_file_copy_dir_cp <- function(source, target) {
   target <- path.expand(target)
 
   # build 'cp' arguments
-  args <- c("-pPR", renv_shell_path(source), renv_shell_path(target))
+  args <- c("-PR", renv_shell_path(source), renv_shell_path(target))
 
   # execute command
   renv_system_exec("cp", args, action = "copying directory")


### PR DESCRIPTION
Hello,

I use `renv` in a secure environment, and have run into an issue where `renv` fails to initialise because of permissions errors from `cp -pPR ...`.

Reason: the `source` directory from which `renv` copies from (set by `renv_namespace_path("renv")` or `renv_package_find("renv")` during `renv_imbue_self()`) is not owned by me, and hence I do not have permission to copy preserving permissions. I don't think my setup is *especially* unusual, so I imagine others might run into this problem.

A workaround for me was to patch the function `renv_file_copy_dir_cp` to remove the `-p` flag.

I wonder why permissions are preserved in the first place? Without `-p`, the copied files would be owned by whoever is running the R process, which I assume is the user. Am I correct in assuming that would be fine? If not, please disregard this PR.