### PR TITLE
fix: typo in R command to retrieve repositories

### DIFF
--- a/R/roxygen.R
+++ b/R/roxygen.R
@@ -32,7 +32,7 @@
 #'   in the lockfile will be, ensuring that (e.g.) CRAN packages are
 #'   re-installed from the same CRAN mirror.
 #'
-#'   Use `repos = getOptions(repos)` to override with the repositories set
+#'   Use `repos = getOption("repos")` to override with the repositories set
 #'   in the current session, or see the `repos.override` option in [config] for
 #'   an alternate way override.
 #'


### PR DESCRIPTION
This PR fixes the R command given to overwrite "repos".

> [!NOTE]
> `roxygen2::roxygenise()` has not be ran to avoid possible merge conflicts.