### PR TITLE
Expand PPM platform support

### DIFF
--- a/R/ppm.R
+++ b/R/ppm.R
@@ -171,7 +171,6 @@ renv_ppm_platform_impl <- function(file = "/etc/os-release") {
       identical(id, "rhel")      ~ renv_ppm_platform_rhel(properties),
       identical(id, "rocky")     ~ renv_ppm_platform_rocky(properties),
       identical(id, "almalinux") ~ renv_ppm_platform_alma(properties),
-      # TODO: Could use `ID_LIKE` and look for \\bsuse\\b here, and get rid of the separate suse and sles calls?
       grepl("suse\\b", id)       ~ renv_ppm_platform_suse(properties),
       identical(id, "sles")      ~ renv_ppm_platform_sles(properties),
       identical(id, "debian")    ~ renv_ppm_platform_debian(properties)

--- a/R/ppm.R
+++ b/R/ppm.R
@@ -166,10 +166,15 @@ renv_ppm_platform_impl <- function(file = "/etc/os-release") {
     id <- properties$ID %||% ""
 
     case(
-      identical(id, "ubuntu") ~ renv_ppm_platform_ubuntu(properties),
-      identical(id, "centos") ~ renv_ppm_platform_centos(properties),
-      identical(id, "rhel")   ~ renv_ppm_platform_rhel(properties),
-      grepl("\\bsuse\\b", id) ~ renv_ppm_platform_suse(properties)
+      identical(id, "ubuntu")    ~ renv_ppm_platform_ubuntu(properties),
+      identical(id, "centos")    ~ renv_ppm_platform_centos(properties),
+      identical(id, "rhel")      ~ renv_ppm_platform_rhel(properties),
+      identical(id, "rocky")     ~ renv_ppm_platform_rocky(properties),
+      identical(id, "almalinux") ~ renv_ppm_platform_alma(properties),
+      # TODO: Could use `ID_LIKE` and look for \\bsuse\\b here, and get rid of the separate suse and sles calls?
+      grepl("suse\\b", id)       ~ renv_ppm_platform_suse(properties),
+      identical(id, "sles")      ~ renv_ppm_platform_sles(properties),
+      identical(id, "debian")    ~ renv_ppm_platform_debian(properties)
     )
 
   }
@@ -207,6 +212,27 @@ renv_ppm_platform_rhel <- function(properties) {
 
 }
 
+renv_ppm_platform_rocky <- function(properties) {
+
+  id <- properties$VERSION_ID
+  if (is.null(id))
+    return(NULL)
+  rhel_version <- ifelse(numeric_version(id) < "9", "centos", "rhel")
+
+  paste0(rhel_version, substring(id, 1L, 1L))
+
+}
+
+renv_ppm_platform_alma <- function(properties) {
+
+  id <- properties$VERSION_ID
+  if (is.null(id))
+    return(NULL)
+  rhel_version <- ifelse(numeric_version(id) < "9", "centos", "rhel")
+
+  paste0(rhel_version, substring(id, 1L, 1L))
+
+}
 
 renv_ppm_platform_suse <- function(properties) {
 
@@ -215,7 +241,28 @@ renv_ppm_platform_suse <- function(properties) {
     return(NULL)
 
   parts <- strsplit(id, ".", fixed = TRUE)[[1L]]
-  paste0("opensuse", parts[[1L]])
+  paste0("opensuse", parts[[1L]], parts[[2L]])
+
+}
+
+renv_ppm_platform_sles <- function(properties) {
+
+  id <- properties$VERSION_ID
+  if (is.null(id))
+    return(NULL)
+
+  parts <- strsplit(id, ".", fixed = TRUE)[[1L]]
+  paste0("opensuse", parts[[1L]], parts[[2L]])
+
+}
+
+renv_ppm_platform_debian <- function(properties) {
+
+  codename <- properties$VERSION_CODENAME
+  if (is.null(codename))
+    return(NULL)
+
+  codename
 
 }
 

--- a/tests/testthat/test-ppm.R
+++ b/tests/testthat/test-ppm.R
@@ -55,7 +55,7 @@ test_that("RSPM is confirmed not supported on trusty", {
   expect_identical(unname(before), unname(after))
 })
 
-test_that("renv correctly detects RHEL as CentOS for RSPM", {
+test_that("renv correctly detects RHEL < 9 as CentOS for RSPM", {
   skip_on_cran()
   skip_on_os("windows")
 
@@ -112,6 +112,178 @@ test_that("renv correctly detects RHEL9 for PPM", {
 
   platform <- renv_ppm_platform_impl(file = file)
   expect_equal(platform, "rhel9")
+
+})
+
+test_that("renv correctly detects Rocky Linux 8 as centos8 for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    NAME="Rocky Linux"
+    VERSION="8.8 (Green Obsidian)"
+    ID="rocky"
+    ID_LIKE="rhel centos fedora"
+    VERSION_ID="8.8"
+    PLATFORM_ID="platform:el8"
+    PRETTY_NAME="Rocky Linux 8.8 (Green Obsidian)"
+    ANSI_COLOR="0;32"
+    LOGO="fedora-logo-icon"
+    CPE_NAME="cpe:/o:rocky:rocky:8:GA"
+    HOME_URL="https://rockylinux.org/"
+    BUG_REPORT_URL="https://bugs.rockylinux.org/"
+    SUPPORT_END="2029-05-31"
+    ROCKY_SUPPORT_PRODUCT="Rocky-Linux-8"
+    ROCKY_SUPPORT_PRODUCT_VERSION="8.8"
+    REDHAT_SUPPORT_PRODUCT="Rocky Linux"
+    REDHAT_SUPPORT_PRODUCT_VERSION="8.8"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "centos8")
+
+})
+
+test_that("renv correctly detects Rocky Linux 9 as rhel9 for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    NAME="Rocky Linux"
+    VERSION="9.2 (Blue Onyx)"
+    ID="rocky"
+    ID_LIKE="rhel centos fedora"
+    VERSION_ID="9.2"
+    PLATFORM_ID="platform:el9"
+    PRETTY_NAME="Rocky Linux 9.2 (Blue Onyx)"
+    ANSI_COLOR="0;32"
+    LOGO="fedora-logo-icon"
+    CPE_NAME="cpe:/o:rocky:rocky:9::baseos"
+    HOME_URL="https://rockylinux.org/"
+    BUG_REPORT_URL="https://bugs.rockylinux.org/"
+    SUPPORT_END="2032-05-31"
+    ROCKY_SUPPORT_PRODUCT="Rocky-Linux-9"
+    ROCKY_SUPPORT_PRODUCT_VERSION="9.2"
+    REDHAT_SUPPORT_PRODUCT="Rocky Linux"
+    REDHAT_SUPPORT_PRODUCT_VERSION="9.2"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "rhel9")
+
+})
+
+test_that("renv correctly detects AlmaLinux 9 as rhel9 for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    NAME="AlmaLinux"
+    VERSION="9.2 (Turquoise Kodkod)"
+    ID="almalinux"
+    ID_LIKE="rhel centos fedora"
+    VERSION_ID="9.2"
+    PLATFORM_ID="platform:el9"
+    PRETTY_NAME="AlmaLinux 9.2 (Turquoise Kodkod)"
+    ANSI_COLOR="0;34"
+    LOGO="fedora-logo-icon"
+    CPE_NAME="cpe:/o:almalinux:almalinux:9::baseos"
+    HOME_URL="https://almalinux.org/"
+    DOCUMENTATION_URL="https://wiki.almalinux.org/"
+    BUG_REPORT_URL="https://bugs.almalinux.org/"
+
+    ALMALINUX_MANTISBT_PROJECT="AlmaLinux-9"
+    ALMALINUX_MANTISBT_PROJECT_VERSION="9.2"
+    REDHAT_SUPPORT_PRODUCT="AlmaLinux"
+    REDHAT_SUPPORT_PRODUCT_VERSION="9.2"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "rhel9")
+
+})
+
+test_that("renv correctly detects OpenSUSE for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    NAME="openSUSE Leap"
+    VERSION="15.4"
+    ID="opensuse-leap"
+    ID_LIKE="suse opensuse"
+    VERSION_ID="15.4"
+    PRETTY_NAME="openSUSE Leap 15.4"
+    ANSI_COLOR="0;32"
+    CPE_NAME="cpe:/o:opensuse:leap:15.4"
+    BUG_REPORT_URL="https://bugs.opensuse.org"
+    HOME_URL="https://www.opensuse.org/"
+    DOCUMENTATION_URL="https://en.opensuse.org/Portal:Leap"
+    LOGO="distributor-logo-Leap"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "opensuse154")
+
+})
+
+test_that("renv correctly detects SLES as OpenSUSE for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    NAME="SLES"
+    VERSION="15-SP5"
+    VERSION_ID="15.5"
+    PRETTY_NAME="SUSE Linux Enterprise Server 15 SP5"
+    ID="sles"
+    ID_LIKE="suse"
+    ANSI_COLOR="0;32"
+    CPE_NAME="cpe:/o:suse:sles:15:sp5"
+    DOCUMENTATION_URL="https://documentation.suse.com/"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "opensuse155")
+
+})
+
+test_that("renv correctly detects Debian for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
+    NAME="Debian GNU/Linux"
+    VERSION_ID="11"
+    VERSION="11 (bullseye)"
+    VERSION_CODENAME=bullseye
+    ID=debian
+    HOME_URL="https://www.debian.org/"
+    SUPPORT_URL="https://www.debian.org/support"
+    BUG_REPORT_URL="https://bugs.debian.org/"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "bullseye")
 
 })
 

--- a/tests/testthat/test-ppm.R
+++ b/tests/testthat/test-ppm.R
@@ -288,6 +288,33 @@ test_that("renv correctly detects Debian for PPM", {
 
 })
 
+test_that("renv correctly detects Ubuntu for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    NAME="Ubuntu"
+    VERSION="20.04.6 LTS (Focal Fossa)"
+    ID=ubuntu
+    ID_LIKE=debian
+    PRETTY_NAME="Ubuntu 20.04.6 LTS"
+    VERSION_ID="20.04"
+    HOME_URL="https://www.ubuntu.com/"
+    SUPPORT_URL="https://help.ubuntu.com/"
+    BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+    PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+    VERSION_CODENAME=focal
+    UBUNTU_CODENAME=focal
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "focal")
+
+})
+
 test_that("URLs like http://foo/bar aren't queried", {
   skip_on_cran()
   skip_on_os("windows")

--- a/tests/testthat/test-ppm.R
+++ b/tests/testthat/test-ppm.R
@@ -243,6 +243,7 @@ test_that("renv correctly detects SLES as OpenSUSE for PPM", {
   skip_on_cran()
   skip_on_os("windows")
 
+  # `docker run -it registry.suse.com/suse/sle15:15.5`
   release <- heredoc('
     NAME="SLES"
     VERSION="15-SP5"


### PR DESCRIPTION
Fixes #1720 

I set out to add support for getting Rocky Linux 9 binaries from Package Manager instances, as it's binary compatible with CentOS/RHEL binaries. This was initially motivated by adding binary support for Connect instances hosted on Rocky. Along the way I went to check out `/etc/os-release` files from other supported distros, and made some other additions/fixes.

Connect's supported distros are listed [here](https://docs.posit.co/connect/admin/), and Package Manager's are available [here](https://packagemanager.posit.co/client/#/repos/cran/setup).

Changes I made:

- Added functions to detect Rocky Linux and AlmaLinux, two CentOS/RHEL-compatible distributions, as `centos8`/`rhel9`.
- Added support for Debian. (It isn't supported by Connect but is by PPM, so it's nice for `renv` to support it.) Its `platform` function is like Ubuntu.
- Fixed support for OpenSUSE. Previously, the `renv_ppm_platform_suse()` function would return something like `opensuse15`, but the minor part of the version needs to be appended, e.g. `opensuse154`. Also, OpenSUSE `/etc/os-release` files don't always contain `suse`  as a standalone word, so the I changed the regex used to identify this distro.
- Added support for SLES, which has different `/etc/os-release` files from OpenSUSE.
- Added tests for a cross-section distros (not all minor versions).

Other changes I'm considering, and would appreciate feedback on whether to include or not:

- Adding support for detecting Amazon Linux 2 as `centos7`. It seems to be mostly compatible ([StackOverflow](https://serverfault.com/questions/798427/what-linux-distribution-is-the-amazon-linux-ami-based-on), [Amazon docs](https://docs.aws.amazon.com/linux/al2023/ug/compare-with-al2.html#epel)), and I think this is the basis of Connect listing it as supported, but I'm not sure.

Code style questions:

- It looks like we previously erred on the side of giving each distro a separate function, even if for now the logic is identical to other functions. I followed this pattern with the new distros. But we could also just call e.g. `renv_ppm_platform_rhel` for AlmaLinux and Rocky.
- We could look for e.g. `\\bsuse\\b` in the `ID_LIKE` field instead of directly looking for the `ID` field.