### PR TITLE
Add PPM binary support for Amazon Linux 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # renv (development version)
 
+* Expanded the set of Linux distributions detected for automatic transformation
+  of Posit Package Manager URLs to install binary packages. `renv` now correctly
+  detects Red Hat Enterprise Linux 9, Rocky Linux 8 and 9, SLES 15 SP4 and SP5,
+  Debian 11 and 12, AlmaLinux 8 and 9, and Amazon Linux 2. (#1720, #1721)
+
 
 # renv 1.0.3
 

--- a/R/ppm.R
+++ b/R/ppm.R
@@ -173,7 +173,8 @@ renv_ppm_platform_impl <- function(file = "/etc/os-release") {
       identical(id, "almalinux") ~ renv_ppm_platform_alma(properties),
       grepl("suse\\b", id)       ~ renv_ppm_platform_suse(properties),
       identical(id, "sles")      ~ renv_ppm_platform_sles(properties),
-      identical(id, "debian")    ~ renv_ppm_platform_debian(properties)
+      identical(id, "debian")    ~ renv_ppm_platform_debian(properties),
+      identical(id, "amzn")      ~ renv_ppm_platform_amzn(properties)
     )
 
   }
@@ -262,6 +263,19 @@ renv_ppm_platform_debian <- function(properties) {
     return(NULL)
 
   codename
+
+}
+
+renv_ppm_platform_amzn <- function(properties) {
+
+  id <- properties$VERSION_ID
+  if (is.null(id))
+    return(NULL)
+
+  if (numeric_version(id) == "2")
+    return("centos7")
+
+  return(NULL)
 
 }
 

--- a/tests/testthat/test-ppm.R
+++ b/tests/testthat/test-ppm.R
@@ -315,6 +315,58 @@ test_that("renv correctly detects Ubuntu for PPM", {
 
 })
 
+test_that("renv correctly detects Amazon Linux 2 as centos7 for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    NAME="Amazon Linux"
+    VERSION="2"
+    ID="amzn"
+    ID_LIKE="centos rhel fedora"
+    VERSION_ID="2"
+    PRETTY_NAME="Amazon Linux 2"
+    ANSI_COLOR="0;33"
+    CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
+    HOME_URL="https://amazonlinux.com/"
+    SUPPORT_END="2025-06-30"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "centos7")
+
+})
+
+test_that("renv detects no supported PPM platform for Amazon Linux 2023", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    NAME="Amazon Linux"
+    VERSION="2023"
+    ID="amzn"
+    ID_LIKE="fedora"
+    VERSION_ID="2023"
+    PLATFORM_ID="platform:al2023"
+    PRETTY_NAME="Amazon Linux 2023"
+    ANSI_COLOR="0;33"
+    CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2023"
+    HOME_URL="https://aws.amazon.com/linux/"
+    BUG_REPORT_URL="https://github.com/amazonlinux/amazon-linux-2023"
+    SUPPORT_END="2028-03-01"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_null(platform)
+
+})
+
 test_that("URLs like http://foo/bar aren't queried", {
   skip_on_cran()
   skip_on_os("windows")


### PR DESCRIPTION
Following on from #1728 (also related to #1720), adds support for detecting Amazon Linux 2 as compatible with `centos7` binaries.

Per Amazon's documentation [here](https://docs.aws.amazon.com/linux/al2023/ug/compare-with-al2.html#epel)

> Extra Packages for Enterprise Linux (EPEL) is a project in the Fedora community with the objective of creating a large array of packages for enterprise-level Linux operating systems. The project has primarily produced RHEL and CentOS packages. AL2 features a high level of compatibility with CentOS 7. As a result, many EPEL7 packages work on AL2. However, AL2023 doesn't support EPEL or EPEL-like repositories.

Connect's support for Amazon Linux 2 is based on its support for `centos7` binaries, so I believe this is the right move. Amazon Linux 2023 is not compatible with CentOS 7 binaries (or any served by Posit Package Manager), and is still detected as `NULL`.