### PR TITLE
return empty data.frame not NULL in renv_available_packages_success

### DIFF
--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -167,7 +167,7 @@ renv_available_packages_success <- function(db, url, type) {
 
   # https://github.com/rstudio/renv/issues/1706
   if (empty(db))
-    return(NULL)
+    return(data.frame())
 
   # convert to data.frame
   db <- as_data_frame(db)


### PR DESCRIPTION
This addresses a bug introduced in the fix for #1706. 

On 2023-12-05 at 09:21 PST, [I had a successful check for MacOS](https://github.com/carpentries/sandpaper/actions/runs/7104065642/job/19338200777) to ensure that a package added with `renv::record("pkg@version")` would be successfully recorded.

EDIT: for context, this test has been running successfully for several months (see https://github.com/carpentries/sandpaper/commit/0de3543d6041155e8eb9bf3f25d8e73edc37a27d for the last time this particular code was modified)

The very next check on 2023-12-05 at 11:07 PST, [had a failure in MacOS](https://github.com/carpentries/sandpaper/actions/runs/7105183840/job/19341804820)

The relevant portion of the error log reads:

```r
Caused by error in `if (length(indices) < nrow(data)) indices <- rep(indices, length.out = nrow(data))`:
! argument is of length zero
```

This code is found in the `rows()` function:

https://github.com/rstudio/renv/blob/4c247486b19dd6747aceff7e6df6ffde32e3e8ce/R/utils.R#L430-L437

When `nrow(NULL)` is called, it returns a NULL and then give the error that I see. I believe this was caused by https://github.com/rstudio/renv/commit/d8722384afc45ab119d5ed2946ab258743f5260c, where it returns a NULL instead of an empty data frame.


