### PR TITLE
Fix link to CI vignette

### DIFF
--- a/vignettes/packages.Rmd
+++ b/vignettes/packages.Rmd
@@ -107,7 +107,7 @@ the caveats to doing this, as the performance of `R CMD build` will be affected.
 While developing your package, you may want to use a continuous integration
 service (such as [Travis CI](https://www.travis-ci.com)) to build and test
 your package remotely. You can use renv to help facilitate this testing --
-see the [Continuous Integration][ci] vignette for more information. In
+see the [Continuous Integration](ci.html) vignette for more information. In
 particular, clever use of the renv cache can help save time that might
 normally be spent on package installation. See
 <https://github.com/rstudio/renv/blob/main/.github/workflows/R-CMD-check.yaml>


### PR DESCRIPTION
You can see the broken link formatting here: https://rstudio.github.io/renv/articles/packages.html#testing