### PR TITLE
minimize env vars needed for renv to work on GitLab CI

### DIFF
--- a/vignettes/ci.Rmd
+++ b/vignettes/ci.Rmd
@@ -97,15 +97,12 @@ The following template can be used as a base when using renv with
 
 ```
 variables:
-  RENV_CONFIG_REPOS_OVERRIDE: "http://cran.r-project.org"
-  RENV_PATHS_CACHE: ${CI_PROJECT_DIR}/cache
-  RENV_PATHS_LIBRARY: ${CI_PROJECT_DIR}/renv/library
+  RENV_PATHS_CACHE: ${CI_PROJECT_DIR}/renv/cache
 
 cache:
   key: ${CI_JOB_NAME}
   paths:
     - ${RENV_PATHS_CACHE}
-    - ${RENV_PATHS_LIBRARY}
 
 before_script:
   - < ... other pre-deploy steps ... >
@@ -113,7 +110,6 @@ before_script:
   - Rscript -e "renv::restore()"
   
 ```
-
 
 [gitlab-ci]: https://about.gitlab.com/solutions/continuous-integration/
 [github-actions]: https://github.com/features/actions


### PR DESCRIPTION
While trying to leverage caching for GitLab CI, https://github.com/rstudio/renv/issues/348 was _extremely_ valuable (thank you!). Experimenting a bit, I found the variables remaining in this MR to be the minimal set needed to leverage the cache in GitLab's CI.