### PR TITLE
avoid need for project.id

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,6 @@
 
 # renv (development version)
 
-* Added the `project.id` project setting, which is used primarily when
-  forming external library paths for use with R package projects. This
-  should help resolve issues seen when attempting to build vignettes
-  during `R CMD build` with projects using renv. (#1798)
-
 * Fixed an issue where attempts to install binary packages from older
   PPM snapshots could fail. (#1839)
 

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -668,22 +668,8 @@ renv_bootstrap_library_root_name <- function(project) {
   if (asis)
     return(basename(project))
 
-  # read an existing id for this project if available
-  id <- NULL
-  file <- renv_bootstrap_paths_renv("settings.json", project = project)
-  if (file.exists(file)) {
-    json <- tryCatch(renv_json_read(file = file), error = function(e) NULL)
-    id <- json[["project.id"]]
-  }
-
-  # if we don't have a project id yet, check overrides
-  id <- id %||% renv_options_override(
-    scope   = "renv.settings",
-    key     = "project.id",
-    default = renv_bootstrap_project_id(project)
-  )
-
-  # generate the library name
+  # otherwise, disambiguate based on project's path
+  id <- substring(renv_bootstrap_hash_text(project), 1L, 8L)
   paste(basename(project), id, sep = "-")
 
 }
@@ -877,11 +863,6 @@ renv_bootstrap_paths_renv <- function(..., profile = TRUE, project = NULL) {
   prefix <- if (profile) renv_bootstrap_profile_prefix()
   components <- c(root, renv, prefix, ...)
   paste(components, collapse = "/")
-}
-
-renv_bootstrap_project_id <- function(project) {
-  id <- renv_bootstrap_hash_text(project)
-  substring(id, 1L, 8L)
 }
 
 renv_bootstrap_project_type <- function(path) {

--- a/R/load.R
+++ b/R/load.R
@@ -373,13 +373,6 @@ renv_load_project <- function(project) {
     renv_load_project_projlist(project)
   }
 
-  # set a unique project id if necessary
-  id <- settings$project.id(project = project)
-  if (is.null(id)) {
-    id <- renv_bootstrap_project_id(project)
-    settings$project.id(value = id, project = project)
-  }
-
   TRUE
 
 }

--- a/R/settings.R
+++ b/R/settings.R
@@ -386,11 +386,6 @@ renv_settings_impl <- function(name, default, scalar, validate, coerce, update) 
 #' binary repository URLs. This setting can be used if you'd like to avoid this
 #' transformation with some subset of repository URLs.
 #'
-#' ## `project.id`
-#'
-#' A unique project identifier assigned to this project. This is primarily
-#' used when constructing external library paths for \R package projects.
-#'
 #' ## `r.version`
 #'
 #' The version of \R to encode within the lockfile. This can be set as a
@@ -520,15 +515,6 @@ settings <- list(
     name     = "ppm.ignored.urls",
     default  = NULL,
     scalar   = FALSE,
-    validate = is.character,
-    coerce   = as.character,
-    update   = NULL
-  ),
-
-  project.id = renv_settings_impl(
-    name     = "project.id",
-    default  = NULL,
-    scalar   = TRUE,
     validate = is.character,
     coerce   = as.character,
     update   = NULL

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -125,7 +125,7 @@ renv_zzz_bootstrap_activate <- function() {
 
   source <- "templates/template-activate.R"
   target <- "inst/resources/activate.R"
-  scripts <- c("R/bootstrap.R", "R/json-read.R", "R/options.R")
+  scripts <- c("R/bootstrap.R", "R/json-read.R")
 
   # Do we need an update
   source_mtime <- max(renv_file_info(c(source, scripts))$mtime)

--- a/inst/resources/activate.R
+++ b/inst/resources/activate.R
@@ -6,7 +6,7 @@ local({
   attr(version, "sha") <- ..sha..
 
   # the project directory
-  project <- getwd()
+  project <- Sys.getenv("RENV_PROJECT", unset = getwd())
 
   # use start-up diagnostics if enabled
   diagnostics <- Sys.getenv("RENV_STARTUP_DIAGNOSTICS", unset = "FALSE")

--- a/man/settings.Rd
+++ b/man/settings.Rd
@@ -77,12 +77,6 @@ binary repository URLs. This setting can be used if you'd like to avoid this
 transformation with some subset of repository URLs.
 }
 
-\subsection{\code{project.id}}{
-
-A unique project identifier assigned to this project. This is primarily
-used when constructing external library paths for \R package projects.
-}
-
 \subsection{\code{r.version}}{
 
 The version of \R to encode within the lockfile. This can be set as a

--- a/templates/template-activate.R
+++ b/templates/template-activate.R
@@ -6,7 +6,7 @@ local({
   attr(version, "sha") <- ..sha..
 
   # the project directory
-  project <- getwd()
+  project <- Sys.getenv("RENV_PROJECT", unset = getwd())
 
   # use start-up diagnostics if enabled
   diagnostics <- Sys.getenv("RENV_STARTUP_DIAGNOSTICS", unset = "FALSE")


### PR DESCRIPTION
By just respecting `RENV_PROJECT` if set.