### PR TITLE
for `settings$ppm.enabled()`, update should be NULL like other settings without config

### DIFF
--- a/R/settings.R
+++ b/R/settings.R
@@ -508,7 +508,7 @@ settings <- list(
     scalar   = TRUE,
     validate = is.logical,
     coerce   = as.logical,
-    update   = FALSE
+    update   = NULL
   ),
 
   ppm.ignored.urls = renv_settings_impl(


### PR DESCRIPTION
Otherwise this creates an issue in `renv_settings_updated` as it will use a wrong update function

https://github.com/rstudio/renv/blob/5bc089696a96ca372f1f1ecaf0a0a4167891ed36/R/settings.R#L180-L183