### PR TITLE
Normalize expanded paths before comparaison 

### DIFF
--- a/R/use-python.R
+++ b/R/use-python.R
@@ -253,8 +253,8 @@ renv_use_python_fini <- function(info,
                                  project)
 {
   # ensure project-local names are treated as such
-  name    <- if (!is.null(name))    path.expand(chartr("\\", "/", name))
-  project <- if (!is.null(project)) path.expand(chartr("\\", "/", project))
+  name    <- if (!is.null(name))    renv_path_normalize(path.expand(chartr("\\", "/", name)))
+  project <- if (!is.null(project)) renv_path_normalize(path.expand(chartr("\\", "/", project)))
 
   if (!is.null(name) && startswith(name, project)) {
     base <- substring(name, nchar(project) + 2L)


### PR DESCRIPTION
Issue was initially found with `use_python()` : using `renv::use_python('.venv\Scripts\python.exe')` would write in the lockfile 

````
  "Python": {
    "Version": "3.12.1",
    "Type": "virtualenv",
    "Name": "C:\\Users\\chris\\Documents/DEV_R/quarto-web/.venv"
  },
````

Note the `\\` in the path. This should have been relative path and `"Name": ".venv"`. 

It does not happen like this because `"~/DEV_R/quarto-web/.venv"` will be expanded with `path.expand()`. This function will use `R_USER` env var,  which can use `\\` as path separator. Path not starting with `~`  and already normalized going through `path.expand()` would be untouched and use only `/` separators.

So comparison does not work. 

More generally, `path.expand()` will give you `\\` most of the time, unless `R_USER` is pre process which seems to happen in RStudio IDE where this issue does not happen because `/` is used in the env var, not `\\`
````
> Sys.getenv("R_USER")
[1] "C:/Users/chris/Documents"
````

Normalizing them before seems the best idea when a comparison of both is required. (e.g. here `startwith()` is used to find one into the other.

Though maybe you would like to normalize all calls to `path.expand()`. 

I don't know if you would fix this like this, but I hope this PR will help understand the problem. 

