### PR TITLE
Document `project` `param` for `lockfile_validate()`

### DIFF
--- a/R/lockfile-validate.R
+++ b/R/lockfile-validate.R
@@ -18,6 +18,9 @@
 #'
 #' @inheritParams renv-params
 #'
+#' @param project Path to the currently active renv project.
+#'   If not provided, renv attempts to resolve the project path.
+#'
 #' @param lockfile Contents of the lockfile, or a filename containing one.
 #'   If not provided, it defaults to the project's lockfile.
 #'

--- a/man/lockfile_validate.Rd
+++ b/man/lockfile_validate.Rd
@@ -15,9 +15,8 @@ lockfile_validate(
 )
 }
 \arguments{
-\item{project}{The project directory. If \code{NULL}, then the active project will
-be used. If no project is currently active, then the current working
-directory is used instead.}
+\item{project}{Path to the currently active renv project.
+If not provided, renv attempts to resolve the project path.}
 
 \item{lockfile}{Contents of the lockfile, or a filename containing one.
 If not provided, it defaults to the project's lockfile.}


### PR DESCRIPTION
I realize I failed to document the `project` `param` for `renv::lockfile_validate()` in #1889. I see some tests failed because of this: https://github.com/rstudio/renv/actions/runs/9141606329.

I've added this documentation.