### PR TITLE
Refine auto-loading behaviour

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -885,13 +885,7 @@ renv_load_report_synchronized <- function(project = NULL, lockfile = NULL) {
     caution("- None of the packages recorded in the lockfile are currently installed.")
     autoloading <- getOption("renv.autoloader.running", default = FALSE)
     if (autoloading) {
-      if (requireNamespace("cli", quietly = TRUE)) {
-        cli::cli_bullets(c(
-          "*" = "Use {.run renv::restore()} to restore the project library."
-        ))
-      } else {
-        caution("- Use `renv::restore()` to restore the project library.")
-      }
+      caution("- Use `renv::restore()` to restore the project library.")
       return(FALSE)
     }
 

--- a/R/load.R
+++ b/R/load.R
@@ -884,7 +884,13 @@ renv_load_report_synchronized <- function(project = NULL, lockfile = NULL) {
     caution("- None of the packages recorded in the lockfile are currently installed.")
     autoloading <- getOption("renv.autoloader.running", default = FALSE)
     if (autoloading) {
-      caution("- Use `renv::restore()` to restore the project library.")
+      if (requireNamespace("cli", quietly = TRUE)) {
+        cli::cli_bullets(c(
+          "*" = "Use {.run renv::restore()} to restore the project library."
+        ))
+      } else {
+        caution("- Use `renv::restore()` to restore the project library.")
+      }
       return(FALSE)
     }
 

--- a/R/load.R
+++ b/R/load.R
@@ -70,7 +70,7 @@ load <- function(project = NULL, quiet = FALSE, profile = NULL, ...) {
 
   action <- renv_load_action(project)
   if (action[[1L]] == "cancel") {
-    cancel()
+    quietly(cancel())
   } else if (action[[1L]] == "init") {
     return(init(project))
   } else if (action[[1L]] == "alt") {

--- a/R/load.R
+++ b/R/load.R
@@ -70,7 +70,8 @@ load <- function(project = NULL, quiet = FALSE, profile = NULL, ...) {
 
   action <- renv_load_action(project)
   if (action[[1L]] == "cancel") {
-    quietly(cancel())
+    autoloading <- getOption("renv.autoloader.running", default = FALSE)
+    cancel(verbose = !autoloading)
   } else if (action[[1L]] == "init") {
     return(init(project))
   } else if (action[[1L]] == "alt") {

--- a/R/load.R
+++ b/R/load.R
@@ -881,7 +881,7 @@ renv_load_report_synchronized <- function(project = NULL, lockfile = NULL) {
       return(FALSE)
     }
 
-    response <- ask("Would you like to restore the project library?", default = FALSE)
+    response <- ask("Would you like to run `renv::restore()` to restore the project library?", default = FALSE)
     if (!response)
       return(FALSE)
 

--- a/R/load.R
+++ b/R/load.R
@@ -146,12 +146,6 @@ renv_load_action <- function(project) {
   if (!interactive())
     return("load")
 
-  # if this project already contains an 'renv' folder, assume it's
-  # already been initialized and we can directly load it
-  renv <- renv_paths_renv(project = project, profile = FALSE)
-  if (dir.exists(renv))
-    return("load")
-
   # if we're running within RStudio at this point, and we're running
   # within the auto-loader, we need to defer execution here so that
   # the console is able to properly receive user input and update
@@ -161,6 +155,12 @@ renv_load_action <- function(project) {
     setHook("rstudio.sessionInit", function() { renv::load(project) })
     return("cancel")
   }
+
+  # if this project already contains an 'renv' folder, assume it's
+  # already been initialized and we can directly load it
+  renv <- renv_paths_renv(project = project, profile = FALSE)
+  if (dir.exists(renv))
+    return("load")
 
   # check and see if we're being called within a sub-directory
   path <- renv_file_find(dirname(project), function(parent) {

--- a/R/load.R
+++ b/R/load.R
@@ -152,7 +152,7 @@ renv_load_action <- function(project) {
   # https://github.com/rstudio/renv/issues/1650
   autoloading <- getOption("renv.autoloader.running", default = FALSE)
   if (autoloading && renv_rstudio_available()) {
-    setHook("rstudio.sessionInit", function() { renv::load(project) })
+    setHook("rstudio.sessionInit", function(...) { renv::load(project) })
     return("cancel")
   }
 

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -10,10 +10,6 @@ renv_rstudio_available <- function() {
 
 }
 
-renv_rstudio_autoloading <- function() {
-  renv_rstudio_available() && getOption("renv.autoloader.running", default = FALSE)
-}
-
 renv_rstudio_initialize <- function(project) {
 
   tools <- catch(as.environment("tools:rstudio"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -126,13 +126,15 @@ ask <- function(question, default = FALSE) {
   if (!interactive())
     return(default)
 
-  # can't prompt for input when running autoloader in RStudio
+  # can't prompt for input when autoloading; code run from `.Rprofile` should
+  # not attempt to interact with the user
+  # from `?Startup`:
+  # "It is not intended that there be interaction with the user during startup
+  # code. Attempting to do so can crash the R process."
   # https://github.com/rstudio/renv/issues/1879
-  if (renv_rstudio_available()) {
-    autoloading <- getOption("renv.autoloader.running", default = FALSE)
-    if (autoloading)
-      return(default)
-  }
+  autoloading <- getOption("renv.autoloader.running", default = FALSE)
+  if (autoloading)
+    return(default)
 
   # be verbose in this scope, as we're asking the user for input
   renv_scope_options(renv.verbose = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -521,13 +521,14 @@ take <- function(data, index = NULL) {
   if (is.null(index)) data else .subset2(data, index)
 }
 
-cancel <- function() {
+cancel <- function(verbose = TRUE) {
 
   renv_snapshot_auto_suppress_next()
   if (testing())
     stop("Operation canceled", call. = FALSE)
 
-  message("- Operation canceled.")
+  if (verbose)
+    message("- Operation canceled.")
   invokeRestart("abort")
 
 }


### PR DESCRIPTION
* Tweak the use of RStudio's session init hook to deliver the intent of PR #1652.
* Otherwise, if RStudio and its session init hook aren't available, just emit a message if we discover the need for `renv::restore()` during auto-loading.

To do/discuss:

* [x] ~After "Installing cli ..." it's easy to think the session is busy or hung. But it's not. If you hit return, you get the normal R prompt. Why does that happen?~ *As I play around with renv, I run into this phenomenon elsewhere. It feels like one or more of the messaging helpers, such as `catf()` or `writef()` sometimes fail to get their trailing newline? In any case, I think it's unrelated to what I'm doing here and out of scope for this PR.*
* [x] The "Operation canceled." is unsightly and confusing. Seems like that should be suppressed or, at least in this context, hidden.
* [x] Try this on: Never try to interact with the user when auto-loading, since user interaction is UB during R startup. If we can defer loading using a hook (like `rstudio.sessionInit` below), do that. If we can't, emit a message telling the user what to do. ~If possible, style the `renv::restore()` part as a runnable link.~ *I had to give up on that part.*