### PR TITLE
typo on doc

### DIFF
--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -80,7 +80,7 @@ the$auto_snapshot_hash <- TRUE
 #'   directly instead.
 #'
 #' @param type The type of snapshot to perform:
-#'   * `"implict"`, (the default), uses all packages captured by [dependencies()].
+#'   * `"implicit"`, (the default), uses all packages captured by [dependencies()].
 #'   * `"explicit"` uses packages recorded in `DESCRIPTION`.
 #'   * `"all"` uses all packages in the project library.
 #'   * `"custom"` uses a custom filter.


### PR DESCRIPTION
Just spotted a small typo on help page. 

Do you need me to re-render `devtools::document()` on the PR ? 