### PR TITLE
when attempting to load a lockfile and finding only a manifest, automatically generate a lockfile and load that

### DIFF
--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -122,16 +122,22 @@ renv_lockfile_save <- function(lockfile, project) {
 }
 
 renv_lockfile_load <- function(project, strict = FALSE) {
-
-  path <- renv_lockfile_path(project)
-  if (file.exists(path))
-    return(renv_lockfile_read(path))
+  lockfile_path <- renv_lockfile_path(project)
+  if (file.exists(lockfile_path))
+    return(renv_lockfile_read(lockfile_path))
 
   if (strict) {
     abort(c(
       "This project does not contain a lockfile.",
       i = "Have you called `snapshot()` yet?"
     ))
+  }
+
+  manifest_path <- renv_manifest_path(project)
+  if (file.exists(manifest_path)) {
+    caution("No lockfile found; creating from `manifest.json`.")
+    renv_lockfile_from_manifest(manifest_path, lockfile_path)
+    return(renv_lockfile_read(lockfile_path))
   }
 
   renv_lockfile_init(project = project)

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -116,15 +116,6 @@ renv_lockfile_path <- function(project) {
   renv_paths_lockfile(project = project)
 }
 
-renv_manifest_path <- function(project = NULL) {
-
-  # similar to default case of `renv_paths_lockfile()`
-  project <- renv_project_resolve(project)
-  renv <- renv_paths_renv(project = project)
-  file.path(dirname(renv), "manifest.json")
-
-}
-
 renv_lockfile_save <- function(lockfile, project) {
   file <- renv_lockfile_path(project)
   renv_lockfile_write(lockfile, file = file)
@@ -142,7 +133,7 @@ renv_lockfile_load <- function(project, strict = FALSE) {
     ))
   }
 
-  manifest <- renv_manifest_path(project)
+  manifest <- file.path(project, "manifest.json")
   if (file.exists(manifest)) {
     caution("No lockfile found; creating from `manifest.json`.")
     renv_lockfile_from_manifest(manifest, path)

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -116,6 +116,15 @@ renv_lockfile_path <- function(project) {
   renv_paths_lockfile(project = project)
 }
 
+renv_manifest_path <- function(project = NULL) {
+
+  # similar to default case of `renv_paths_lockfile()`
+  project <- renv_project_resolve(project)
+  renv <- renv_paths_renv(project = project)
+  file.path(dirname(renv), "manifest.json")
+
+}
+
 renv_lockfile_save <- function(lockfile, project) {
   file <- renv_lockfile_path(project)
   renv_lockfile_write(lockfile, file = file)

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -131,9 +131,9 @@ renv_lockfile_save <- function(lockfile, project) {
 }
 
 renv_lockfile_load <- function(project, strict = FALSE) {
-  lockfile_path <- renv_lockfile_path(project)
-  if (file.exists(lockfile_path))
-    return(renv_lockfile_read(lockfile_path))
+  path <- renv_lockfile_path(project)
+  if (file.exists(path))
+    return(renv_lockfile_read(path))
 
   if (strict) {
     abort(c(
@@ -142,11 +142,11 @@ renv_lockfile_load <- function(project, strict = FALSE) {
     ))
   }
 
-  manifest_path <- renv_manifest_path(project)
-  if (file.exists(manifest_path)) {
+  manifest <- renv_manifest_path(project)
+  if (file.exists(manifest)) {
     caution("No lockfile found; creating from `manifest.json`.")
-    renv_lockfile_from_manifest(manifest_path, lockfile_path)
-    return(renv_lockfile_read(lockfile_path))
+    renv_lockfile_from_manifest(manifest, path)
+    return(renv_lockfile_read(path))
   }
 
   renv_lockfile_init(project = project)

--- a/R/manifest-convert.R
+++ b/R/manifest-convert.R
@@ -73,10 +73,8 @@ renv_lockfile_from_manifest <- function(manifest = "manifest.json",
   if (is.na(lockfile))
     return(lock)
 
-  # otherwise, write to file and report for user
+  # otherwise, write to file
   renv_lockfile_write(lock, file = lockfile)
-  fmt <- "- Lockfile written to %s."
-  writef(fmt, renv_path_pretty(lockfile))
 
   invisible(lock)
 

--- a/R/paths.R
+++ b/R/paths.R
@@ -73,15 +73,6 @@ renv_paths_lockfile <- function(project = NULL) {
 
 }
 
-renv_manifest_path <- function(project = NULL) {
-
-  # otherwise, use default location (location relative to renv folder)
-  project <- renv_project_resolve(project)
-  renv <- renv_paths_renv(project = project)
-  file.path(dirname(renv), "manifest.json")
-
-}
-
 renv_paths_settings <- function(project = NULL) {
   renv_paths_renv("settings.json", project = project)
 }

--- a/R/paths.R
+++ b/R/paths.R
@@ -66,7 +66,7 @@ renv_paths_lockfile <- function(project = NULL) {
     return(override)
   }
 
-  # otherwise, use default location (location location relative to renv folder)
+  # otherwise, use default location (location relative to renv folder)
   project <- renv_project_resolve(project)
   renv <- renv_paths_renv(project = project)
   file.path(dirname(renv), "renv.lock")
@@ -75,7 +75,7 @@ renv_paths_lockfile <- function(project = NULL) {
 
 renv_manifest_path <- function(project = NULL) {
 
-  # otherwise, use default location (location location relative to renv folder)
+  # otherwise, use default location (location relative to renv folder)
   project <- renv_project_resolve(project)
   renv <- renv_paths_renv(project = project)
   file.path(dirname(renv), "manifest.json")

--- a/R/paths.R
+++ b/R/paths.R
@@ -73,6 +73,15 @@ renv_paths_lockfile <- function(project = NULL) {
 
 }
 
+renv_manifest_path <- function(project = NULL) {
+
+  # otherwise, use default location (location location relative to renv folder)
+  project <- renv_project_resolve(project)
+  renv <- renv_paths_renv(project = project)
+  file.path(dirname(renv), "manifest.json")
+
+}
+
 renv_paths_settings <- function(project = NULL) {
   renv_paths_renv("settings.json", project = project)
 }

--- a/tests/testthat/test-lockfile.R
+++ b/tests/testthat/test-lockfile.R
@@ -49,6 +49,28 @@ test_that("we can create lockfiles from manifests", {
 
 })
 
+test_that("we create lockfile from a manifest automatically when no lockfile found", {
+
+  skip_on_cran()
+
+  project_dir <- tempfile()
+  dir.create(project_dir)
+
+  manifest <- "resources/manifest.json"
+  expected_lock <- renv_lockfile_from_manifest("resources/manifest.json")
+  file.copy(manifest, file.path(project_dir, "manifest.json"))
+
+  # when called with `strict = TRUE` does not create manifest
+  expect_error(renv_lockfile_load(project_dir, strict = TRUE))
+
+  # creates and reads lockfile
+  obtained_lock <- renv_lockfile_load(project_dir)
+  expect_identical(expected_lock, obtained_lock)
+  expect_true(file.exists(file.path(project_dir, "renv.lock")))
+
+  unlink(project_dir, recursive = TRUE)
+})
+
 test_that("the Requirements field is read as character", {
 
   lockfile <- renv_lockfile_read(text = '


### PR DESCRIPTION
This pull request changes the behavior of `renv_lockfile_load()`, which attempts to load a lockfile from a directory. When no lockfile is found, but a `manifest.json` is found, the manifest is used to automatically generate a lockfile, which is then loaded. The behavior only occurs when the function is called with `strict = FALSE`, the default. If no manifest is present, the function `renv_lockfile_init()` is called, as before. A message is printed when this happens.

I added a supporting function in `paths.R` to return a manifest path, just cribbing from `renv_paths_lockfile()`. However, just doing `file.path(project, "manifest.json")` might be just as good. I'm not sure what the semantics are around path loading, so was just trying to follow existing patterns.

The logic in `renv_manifest_path()` is similar to `renv_paths_lockfile()`, or at least, the default case. I'm unsure about needing to add an extra layer of abstraction similar to `renv_lockfile_path()` -> `renv_paths_lockfile()`.

When testing, I saw a duplicated log line:

```
No lockfile found; creating from `manifest.json`.
- Lockfile written to "/private/var/folders/q7/1b7h_nx931q6mc70r3w8k_2c0000gp/T/RtmpsmRCq6/file62e9cace1/renv.lock".
- Lockfile written to "/private/var/folders/q7/1b7h_nx931q6mc70r3w8k_2c0000gp/T/RtmpsmRCq6/file62e9cace1/renv.lock".
```

This came from explicit logging in `renv_lockfile_from_manifest()`, which duplicated a log message within `renv_lockfile_write()`, so I removed the duplicated outer logging statement.