### PR TITLE
Use `CI_PROJECT_NAME` instead of `CI_JOB_NAME` for GitLab CI vignette

### DIFF
--- a/vignettes/ci.Rmd
+++ b/vignettes/ci.Rmd
@@ -100,9 +100,9 @@ variables:
   RENV_PATHS_CACHE: ${CI_PROJECT_DIR}/renv/cache
 
 cache:
-    key: ${CI_PROJECT_NAME}
-    paths:
-      - ${RENV_PATHS_CACHE}
+  key: ${CI_PROJECT_NAME}
+  paths:
+    - ${RENV_PATHS_CACHE}
 
 before_script:
   - < ... other pre-deploy steps ... >

--- a/vignettes/ci.Rmd
+++ b/vignettes/ci.Rmd
@@ -100,9 +100,9 @@ variables:
   RENV_PATHS_CACHE: ${CI_PROJECT_DIR}/renv/cache
 
 cache:
-  key: ${CI_JOB_NAME}
-  paths:
-    - ${RENV_PATHS_CACHE}
+    key: ${CI_PROJECT_NAME}
+    paths:
+      - ${RENV_PATHS_CACHE}
 
 before_script:
   - < ... other pre-deploy steps ... >


### PR DESCRIPTION
A follow-on to #1822 now that I've used `renv` across more complex GitLab CI jobs.

`CI_PROJECT_NAME` (e.g., `dplyr`)  allow for consistent re-use across runs / stages / jobs vs. `CI_JOB_NAME` (e.g., `lint`)