### PR TITLE
run styler on template-activate.R

### DIFF
--- a/templates/template-activate.R
+++ b/templates/template-activate.R
@@ -1,14 +1,13 @@
-
 local({
-
   # the requested version of renv
   version <- ..version..
   attr(version, "sha") <- ..sha..
 
   # the project directory
   project <- Sys.getenv("RENV_PROJECT")
-  if (!nzchar(project))
+  if (!nzchar(project)) {
     project <- getwd()
+  }
 
   # use start-up diagnostics if enabled
   diagnostics <- Sys.getenv("RENV_STARTUP_DIAGNOSTICS", unset = "FALSE")
@@ -16,30 +15,34 @@ local({
     start <- Sys.time()
     profile <- tempfile("renv-startup-", fileext = ".Rprof")
     utils::Rprof(profile)
-    on.exit({
-      utils::Rprof(NULL)
-      elapsed <- signif(difftime(Sys.time(), start, units = "auto"), digits = 2L)
-      writeLines(sprintf("- renv took %s to run the autoloader.", format(elapsed)))
-      writeLines(sprintf("- Profile: %s", profile))
-      print(utils::summaryRprof(profile))
-    }, add = TRUE)
+    on.exit(
+      {
+        utils::Rprof(NULL)
+        elapsed <- signif(difftime(Sys.time(), start, units = "auto"), digits = 2L)
+        writeLines(sprintf("- renv took %s to run the autoloader.", format(elapsed)))
+        writeLines(sprintf("- Profile: %s", profile))
+        print(utils::summaryRprof(profile))
+      },
+      add = TRUE
+    )
   }
 
   # figure out whether the autoloader is enabled
   enabled <- local({
-
     # first, check config option
     override <- getOption("renv.config.autoloader.enabled")
-    if (!is.null(override))
+    if (!is.null(override)) {
       return(override)
+    }
 
     # if we're being run in a context where R_LIBS is already set,
     # don't load -- presumably we're being run as a sub-process and
     # the parent process has already set up library paths for us
     rcmd <- Sys.getenv("R_CMD", unset = NA)
     rlibs <- Sys.getenv("R_LIBS", unset = NA)
-    if (!is.na(rlibs) && !is.na(rcmd))
+    if (!is.na(rlibs) && !is.na(rcmd)) {
       return(FALSE)
+    }
 
     # next, check environment variables
     # TODO: prefer using the configuration one in the future
@@ -51,29 +54,28 @@ local({
 
     for (envvar in envvars) {
       envval <- Sys.getenv(envvar, unset = NA)
-      if (!is.na(envval))
+      if (!is.na(envval)) {
         return(tolower(envval) %in% c("true", "t", "1"))
+      }
     }
 
     # enable by default
     TRUE
-
   })
 
   # bail if we're not enabled
   if (!enabled) {
-
     # if we're not enabled, we might still need to manually load
     # the user profile here
     profile <- Sys.getenv("R_PROFILE_USER", unset = "~/.Rprofile")
     if (file.exists(profile)) {
       cfg <- Sys.getenv("RENV_CONFIG_USER_PROFILE", unset = "TRUE")
-      if (tolower(cfg) %in% c("true", "t", "1"))
+      if (tolower(cfg) %in% c("true", "t", "1")) {
         sys.source(profile, envir = globalenv())
+      }
     }
 
     return(FALSE)
-
   }
 
   # avoid recursion
@@ -94,8 +96,9 @@ local({
   library(utils, lib.loc = .Library)
 
   # unload renv if it's already been loaded
-  if ("renv" %in% loadedNamespaces())
+  if ("renv" %in% loadedNamespaces()) {
     unloadNamespace("renv")
+  }
 
   # load bootstrap tools ${BOOTSTRAP}
 
@@ -115,5 +118,4 @@ local({
   renv_bootstrap_exec(project, libpath, version)
 
   invisible()
-
 })


### PR DESCRIPTION
When calling `styler::style_dir()` on a project using `renv`, `renv/activate.R` gets auto-updated, which leads to some subtle noise / churn. 

Changes in this MR were made as follows:
```
> styler::style_file("templates/template-activate.R")
Styling  1  files:
 templates/template-activate.R ℹ 
────────────────────────────────────────
Status	Count	Legend 
✔ 	0	File unchanged.
ℹ 	1	File changed.
✖ 	0	Styling threw an error.
────────────────────────────────────────
Please review the changes carefully!
```

Using the latest version on CRAN:
```
> packageVersion('styler')
[1] ‘1.10.3’
```