### PR TITLE
update embed docs to include qmd

### DIFF
--- a/R/embed.R
+++ b/R/embed.R
@@ -1,4 +1,4 @@
-#' Capture and re-use dependencies within a `.R` or `.Rmd`
+#' Capture and re-use dependencies within a `.R`, `.Rmd` or `.qmd`
 #'
 #' @description
 #' Together, `embed()` and `use()` provide a lightweight way to specify and
@@ -16,7 +16,7 @@
 #' )
 #' ```
 #'
-#' Then, when you next run your R script or render your `.Rmd`, `use()` will:
+#' Then, when you next run your R script or render your `.Rmd` or `.qmd`, `use()` will:
 #'
 #' 1. Create a temporary library path.
 #'

--- a/man/embed.Rd
+++ b/man/embed.Rd
@@ -3,7 +3,7 @@
 \name{embed}
 \alias{embed}
 \alias{use}
-\title{Capture and re-use dependencies within a \code{.R} or \code{.Rmd}}
+\title{Capture and re-use dependencies within a \code{.R}, \code{.Rmd} or \code{.qmd}}
 \usage{
 embed(path = NULL, ..., lockfile = NULL, project = NULL)
 
@@ -70,7 +70,7 @@ generates and inserts a call to \code{use()} that looks something like this:
 )
 }\if{html}{\out{</div>}}
 
-Then, when you next run your R script or render your \code{.Rmd}, \code{use()} will:
+Then, when you next run your R script or render your \code{.Rmd} or \code{.qmd}, \code{use()} will:
 \enumerate{
 \item Create a temporary library path.
 \item Install the requested packages and their recursive dependencies into that


### PR DESCRIPTION
`embed()` supports `.qmd` files as of https://github.com/rstudio/renv/commit/884569687ed75efa22a4f5b9fd5ab6f75aa9a7c3

However, `.qmd` format is not mentioned in the docs. 

I've not bumped / updated NEWS as you might want to combine with larger changes.