### PR TITLE
Pass project to renv_bootstrap_run reloading with the correct project

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -975,10 +975,10 @@ renv_bootstrap_version_friendly <- function(version, shafmt = NULL, sha = NULL) 
 
 renv_bootstrap_exec <- function(project, libpath, version) {
   if (!renv_bootstrap_load(project, libpath, version))
-    renv_bootstrap_run(version, libpath)
+    renv_bootstrap_run(project, libpath, version)
 }
 
-renv_bootstrap_run <- function(version, libpath) {
+renv_bootstrap_run <- function(project, libpath, version) {
 
   # perform bootstrap
   bootstrap(version, libpath)
@@ -989,7 +989,7 @@ renv_bootstrap_run <- function(version, libpath) {
 
   # try again to load
   if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
-    return(renv::load(project = getwd()))
+    return(renv::load(project = project))
   }
 
   # failed to download or load renv; warn the user

--- a/inst/resources/activate.R
+++ b/inst/resources/activate.R
@@ -1134,10 +1134,10 @@ local({
   
   renv_bootstrap_exec <- function(project, libpath, version) {
     if (!renv_bootstrap_load(project, libpath, version))
-      renv_bootstrap_run(version, libpath)
+      renv_bootstrap_run(project, libpath, version)
   }
   
-  renv_bootstrap_run <- function(version, libpath) {
+  renv_bootstrap_run <- function(project, libpath, version) {
   
     # perform bootstrap
     bootstrap(version, libpath)
@@ -1148,7 +1148,7 @@ local({
   
     # try again to load
     if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
-      return(renv::load(project = getwd()))
+      return(renv::load(project = project))
     }
   
     # failed to download or load renv; warn the user


### PR DESCRIPTION
If renv was bootsraped with a differen RENV_PROJECT environment, the reload would ignore the setting and create renv/ directory in the working directory instead of the project directory.