### PR TITLE
include all required fields for hashing in lockfile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # renv 1.1.0  (UNRELEASED)
 
+* `renv` now includes the contents of each package's DESCRIPTION file in
+  the package records for generated lockfiles. (#2057)
+
 * `renv` now detects dependencies from usages of `utils::citation()`. (#2047)
   
 * Fixed an issue where packages installed from r-universe via an explicit

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -42,3 +42,8 @@ testing <- function() {
 devel <- function() {
   identical(R.version[["status"]], "Under development (unstable)")
 }
+
+devmode <- function() {
+  load <- Sys.getenv("DEVTOOLS_LOAD", unset = NA)
+  identical(load, "renv")
+}

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -44,6 +44,5 @@ devel <- function() {
 }
 
 devmode <- function() {
-  load <- Sys.getenv("DEVTOOLS_LOAD", unset = NA)
-  identical(load, "renv")
+  Sys.getenv("DEVTOOLS_LOAD") == .packageName
 }

--- a/R/backports.R
+++ b/R/backports.R
@@ -1,11 +1,11 @@
 
-if (is.null(.BaseNamespaceEnv$startsWith)) {
-  
-  startsWith <- function(x, prefix) {
-    pattern <- sprintf("^\\Q%s\\E", prefix)
-    grepl(pattern, x, perl = TRUE)
+if (is.null(.BaseNamespaceEnv$dir.exists)) {
+
+  dir.exists <- function(paths) {
+    info <- suppressWarnings(file.info(paths, extra_cols = FALSE))
+    info$isdir %in% TRUE
   }
-  
+
 }
 
 if (is.null(.BaseNamespaceEnv$lengths)) {
@@ -15,3 +15,13 @@ if (is.null(.BaseNamespaceEnv$lengths)) {
   }
 
 }
+
+if (is.null(.BaseNamespaceEnv$startsWith)) {
+
+  startsWith <- function(x, prefix) {
+    pattern <- sprintf("^\\Q%s\\E", prefix)
+    grepl(pattern, x, perl = TRUE)
+  }
+
+}
+

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -400,6 +400,9 @@ renv_bootstrap_download_github <- function(version) {
 
   # prepare download options
   token <- renv_bootstrap_github_token()
+  if (is.null(token))
+    token <- ""
+
   if (nzchar(Sys.which("curl")) && nzchar(token)) {
     fmt <- "--location --fail --header \"Authorization: token %s\""
     extra <- sprintf(fmt, token)

--- a/R/files.R
+++ b/R/files.R
@@ -579,7 +579,10 @@ renv_file_broken_unix <- function(paths) {
 # unfortunately, as far as I know, there isn't a more reliable
 # way of detecting broken junction points on Windows using vanilla R
 renv_file_broken_win32 <- function(paths) {
-  !map_lgl(paths, Sys.setFileTime, Sys.time())
+  time <- Sys.time()
+  map_lgl(paths, function(path) {
+    dir.exists(path) && !Sys.setFileTime(path, time)
+  })
 }
 
 renv_file_size <- function(path) {

--- a/R/files.R
+++ b/R/files.R
@@ -577,15 +577,8 @@ renv_file_broken_unix <- function(paths) {
 }
 
 renv_file_broken_win32 <- function(paths) {
-  # TODO: the behavior of file.exists() for a broken junction point
-  # appears to have changed in the development version of R;
-  # we have to be extra careful here...
-  if (getRversion() < "4.2.0") {
-    info <- renv_file_info(paths)
-    (info$isdir %in% TRUE) & is.na(info$mtime)
-  } else {
-    file.access(paths, mode = 0L) == 0L & !file.exists(paths)
-  }
+  info <- renv_file_info(paths)
+  (info$isdir %in% TRUE) & is.na(info$mtime)
 }
 
 renv_file_size <- function(path) {

--- a/R/files.R
+++ b/R/files.R
@@ -579,21 +579,7 @@ renv_file_broken_unix <- function(paths) {
 # unfortunately, as far as I know, there isn't a more reliable
 # way of detecting broken junction points on Windows using vanilla R
 renv_file_broken_win32 <- function(paths) {
-
-  owd <- getwd()
-  on.exit(setwd(owd), add = TRUE)
-
-  broken <- rep.int(FALSE, length(paths))
-  for (i in seq_along(paths)) {
-    if (dir.exists(paths[[i]])) {
-      broken[[i]] <- tryCatch(
-        !nzchar(setwd(paths[[i]])),
-        error = function(cnd) TRUE
-      )
-    }
-  }
-  broken
-
+  !map_lgl(paths, Sys.setFileTime, Sys.time())
 }
 
 renv_file_size <- function(path) {

--- a/R/files.R
+++ b/R/files.R
@@ -581,7 +581,7 @@ renv_file_broken_unix <- function(paths) {
 renv_file_broken_win32 <- function(paths) {
   time <- Sys.time()
   map_lgl(paths, function(path) {
-    dir.exists(path) && !Sys.setFileTime(path, time)
+    file.access(path) == 0L && !Sys.setFileTime(path, time)
   })
 }
 

--- a/R/hash.R
+++ b/R/hash.R
@@ -50,18 +50,17 @@ renv_hash_description <- function(path) {
 }
 
 renv_hash_description_impl <- function(path) {
+  record <- renv_description_read(path)
+  renv_hash_record(record)
+}
 
-  dcf <- case(
-    is.character(path) ~ renv_description_read(path),
-    is.list(path)      ~ path,
-    ~ stop("unexpected path '%s'", path)
-  )
+renv_hash_record <- function(record) {
 
   # find relevant fields for hashing
-  fields <- renv_hash_fields(dcf)
+  fields <- renv_hash_fields(record)
 
   # retrieve these fields
-  subsetted <- dcf[renv_vector_intersect(fields, names(dcf))]
+  subsetted <- record[renv_vector_intersect(fields, names(record))]
 
   # sort names (use C locale to ensure consistent ordering)
   ordered <- subsetted[csort(names(subsetted))]

--- a/R/hash.R
+++ b/R/hash.R
@@ -10,10 +10,10 @@ renv_hash_fields <- function(dcf) {
   )
 }
 
-renv_hash_fields_default <- function(dcf) {
+renv_hash_fields_default <- function() {
   c(
-    "Package", "Version",
-    "Title", "Author", "Maintainer", "Description",
+    "Package", "Version", "Title",
+    "Author", "Maintainer", "Description",
     "Depends", "Imports", "Suggests", "LinkingTo"
   )
 }

--- a/R/hash.R
+++ b/R/hash.R
@@ -10,7 +10,7 @@ renv_hash_fields <- function(dcf) {
   )
 }
 
-renv_hash_fields_default <- function() {
+renv_hash_fields_default <- function(dcf) {
   c(
     "Package", "Version",
     "Title", "Author", "Maintainer", "Description",
@@ -31,7 +31,7 @@ renv_hash_fields_remotes <- function(dcf) {
   }
   
   # grab the relevant remotes
-  remotes <- grep("^Remote(?!s)", names(dcf), perl = TRUE, value = TRUE)
+  remotes <- grep("^Remote", names(dcf), perl = TRUE, value = TRUE)
   
   # don't include 'RemoteRef' if it's a non-informative remote
   if (identical(dcf[["RemoteRef"]], "HEAD"))

--- a/R/hash.R
+++ b/R/hash.R
@@ -19,7 +19,7 @@ renv_hash_fields_default <- function() {
 }
 
 renv_hash_fields_remotes <- function(dcf) {
-  
+
   # if this seems to be a cran-like record, only keep remotes
   # when RemoteSha appears to be a hash (e.g. for r-universe)
   # note that RemoteSha may be a package version when installed
@@ -29,16 +29,16 @@ renv_hash_fields_remotes <- function(dcf) {
     if (is.null(sha) || nchar(sha) < 40L)
       return(character())
   }
-  
+
   # grab the relevant remotes
   remotes <- grep("^Remote", names(dcf), perl = TRUE, value = TRUE)
-  
+
   # don't include 'RemoteRef' if it's a non-informative remote
   if (identical(dcf[["RemoteRef"]], "HEAD"))
     remotes <- setdiff(remotes, "RemoteRef")
-  
+
   remotes
-  
+
 }
 
 renv_hash_description <- function(path) {
@@ -58,6 +58,15 @@ renv_hash_record <- function(record) {
 
   # find relevant fields for hashing
   fields <- renv_hash_fields(record)
+
+  # collapse vector / list dependency fields
+  depfields <- c("Depends", "Imports", "Suggests", "LinkingTo", "Enhances")
+  for (depfield in depfields) {
+    if (!is.null(record[[depfield]])) {
+      value <- unlist(record[[depfield]])
+      record[[depfield]] <- paste(value, collapse = ", ")
+    }
+  }
 
   # retrieve these fields
   subsetted <- record[renv_vector_intersect(fields, names(record))]

--- a/R/hash.R
+++ b/R/hash.R
@@ -3,6 +3,44 @@ renv_hash_text <- function(text) {
   renv_bootstrap_hash_text(text)
 }
 
+renv_hash_fields <- function(dcf) {
+  c(
+    renv_hash_fields_default(),
+    renv_hash_fields_remotes(dcf)
+  )
+}
+
+renv_hash_fields_default <- function() {
+  c(
+    "Package", "Version",
+    "Title", "Author", "Maintainer", "Description",
+    "Depends", "Imports", "Suggests", "LinkingTo"
+  )
+}
+
+renv_hash_fields_remotes <- function(dcf) {
+  
+  # if this seems to be a cran-like record, only keep remotes
+  # when RemoteSha appears to be a hash (e.g. for r-universe)
+  # note that RemoteSha may be a package version when installed
+  # by e.g. pak
+  if (renv_record_cranlike(dcf)) {
+    sha <- dcf[["RemoteSha"]]
+    if (is.null(sha) || nchar(sha) < 40L)
+      return(character())
+  }
+  
+  # grab the relevant remotes
+  remotes <- grep("^Remote(?!s)", names(dcf), perl = TRUE, value = TRUE)
+  
+  # don't include 'RemoteRef' if it's a non-informative remote
+  if (identical(dcf[["RemoteRef"]], "HEAD"))
+    remotes <- setdiff(remotes, "RemoteRef")
+  
+  remotes
+  
+}
+
 renv_hash_description <- function(path) {
   filebacked(
     context  = "renv_hash_description",
@@ -19,17 +57,11 @@ renv_hash_description_impl <- function(path) {
     ~ stop("unexpected path '%s'", path)
   )
 
-  # include default fields
-  fields <- c(
-    "Package", "Version", "Title", "Author", "Maintainer", "Description",
-    "Depends", "Imports", "Suggests", "LinkingTo"
-  )
-
-  # add remotes fields
-  remotes <- renv_hash_description_remotes(dcf)
+  # find relevant fields for hashing
+  fields <- renv_hash_fields(dcf)
 
   # retrieve these fields
-  subsetted <- dcf[renv_vector_intersect(c(fields, remotes), names(dcf))]
+  subsetted <- dcf[renv_vector_intersect(fields, names(dcf))]
 
   # sort names (use C locale to ensure consistent ordering)
   ordered <- subsetted[csort(names(subsetted))]
@@ -69,16 +101,5 @@ renv_hash_description_impl <- function(path) {
 
   # return hash
   invisible(hash)
-
-}
-
-renv_hash_description_remotes <- function(dcf) {
-
-  # ignore other remote fields for cranlike remotes
-  if (renv_record_cranlike(dcf))
-    return(character())
-
-  # otherwise, include any other discovered remote fields
-  grep("^Remote", names(dcf), value = TRUE)
 
 }

--- a/R/lockfile-read.R
+++ b/R/lockfile-read.R
@@ -33,9 +33,28 @@ renv_lockfile_read_finish_impl <- function(key, val) {
 }
 
 renv_lockfile_read_finish <- function(data) {
-  data <- enumerate(data, renv_lockfile_read_finish_impl)
-  class(data) <- "renv_lockfile"
-  data
+  
+  # create lockfile
+  lockfile <- enumerate(data, renv_lockfile_read_finish_impl)
+  class(lockfile) <- "renv_lockfile"
+  
+  # compute hashes for records if possible
+  renv_lockfile_records(lockfile) <-
+    renv_lockfile_records(lockfile) %>%
+    map(function(record) {
+      
+      record$Hash <- record$Hash %||% {
+        fields <- renv_hash_fields_remotes(record)
+        if (all(names(record) %in% fields))
+          renv_hash_record(record)
+      }
+      
+      record
+      
+    })
+  
+  # return lockfile
+  lockfile
 }
 
 renv_lockfile_read_preflight <- function(contents) {

--- a/R/lockfile-write.R
+++ b/R/lockfile-write.R
@@ -90,7 +90,10 @@ renv_lockfile_write_json <- function(lockfile, file = stdout()) {
 
   prepared <- enumerate(lockfile, renv_lockfile_write_json_prepare)
 
-  json <- renv_json_convert(prepared)
+  box <- c("Requirements")
+  config <- list(box = box)
+  
+  json <- renv_json_convert(prepared, config)
   if (is.null(file))
     return(json)
 

--- a/R/lockfile-write.R
+++ b/R/lockfile-write.R
@@ -90,9 +90,7 @@ renv_lockfile_write_json <- function(lockfile, file = stdout()) {
 
   prepared <- enumerate(lockfile, renv_lockfile_write_json_prepare)
 
-  box <- c("Depends", "Imports", "Suggests", "LinkingTo", "Requirements")
-  config <- list(box = box)
-  json <- renv_json_convert(prepared, config)
+  json <- renv_json_convert(prepared)
   if (is.null(file))
     return(json)
 

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -122,6 +122,7 @@ renv_lockfile_save <- function(lockfile, project) {
 }
 
 renv_lockfile_load <- function(project, strict = FALSE) {
+  
   path <- renv_lockfile_path(project)
   if (file.exists(path))
     return(renv_lockfile_read(path))

--- a/R/record.R
+++ b/R/record.R
@@ -121,5 +121,5 @@ renv_record_placeholder <- function() {
 
 renv_record_cranlike <- function(record) {
   type <- record[["RemoteType"]]
-  is.null(type) || type %in% c("cran", "repository", "standard")
+  is.null(type) || tolower(type) %in% c("cran", "repository", "standard")
 }

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -744,7 +744,7 @@ renv_snapshot_description_impl <- function(dcf, path = NULL) {
   # drop fields that normally only appear in binary packages,
   # or fields which might differ from user to user, or might
   # differ depending on the mirror used for publication
-  ignore <- c("Packaged", "Date/Publication", "Built")
+  ignore <- c("Archs", "Built", "Date/Publication", "File", "MD5sum", "Packaged")
   dcf[ignore] <- NULL
   
   # drop remote fields for cranlike remotes
@@ -755,6 +755,10 @@ renv_snapshot_description_impl <- function(dcf, path = NULL) {
       dcf[remotes] <- NULL
     }
   }
+  
+  # drop the old Github remote fields
+  github <- grepl("^Github", names(dcf), perl = TRUE)
+  dcf <- dcf[!github]
   
   # generate a hash if we can
   dcf[["Hash"]] <- if (the$auto_snapshot_hash) {

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -747,6 +747,15 @@ renv_snapshot_description_impl <- function(dcf, path = NULL) {
   ignore <- c("Packaged", "Date/Publication", "Built")
   dcf[ignore] <- NULL
   
+  # drop remote fields for cranlike remotes
+  if (renv_record_cranlike(dcf)) {
+    sha <- dcf[["RemoteSha"]]
+    if (is.null(sha) || nchar(sha) < 40L) {
+      remotes <- grep("^Remote", names(dcf), perl = TRUE, value = TRUE)
+      dcf[remotes] <- NULL
+    }
+  }
+  
   # generate a hash if we can
   dcf[["Hash"]] <- if (the$auto_snapshot_hash) {
     if (is.null(path))

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -753,6 +753,9 @@ renv_snapshot_description_impl <- function(dcf, path = NULL) {
       renv_hash_description(path)
   }
   
+  # reorganize fields a bit
+  dcf <- dcf[c(required, setdiff(names(dcf), required))]
+  
   # return as list
   as.list(dcf)
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -741,9 +741,11 @@ renv_snapshot_description_impl <- function(dcf, path = NULL) {
     dcf <- dcf[fields]
   }
 
-  # collect fields to include in lockfile
-  fields <- c("Source", renv_hash_fields(dcf), "Repository", "OS_type")
-  dcf <- dcf[renv_vector_intersect(names(dcf), fields)]
+  # drop fields that normally only appear in binary packages,
+  # or fields which might differ from user to user, or might
+  # differ depending on the mirror used for publication
+  ignore <- c("Packaged", "Date/Publication", "Built")
+  dcf[ignore] <- NULL
   
   # generate a hash if we can
   dcf[["Hash"]] <- if (the$auto_snapshot_hash) {

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -756,7 +756,7 @@ renv_snapshot_description_impl_v1 <- function(dcf, path = NULL) {
   # generate a hash if we can
   dcf[["Hash"]] <- if (the$auto_snapshot_hash) {
     if (is.null(path))
-      renv_hash_description_impl(dcf)
+      renv_hash_record(dcf)
     else
       renv_hash_description(path)
   }
@@ -845,14 +845,6 @@ renv_snapshot_description_impl_v2 <- function(dcf, path) {
   # drop the old Github remote fields
   github <- grepl("^Github", names(dcf), perl = TRUE)
   dcf <- dcf[!github]
-  
-  # generate a hash if we can
-  dcf[["Hash"]] <- if (the$auto_snapshot_hash) {
-    if (is.null(path))
-      renv_hash_description_impl(dcf)
-    else
-      renv_hash_description(path)
-  }
   
   # reorganize fields a bit
   dcf <- dcf[c(required, setdiff(names(dcf), required))]

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -29,7 +29,7 @@
     }
 
     # don't lock sandbox while testing / checking
-    options(renv.sandbox.locking_enabled = FALSE)
+    Sys.setenv(RENV_SANDBOX_LOCKING_ENABLED = FALSE)
 
   }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -28,10 +28,15 @@
       Sys.setenv(RENV_PATHS_SANDBOX = sandbox)
     }
 
-    # don't lock sandbox while testing / checking
-    Sys.setenv(RENV_SANDBOX_LOCKING_ENABLED = FALSE)
-
   }
+  
+  # don't lock sandbox while testing / checking
+  if (testing() || checking() || devmode()) {
+    options(renv.sandbox.locking_enabled = FALSE)
+    Sys.setenv(RENV_SANDBOX_LOCKING_ENABLED = FALSE)
+  }
+  
+  
 
   renv_defer_init()
   renv_metadata_init()

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -113,8 +113,7 @@
 
 # NOTE: required for devtools::load_all()
 .onDetach <- function(libpath) {
-  package <- Sys.getenv("DEVTOOLS_LOAD", unset = NA)
-  if (identical(package, .packageName))
+  if (devmode())
     .onUnload(libpath)
 }
 
@@ -122,7 +121,7 @@ renv_zzz_run <- function() {
 
   # check if we're in pkgload::load_all()
   # if so, then create some files
-  if (renv_envvar_exists("DEVTOOLS_LOAD")) {
+  if (devmode()) {
     renv_zzz_bootstrap_activate()
     renv_zzz_bootstrap_config()
   }

--- a/inst/resources/activate.R
+++ b/inst/resources/activate.R
@@ -559,6 +559,9 @@ local({
   
     # prepare download options
     token <- renv_bootstrap_github_token()
+    if (is.null(token))
+      token <- ""
+  
     if (nzchar(Sys.which("curl")) && nzchar(token)) {
       fmt <- "--location --fail --header \"Authorization: token %s\""
       extra <- sprintf(fmt, token)

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -226,7 +226,7 @@
       
       - The lockfile is already up to date.
 
-# we can produce old-style lockfiles if requested
+# lockfiles are stable (v1)
 
     Code
       . <- writeLines(readLines("renv.lock"))
@@ -275,6 +275,82 @@
             "Requirements": [
               "bread"
             ],
+            "Hash": "d2f51ee89552a4668cbe9fc25b1f7c1e"
+          }
+        }
+      }
+
+# lockfiles are stable (v2)
+
+    Code
+      . <- writeLines(readLines("renv.lock"))
+    Output
+      {
+        "R": {
+          "Version": "<r-version>",
+          "Repositories": [
+            {
+              "Name": "CRAN",
+              "URL": "<test-repo>"
+            }
+          ]
+        },
+        "Packages": {
+          "bread": {
+            "Package": "bread",
+            "Version": "1.0.0",
+            "Source": "Repository",
+            "Type": "Package",
+            "Repository": "CRAN",
+            "License": "GPL",
+            "Description": "renv test package",
+            "Title": "renv test package",
+            "Author": "Anonymous Person <Anonymous@rstudio.org>",
+            "Maintainer": "Anonymous Person <Anonymous@rstudio.org>",
+            "Config/Needs/protein": "egg",
+            "Hash": "3d2aa8db4086921058b23ce646e01c7a"
+          },
+          "breakfast": {
+            "Package": "breakfast",
+            "Version": "1.0.0",
+            "Source": "Repository",
+            "Type": "Package",
+            "Depends": "oatmeal, toast (>= 1.0.0)",
+            "Suggests": "egg",
+            "Repository": "CRAN",
+            "License": "GPL",
+            "Description": "renv test package",
+            "Title": "renv test package",
+            "Author": "Anonymous Person <Anonymous@rstudio.org>",
+            "Maintainer": "Anonymous Person <Anonymous@rstudio.org>",
+            "Config/Needs/protein": "egg",
+            "Hash": "0fcd2a795901b4b21326a3e35442c97c"
+          },
+          "oatmeal": {
+            "Package": "oatmeal",
+            "Version": "1.0.0",
+            "Source": "Repository",
+            "Type": "Package",
+            "Repository": "CRAN",
+            "License": "GPL",
+            "Description": "renv test package",
+            "Title": "renv test package",
+            "Author": "Anonymous Person <Anonymous@rstudio.org>",
+            "Maintainer": "Anonymous Person <Anonymous@rstudio.org>",
+            "Hash": "1997110c04a1a14551dc791abb7cf8cf"
+          },
+          "toast": {
+            "Package": "toast",
+            "Version": "1.0.0",
+            "Source": "Repository",
+            "Depends": "bread",
+            "Type": "Package",
+            "Repository": "CRAN",
+            "License": "GPL",
+            "Description": "renv test package",
+            "Title": "renv test package",
+            "Author": "Anonymous Person <Anonymous@rstudio.org>",
+            "Maintainer": "Anonymous Person <Anonymous@rstudio.org>",
             "Hash": "d2f51ee89552a4668cbe9fc25b1f7c1e"
           }
         }

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -314,8 +314,13 @@
             "Version": "1.0.0",
             "Source": "Repository",
             "Type": "Package",
-            "Depends": "oatmeal, toast (>= 1.0.0)",
-            "Suggests": "egg",
+            "Depends": [
+              "oatmeal",
+              "toast (>= 1.0.0)"
+            ],
+            "Suggests": [
+              "egg"
+            ],
             "Repository": "CRAN",
             "License": "GPL",
             "Description": "renv test package",
@@ -340,7 +345,9 @@
             "Package": "toast",
             "Version": "1.0.0",
             "Source": "Repository",
-            "Depends": "bread",
+            "Depends": [
+              "bread"
+            ],
             "Type": "Package",
             "Repository": "CRAN",
             "License": "GPL",

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -307,8 +307,7 @@
             "Title": "renv test package",
             "Author": "Anonymous Person <Anonymous@rstudio.org>",
             "Maintainer": "Anonymous Person <Anonymous@rstudio.org>",
-            "Config/Needs/protein": "egg",
-            "Hash": "3d2aa8db4086921058b23ce646e01c7a"
+            "Config/Needs/protein": "egg"
           },
           "breakfast": {
             "Package": "breakfast",
@@ -323,8 +322,7 @@
             "Title": "renv test package",
             "Author": "Anonymous Person <Anonymous@rstudio.org>",
             "Maintainer": "Anonymous Person <Anonymous@rstudio.org>",
-            "Config/Needs/protein": "egg",
-            "Hash": "0fcd2a795901b4b21326a3e35442c97c"
+            "Config/Needs/protein": "egg"
           },
           "oatmeal": {
             "Package": "oatmeal",
@@ -336,8 +334,7 @@
             "Description": "renv test package",
             "Title": "renv test package",
             "Author": "Anonymous Person <Anonymous@rstudio.org>",
-            "Maintainer": "Anonymous Person <Anonymous@rstudio.org>",
-            "Hash": "1997110c04a1a14551dc791abb7cf8cf"
+            "Maintainer": "Anonymous Person <Anonymous@rstudio.org>"
           },
           "toast": {
             "Package": "toast",
@@ -350,8 +347,7 @@
             "Description": "renv test package",
             "Title": "renv test package",
             "Author": "Anonymous Person <Anonymous@rstudio.org>",
-            "Maintainer": "Anonymous Person <Anonymous@rstudio.org>",
-            "Hash": "d2f51ee89552a4668cbe9fc25b1f7c1e"
+            "Maintainer": "Anonymous Person <Anonymous@rstudio.org>"
           }
         }
       }

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -226,3 +226,57 @@
       
       - The lockfile is already up to date.
 
+# we can produce old-style lockfiles if requested
+
+    Code
+      . <- writeLines(readLines("renv.lock"))
+    Output
+      {
+        "R": {
+          "Version": "<r-version>",
+          "Repositories": [
+            {
+              "Name": "CRAN",
+              "URL": "<test-repo>"
+            }
+          ]
+        },
+        "Packages": {
+          "bread": {
+            "Package": "bread",
+            "Version": "1.0.0",
+            "Source": "Repository",
+            "Repository": "CRAN",
+            "Hash": "3d2aa8db4086921058b23ce646e01c7a"
+          },
+          "breakfast": {
+            "Package": "breakfast",
+            "Version": "1.0.0",
+            "Source": "Repository",
+            "Repository": "CRAN",
+            "Requirements": [
+              "oatmeal",
+              "toast"
+            ],
+            "Hash": "0fcd2a795901b4b21326a3e35442c97c"
+          },
+          "oatmeal": {
+            "Package": "oatmeal",
+            "Version": "1.0.0",
+            "Source": "Repository",
+            "Repository": "CRAN",
+            "Hash": "1997110c04a1a14551dc791abb7cf8cf"
+          },
+          "toast": {
+            "Package": "toast",
+            "Version": "1.0.0",
+            "Source": "Repository",
+            "Repository": "CRAN",
+            "Requirements": [
+              "bread"
+            ],
+            "Hash": "d2f51ee89552a4668cbe9fc25b1f7c1e"
+          }
+        }
+      }
+

--- a/tests/testthat/helper-snapshot.R
+++ b/tests/testthat/helper-snapshot.R
@@ -34,6 +34,7 @@ strip_dirs <- function(x) {
     "<test-repo>"       = getOption("repos")[[1L]],
     "<test-repo-path>"  = gsub(prefix, "", getOption("repos")[[1L]]),
     "<root>"            = renv_path_normalize(renv_paths_root()),
+    "<wd>"              = renv_path_aliased(getwd()),
     "<wd>"              = renv_path_normalize(getwd()),
     "<tempdir>"         = renv_path_normalize(tempdir()),
     "<wd-name>"         = basename(getwd())

--- a/tests/testthat/test-bioconductor.R
+++ b/tests/testthat/test-bioconductor.R
@@ -222,11 +222,9 @@ test_that("standard bioc remotes are standardized appropriately", {
     Package      = "BiocVersion",
     Version      = "3.18.1",
     Source       = "Bioconductor",
-    Repository   = "Bioconductor 3.18",
-    Requirements = "R",
-    Hash         = "2ecaed86684f5fae76ed5530f9d29c4a"
+    Repository   = "Bioconductor 3.18"
   )
 
-  expect_identical(actual, expected)
+  expect_identical(actual[names(expected)], expected)
 
 })

--- a/tests/testthat/test-files.R
+++ b/tests/testthat/test-files.R
@@ -176,6 +176,7 @@ test_that("renv can detect broken junctions / symlinks", {
 
   if (renv_platform_windows()) {
 
+    file.create("file")
     dir.create("dir")
     dir.create("nowhere")
     Sys.junction("dir", "junction")

--- a/tests/testthat/test-lockfile.R
+++ b/tests/testthat/test-lockfile.R
@@ -53,22 +53,23 @@ test_that("we create lockfile from a manifest automatically when no lockfile fou
 
   skip_on_cran()
 
-  project_dir <- tempfile()
-  dir.create(project_dir)
+  project <- tempfile()
+  dir.create(project)
 
-  manifest <- "resources/manifest.json"
-  expected_lock <- renv_lockfile_from_manifest("resources/manifest.json")
-  file.copy(manifest, file.path(project_dir, "manifest.json"))
+  path <- renv_tests_path("resources/manifest.json")
+  expected <- renv_lockfile_from_manifest(path)
+  file.copy(path, file.path(project, "manifest.json"))
 
   # when called with `strict = TRUE` does not create manifest
-  expect_error(renv_lockfile_load(project_dir, strict = TRUE))
+  expect_error(renv_lockfile_load(project, strict = TRUE))
 
   # creates and reads lockfile
-  obtained_lock <- renv_lockfile_load(project_dir)
-  expect_identical(expected_lock, obtained_lock)
-  expect_true(file.exists(file.path(project_dir, "renv.lock")))
+  actual <- renv_lockfile_load(project)
+  expect_identical(expected, actual)
+  expect_true(file.exists(file.path(project, "renv.lock")))
 
-  unlink(project_dir, recursive = TRUE)
+  unlink(project, recursive = TRUE)
+  
 })
 
 test_that("the Requirements field is read as character", {

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -629,3 +629,16 @@ test_that("a package's hash can be re-generated from lockfile", {
   })
   
 })
+
+test_that("we can produce old-style lockfiles if requested", {
+  
+  skip_on_cran()
+  skip_on_ci()
+  
+  renv_scope_options(renv.lockfile.minimal = TRUE)
+  
+  project <- renv_tests_scope("breakfast")
+  init()
+  expect_snapshot(. <- writeLines(readLines("renv.lock")))
+  
+})

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -630,13 +630,24 @@ test_that("a package's hash can be re-generated from lockfile", {
   
 })
 
-test_that("we can produce old-style lockfiles if requested", {
+test_that("lockfiles are stable (v1)", {
   
-  skip_on_cran()
-  renv_scope_options(renv.lockfile.minimal = TRUE)
+  renv_scope_options(renv.lockfile.version = 1L)
   
   project <- renv_tests_scope("breakfast")
   init()
+  
+  expect_snapshot(. <- writeLines(readLines("renv.lock")))
+  
+})
+
+test_that("lockfiles are stable (v2)", {
+  
+  renv_scope_options(renv.lockfile.version = 2L)
+  
+  project <- renv_tests_scope("breakfast")
+  init()
+  
   expect_snapshot(. <- writeLines(readLines("renv.lock")))
   
 })

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -400,7 +400,7 @@ test_that("packages installed from CRAN using pak are handled", {
   quietly(pak$pkg_install("toast"))
   record <- renv_snapshot_description(package = "toast")
 
-  expected <- c("Package", "Version", "Source", "Repository", "Hash")
+  expected <- c("Package", "Version", "Source", "Repository")
   expect_contains(names(record), expected)
 
   expect_identical(record$Source, "Repository")
@@ -622,9 +622,10 @@ test_that("a package's hash can be re-generated from lockfile", {
   lockfile <- snapshot(lockfile = NULL)
   records <- renv_lockfile_records(lockfile)
   
-  map(records, function(record) {
-    actual <- record[["Hash"]]
-    expected <- renv_hash_description_impl(record)
+  enumerate(records, function(package, record) {
+    path <- system.file("DESCRIPTION", package = package)
+    actual <- renv_hash_description(path)
+    expected <- renv_hash_record(record)
     expect_equal(actual, expected)
   })
   

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -397,13 +397,11 @@ test_that("packages installed from CRAN using pak are handled", {
   library <- renv_paths_library()
   ensure_directory(library)
   pak <- renv_namespace_load("pak")
-  suppressMessages(pak$pkg_install("toast"))
+  quietly(pak$pkg_install("toast"))
   record <- renv_snapshot_description(package = "toast")
 
-  expect_named(
-    record,
-    c("Package", "Version", "Source", "Repository", "Requirements", "Hash")
-  )
+  expected <- c("Package", "Version", "Source", "Repository", "Hash")
+  expect_contains(names(record), expected)
 
   expect_identical(record$Source, "Repository")
   expect_identical(record$Repository, "CRAN")

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -613,3 +613,19 @@ test_that("standard remotes drop RemoteSha if it's a version", {
   expect_null(record[["RemoteSha"]])
 
 })
+
+test_that("a package's hash can be re-generated from lockfile", {
+  
+  project <- renv_tests_scope("breakfast")
+  init()
+  
+  lockfile <- snapshot(lockfile = NULL)
+  records <- renv_lockfile_records(lockfile)
+  
+  map(records, function(record) {
+    actual <- record[["Hash"]]
+    expected <- renv_hash_description_impl(record)
+    expect_equal(actual, expected)
+  })
+  
+})

--- a/tests/testthat/test-vendor.R
+++ b/tests/testthat/test-vendor.R
@@ -43,10 +43,6 @@ test_that("renv can be vendored into an R package", {
     base <- .BaseNamespaceEnv
     base$.libPaths(path)
 
-    # extra sanity check
-    if (requireNamespace("renv", quietly = TRUE))
-      stop("internal error: renv shouldn't be visible on library paths")
-
     # load the package, and check that renv realizes it's embedded
     namespace <- base$asNamespace("test.renv.embedding")
     embedded <- namespace$renv$renv_metadata_embedded()


### PR DESCRIPTION
Closes https://github.com/rstudio/renv/issues/2057.

Should we still include a Hash field in the lockfile, or should we recompute hashes on the fly? This mainly comes to mind as the hash would be invalid if the lockfile's fields were changed by a user.

I also wonder if there are any DESCRIPTION fields that we should exclude from the lockfile -- for example, fields like Packaged, Built, and Date/Publication, since those will differ depending on where and how the package was built. (A common request for users was to make sure that packages installed from CRAN, and packages installed from P3M, produced otherwise identical lockfile records.)

Should we include the exact, raw, contents of the DESCRIPTION fields in the lockfile (including newlines)? Or is it okay to normalize that whitespace? (In any case, it does not affect the hash.)