### PR TITLE
Fix R-CMD-check badge

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 
-[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html) [![CRAN status](https://www.r-pkg.org/badges/version/renv)](https://CRAN.R-project.org/package=renv) [![R-CMD-check](https://github.com/rstudio/renv/workflows/R-CMD-check/badge.svg)](https://github.com/rstudio/renv/actions)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html) [![CRAN status](https://www.r-pkg.org/badges/version/renv)](https://CRAN.R-project.org/package=renv) [![R-CMD-check](https://github.com/rstudio/renv/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/rstudio/renv/actions/workflows/R-CMD-check.yaml)
 
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/renv)](https://CRAN.R-project.org/package=renv)
-[![R-CMD-check](https://github.com/rstudio/renv/workflows/R-CMD-check/badge.svg)](https://github.com/rstudio/renv/actions)
+[![R-CMD-check](https://github.com/rstudio/renv/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/rstudio/renv/actions/workflows/R-CMD-check.yaml)
 
 <!-- badges: end -->
 


### PR DESCRIPTION
This fixes the `R-CMD-check.yaml` badge. The `README` currently has an outdated link and is reporting as failed even though the check is passing. 