### PR TITLE
Add `lockfile_validate` to reference

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -45,6 +45,7 @@ reference:
 - title: Lockfile Management
   contents:
   - lockfiles
+  - lockfile_validate
   - record
   - remote
   - modify


### PR DESCRIPTION
Closes #2048.

This seems like the best way to add this function to the reference since the docs need to be filled out a bit more than functions under `@rdname lockfiles`. Happy to change it up if you disagree.