### PR TITLE
Update actions/checkout to v5

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
@@ -51,7 +51,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/pr-fetch@v2
         with:

--- a/.github/workflows/slow-tests.yaml
+++ b/.github/workflows/slow-tests.yaml
@@ -18,7 +18,7 @@ jobs:
       RENV_TESTTHAT_SLOW: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/vignettes/ci.Rmd
+++ b/vignettes/ci.Rmd
@@ -45,7 +45,7 @@ The r-lib organization offers some actions for R users, and among them a [`setup
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v5
 - uses: r-lib/actions/setup-r@v2
 - uses: r-lib/actions/setup-renv@v2
 ```


### PR DESCRIPTION
I noticed the version mentioned in the ci.Rmd vignette is a bit out of date, I bumped it there and in the workflows.