### PR TITLE
Fix posit project manager repo link for linux mint

### DIFF
--- a/R/ppm.R
+++ b/R/ppm.R
@@ -191,9 +191,11 @@ renv_ppm_platform_impl <- function(file = "/etc/os-release") {
 
     id <- properties$ID %||% ""
 
-    if ("UBUNTU_CODENAME" %in% names(properties))
+    # handle distros based on Ubuntu
+    if ("UBUNTU_CODENAME" %in% names(properties)) {
       id <- "ubuntu"
       properties$VERSION_CODENAME <- properties$UBUNTU_CODENAME
+    }
 
     case(
       identical(id, "ubuntu")    ~ renv_ppm_platform_ubuntu(properties),


### PR DESCRIPTION
I had a minor issues with downloading r-package binaries within renv projects because I am using Linux Mint and not Ubuntu directly. 

This meant that whenever I created a new project, the loaded repos, `getOption("repos"`, would contain `c(P3M = "https://packagemanager.posit.co/cran/latest", CRAN = "https://cloud.r-project.org"`. This would result in all downloaded packages had to be compiled. 

If I use Ubuntu the P3M repo would be: `"https://packagemanager.posit.co/cran/__linux__/noble/latest"`. These changes ensure that I get the same functionality with linux mint. 