### PR TITLE
link lockfile-api to current lockfile API docs

### DIFF
--- a/R/lockfile-api.R
+++ b/R/lockfile-api.R
@@ -79,6 +79,9 @@ renv_lockfile_api <- function(lockfile = NULL) {
 
 #' Programmatically Create and Modify a Lockfile
 #'
+#' **NOTE: `lockfile()` is now internal, please use the \link{lockfiles} 
+#' API.**
+#' 
 #' This function provides an API for creating and modifying `renv` lockfiles.
 #' This can be useful when you'd like to programmatically generate or modify
 #' a lockfile -- for example, because you want to update or change a package

--- a/man/lockfile-api.Rd
+++ b/man/lockfile-api.Rd
@@ -17,6 +17,10 @@ be used. If no project is currently active, then the current working
 directory is used instead.}
 }
 \description{
+\strong{NOTE: \code{lockfile()} is now internal, please use the \link{lockfiles}
+API.}
+}
+\details{
 This function provides an API for creating and modifying \code{renv} lockfiles.
 This can be useful when you'd like to programmatically generate or modify
 a lockfile -- for example, because you want to update or change a package


### PR DESCRIPTION
Addresses #2196. Not sure if `internal` or `deprecated` is the right word, or if there's a better one to use...