### PR TITLE
fix: repos.override() to handle multiple env-var named repos

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -138,6 +138,10 @@ renv_config_decode_envvar <- function(envname, envval) {
     return(decoded)
   }
 
+  if (envname == "RENV_CONFIG_REPOS_OVERRIDE") {
+    return(renv_bootstrap_repos())
+  }
+
   strsplit(envval, "\\s*,\\s*", perl = TRUE)[[1L]]
 
 }

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -806,3 +806,26 @@ test_that("irrelevant R version requirements don't prevent package installation"
   expect_error(install("today"))
 
 })
+
+
+test_that("install() respects RENV_CONFIG_REPOS_OVERRIDE with multiple named repositories", {
+
+  skip_on_cran()
+  project <- renv_tests_scope()
+  init()
+
+  renv_scope_envvars(
+    RENV_CONFIG_REPOS_OVERRIDE = "CRAN=https://cran.r-project.org/;RSPM=https://p3m.dev/cran/latest"
+  )
+
+  override <- config$repos.override()
+  expect_type(override, "character")
+  expect_equal(names(override), c("CRAN", "RSPM"))
+  expect_equal(unname(override[["CRAN"]]), "https://cran.r-project.org/")
+  expect_equal(unname(override[["RSPM"]]), "https://p3m.dev/cran/latest")
+
+  # install a package and verify it uses the override
+  install("bread", rebuild = TRUE)
+  expect_true(renv_package_installed("bread"))
+
+})


### PR DESCRIPTION
Following #2200 the `renv::install()` and `renv::restore()` failed to properly resolve the repos from the environment variable `RENV_CONFIG_REPOS_OVERRIDE`.

This pr closes #2209  (sorry!) by calling `renv_bootstrap_repos()` in `renv_config_decode_envvar()` when the `envname` is  `RENV_CONFIG_REPOS_OVERRIDE`

I've added an install test as well to make sure this is tested **properly!**