### PR TITLE
use crandb to search for available / compatible packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # renv (under development)
 
+* renv gains the configuration option `renv.config.crandb.enabled`. When
+  enabled, renv will query the [crandb](https://github.com/r-hub/crandb)
+  service to find the newest version of a package compatible with the current
+  version of R. This can be useful when using an older version of R, where
+  the latest version of a package on CRAN requires a newer R version.
+  (#1735)
+
 # renv 1.1.7
 
 * Fixed an issue where `.renvignore` files were not read when the project root

--- a/R/config-defaults.R
+++ b/R/config-defaults.R
@@ -60,6 +60,15 @@ config <- list(
     )
   },
 
+  crandb.enabled = function(..., default = FALSE) {
+    renv_config_get(
+      name    = "crandb.enabled",
+      type    = "logical[1]",
+      default = default,
+      args    = list(...)
+    )
+  },
+
   connect.timeout = function(..., default = 20L) {
     renv_config_get(
       name    = "connect.timeout",

--- a/inst/config.yml
+++ b/inst/config.yml
@@ -46,6 +46,18 @@
     The method to use when attempting to copy directories. See **Copy Methods**
     for more information.
 
+- name: "crandb.enabled"
+  type: "logical[1]"
+  default: false
+  description: >
+    Use the [crandb](https://github.com/r-hub/crandb) service when
+    looking up packages from CRAN which are not available in the configured
+    repositories? When enabled, renv will query the crandb API to find the
+    latest version of a package compatible with the current version of R.
+    This can be useful when an older version of R is being used, and the
+    latest version of a package on CRAN requires a newer version of R.
+    Disabled by default.
+
 - name: "connect.timeout"
   type: "integer[1]"
   default: 20


### PR DESCRIPTION
Improved `renv`'s ability to install older packages when the latest-available version is not compatible with the current version of R.