### PR TITLE
use(repos = NULL) now installs from cache only

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # renv (under development)
 
+* `renv::use(repos = NULL)` now uses a cache-only install path, ensuring
+  packages are only installed from the renv cache and no external sources
+  (repositories, GitHub, etc.) are queried. Previously, `restore()` and
+  `install()` could still reach external sources through internal fallback
+  logic.
+
 * `renv::init(bioconductor = "devel")` now resolves symbolic Bioconductor
   version names (e.g. `"devel"`, `"release"`) to their numeric equivalents
   before writing to the lockfile. Previously, the literal string `"devel"`

--- a/man/config.Rd
+++ b/man/config.Rd
@@ -60,6 +60,8 @@ Defaults to \code{NULL}.}
 Defaults to \code{"api.bitbucket.org/2.0"}.}
 \subsection{renv.config.copy.method}{The method to use when attempting to copy directories. See \strong{Copy Methods} for more information.
 Defaults to \code{"auto"}.}
+\subsection{renv.config.crandb.enabled}{Use the \href{https://github.com/r-hub/crandb}{crandb} service when looking up packages from CRAN which are not available in the configured repositories? When enabled, renv will query the crandb API to find the latest version of a package compatible with the current version of R. This can be useful when an older version of R is being used, and the latest version of a package on CRAN requires a newer version of R. Disabled by default.
+Defaults to \code{FALSE}.}
 \subsection{renv.config.connect.timeout}{The amount of time to spend (in seconds) when attempting to download a file. Only applicable when the \code{curl} downloader is used.
 Defaults to \code{20L}.}
 \subsection{renv.config.connect.retry}{The number of times to attempt re-downloading a file, when transient download errors occur. Only applicable when the \code{curl} downloader is used.

--- a/man/embed.Rd
+++ b/man/embed.Rd
@@ -11,6 +11,7 @@ use(
   ...,
   lockfile = NULL,
   library = NULL,
+  repos = getOption("repos"),
   isolate = TRUE,
   sandbox = TRUE,
   attach = FALSE,
@@ -36,6 +37,12 @@ When \code{NULL} (the default), a library path within the \R temporary
 directory will be generated and used. Note that this same library path
 will be re-used on future calls to \code{renv::use()}, allowing \code{renv::use()}
 to be used multiple times within a single script.}
+
+\item{repos}{The \R package repositories to use. When \code{NULL}, packages will be
+resolved from the renv cache, without querying any external repositories.
+This can be useful if you'd like to use packages that have already been
+cached by renv, even when no active package repositories have been
+configured.}
 
 \item{isolate}{Boolean; should the active library paths be included in the set of library
 paths activated for this script? Set this to \code{TRUE} if you only want the

--- a/tests/testthat/test-use.R
+++ b/tests/testthat/test-use.R
@@ -45,3 +45,91 @@ test_that("use(lockfile) works as intended", {
   )
 
 })
+
+test_that("renv_use_cacheonly_install installs packages from the cache", {
+
+  skip_on_cran()
+
+  renv_tests_scope("bread")
+  init()
+
+  # get records from the lockfile (has proper Source, Version, etc.)
+  lockfile <- renv_lockfile_read("renv.lock")
+  records <- renv_lockfile_records(lockfile)
+
+  # set up a fresh library and install from cache
+  library <- tempfile("renv-library-")
+  ensure_directory(library)
+
+  installed <- renv_use_cacheonly_install(records = records, library = library)
+  expect_true("bread" %in% names(installed))
+  expect_true(file.exists(file.path(library, "bread")))
+
+})
+
+test_that("renv_use_cacheonly_install skips packages not in the cache", {
+
+  skip_on_cran()
+
+  renv_tests_scope()
+
+  # set up a fresh library
+  library <- tempfile("renv-library-")
+  ensure_directory(library)
+
+  # use a record for a package that won't be in the cache
+  records <- list(
+    nosuchpackage = list(
+      Package = "nosuchpackage",
+      Version = "1.0.0",
+      Source  = "Repository"
+    )
+  )
+
+  installed <- renv_use_cacheonly_install(records = records, library = library)
+  expect_length(installed, 0)
+  expect_false(file.exists(file.path(library, "nosuchpackage")))
+
+})
+
+test_that("renv_use_cacheonly_restore installs lockfile packages from cache", {
+
+  skip_on_cran()
+  skip_on_windows()
+
+  renv_tests_scope("bread")
+  init()
+
+  # set up a fresh library
+  library <- tempfile("renv-library-")
+  ensure_directory(library)
+
+  installed <- renv_use_cacheonly_restore(lockfile = "renv.lock", library = library)
+  expect_true("bread" %in% names(installed))
+  expect_true(file.exists(file.path(library, "bread")))
+
+})
+
+test_that("use(repos = NULL) installs from cache only", {
+
+  skip_on_cran()
+
+  renv_tests_scope("bread")
+  init()
+
+  # reset the shared use libpath so we get a fresh library
+  renv_scope_binding(the, "use_libpath", NULL)
+  renv_scope_libpaths()
+
+  use(
+    "bread",
+    repos    = NULL,
+    isolate  = TRUE,
+    verbose  = FALSE,
+    sandbox  = FALSE
+  )
+
+  libpath <- renv_use_libpath()
+  expect_true(file.exists(file.path(libpath, "bread")))
+
+})


### PR DESCRIPTION
Closes #2213.

## Summary

- When `repos = NULL` (cache-only mode), `use()` now delegates to dedicated `renv_use_cacheonly_restore()` and `renv_use_cacheonly_install()` helpers that bypass the `restore()`/`install()` pipeline entirely
- Packages either come from the renv cache or are skipped -- no external sources (repositories, GitHub, URLs, etc.) are queried
- When a record has no version (e.g. resolved with `latest = FALSE`), falls back to searching the cache for any available version of the package

## Motivation

Previously, the `cacheonly` flag was partially respected: `renv_remotes_resolve()` was called with `latest = FALSE`, but the subsequent `restore()` and `install()` calls could still reach external sources through internal fallback logic (e.g. lockfile repositories, config overrides, or non-repository remotes like GitHub).

## Test plan

- [x] `renv_use_cacheonly_install()` installs packages from cache into a fresh library
- [x] `renv_use_cacheonly_install()` skips packages not in the cache
- [x] `renv_use_cacheonly_restore()` reads a lockfile and installs from cache
- [x] `use(repos = NULL)` end-to-end integration test