### PR TITLE
add `description` parameter to `snapshot()`

### DIFF
--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -112,8 +112,16 @@
 #' @param reprex Boolean; generate output appropriate for embedding the lockfile
 #'   as part of a [reprex](https://tidyverse.org/help/#reprex)?
 #'
+#' @param description A package DESCRIPTION, provided either as a named list
+#'   of DESCRIPTION fields, or a path to a package directory or DESCRIPTION
+#'   file. When set, all other arguments are ignored, and a single lockfile
+#'   record for that package is returned.
+#'
 #' @return The generated lockfile, as an \R object (invisibly). Note that
 #'   this function is normally called for its side effects.
+#'
+#'   When `description` is provided, a single lockfile record (a named list)
+#'   is returned instead.
 #'
 #'
 #' @seealso More on handling package [dependencies()]
@@ -134,12 +142,16 @@ snapshot <- function(project  = NULL,
                      prompt   = interactive(),
                      update   = FALSE,
                      force    = FALSE,
-                     reprex   = FALSE)
+                     reprex   = FALSE,
+                     description = NULL)
 {
-  renv_consent_check()
   renv_scope_error_handler()
   renv_dots_check(...)
 
+  if (!is.null(description))
+    return(renv_snapshot_description_dispatch(description))
+
+  renv_consent_check()
   renv_snapshot_auto_suppress_next()
 
   project <- renv_project_resolve(project)
@@ -709,6 +721,18 @@ renv_snapshot_check_missing_description <- function(paths) {
   )
 
   paths[!missing]
+
+}
+
+renv_snapshot_description_dispatch <- function(description) {
+
+  dcf <- case(
+    is.character(description) ~ renv_description_read(description),
+    is.list(description)      ~ description,
+    TRUE                      ~ renv_type_unexpected(description)
+  )
+
+  renv_snapshot_description_impl(dcf)
 
 }
 

--- a/man/snapshot.Rd
+++ b/man/snapshot.Rd
@@ -17,7 +17,8 @@ snapshot(
   prompt = interactive(),
   update = FALSE,
   force = FALSE,
-  reprex = FALSE
+  reprex = FALSE,
+  description = NULL
 )
 }
 \arguments{
@@ -81,10 +82,18 @@ validation checks have failed?}
 
 \item{reprex}{Boolean; generate output appropriate for embedding the lockfile
 as part of a \href{https://tidyverse.org/help/#reprex}{reprex}?}
+
+\item{description}{A package DESCRIPTION, provided either as a named list
+of DESCRIPTION fields, or a path to a package directory or DESCRIPTION
+file. When set, all other arguments are ignored, and a single lockfile
+record for that package is returned.}
 }
 \value{
 The generated lockfile, as an \R object (invisibly). Note that
 this function is normally called for its side effects.
+
+When \code{description} is provided, a single lockfile record (a named list)
+is returned instead.
 }
 \description{
 Call \code{renv::snapshot()} to update a \link{lockfile} with the current state of

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -739,3 +739,30 @@ test_that("snapshot.dev setting works and snapshot() uses it as default", {
   expect_true("devtools" %in% deps2)
 
 })
+
+test_that("snapshot(description) creates a record from a list", {
+
+  desc <- list(
+    Package    = "example",
+    Version    = "1.0.0",
+    Repository = "CRAN"
+  )
+
+  record <- snapshot(description = desc)
+  expect_true(is.list(record))
+  expect_equal(record$Package, "example")
+  expect_equal(record$Version, "1.0.0")
+  expect_equal(record$Source, "Repository")
+
+})
+
+test_that("snapshot(description) creates a record from a path", {
+
+  skip_on_cran()
+
+  descpath <- system.file("DESCRIPTION", package = "utils")
+  record <- snapshot(description = descpath)
+  expect_true(is.list(record))
+  expect_equal(record$Package, "utils")
+
+})


### PR DESCRIPTION
## Summary

- Adds a `description` parameter to `snapshot()` that accepts a package DESCRIPTION as either a named list or a file path
- When provided, returns a single lockfile record for that package without requiring it to be installed
- Enables downstream packages (e.g. rsconnect) to use exported renv APIs for manifest-to-lockfile conversion, replacing usage of `renv:::renv_lockfile_from_manifest()`

## Test plan

- [x] New test: `snapshot(description = <list>)` returns correct record
- [x] New test: `snapshot(description = <path>)` returns correct record
- [x] Existing snapshot tests pass (82 pass, 2 pre-existing skips)