### PR TITLE
fix install(..., type = "binary") not respected during graph resolution

### DIFF
--- a/R/graph.R
+++ b/R/graph.R
@@ -208,6 +208,12 @@ renv_graph_description_repository <- function(record) {
   package <- record$Package
   version <- record$Version
 
+  # respect explicitly-requested package type (e.g. install(..., type = "binary"))
+  # so that graph resolution finds versions available for the requested type;
+  # without this, we always search source packages and may resolve a version
+  # that only exists as source when the user asked for binaries
+  type <- the$install_pkg_type %||% "source"
+
   # try available packages entry (returns full fields including Imports, Depends);
   # we need these fields for dependency graph resolution;
   # in strict mode with a URL-valued Repository, search only that repository
@@ -219,6 +225,7 @@ renv_graph_description_repository <- function(record) {
   entry <- catch(
     renv_available_packages_entry(
       package = package,
+      type    = type,
       filter  = version,
       repos   = repos,
       prefer  = record[["Repository"]]
@@ -232,7 +239,7 @@ renv_graph_description_repository <- function(record) {
   # cellar packages won't be found by renv_available_packages_entry.
   # NOTE: renv_available_packages_latest only returns limited fields
   # (Package, Version, etc.) — no Depends/Imports/LinkingTo
-  latest <- catch(renv_available_packages_latest(package))
+  latest <- catch(renv_available_packages_latest(package, type = type))
   if (!inherits(latest, "error")) {
     if (is.null(version) || identical(latest$Version, version))
       return(as.list(latest))
@@ -242,7 +249,7 @@ renv_graph_description_repository <- function(record) {
   # the full-field entry with overridden version; renv_available_packages_entry
   # without filter returns complete dependency fields unlike latest
   if (!is.null(version) && !inherits(latest, "error")) {
-    full <- catch(renv_available_packages_entry(package))
+    full <- catch(renv_available_packages_entry(package, type = type))
     if (!inherits(full, "error")) {
       desc <- as.list(full)
       desc$Version <- version

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -866,6 +866,38 @@ test_that("renv_graph_urls gracefully handles mixed sources", {
 
 })
 
+# https://github.com/rstudio/renv/issues/2264
+test_that("renv_graph_description_repository respects install_pkg_type", {
+
+  renv_tests_scope()
+
+  # track the type argument passed to renv_available_packages_entry
+  env <- new.env(parent = emptyenv())
+  env$types <- character()
+
+  renv_scope_trace(
+    what   = renv:::renv_available_packages_entry,
+    tracer = bquote({
+      .env <- .(env)
+      .env$types <- c(.env$types, type)
+    })
+  )
+
+  record <- list(Package = "bread", Source = "Repository")
+
+  # default: install_pkg_type is NULL, should fall back to "source"
+  renv_graph_description_repository(record)
+  expect_true("source" %in% env$types)
+
+  # when install_pkg_type is set, it should be forwarded
+  env$types <- character()
+  renv_scope_binding(the, "install_pkg_type", "binary")
+  catch(renv_graph_description_repository(record))
+  expect_true("binary" %in% env$types)
+  expect_false("source" %in% env$types)
+
+})
+
 # https://github.com/rstudio/renv/issues/2249
 test_that("gitlab DESCRIPTION path handles empty RemoteSubdir", {
 


### PR DESCRIPTION
## Summary

Fixes #2264.

- `renv_graph_description_repository()` was calling `renv_available_packages_entry()` without forwarding the user's requested package type, so it always defaulted to `"source"`. When a new version was released on CRAN but binaries weren't built yet, the graph resolved to the source-only version and installation as binary failed.
- Now reads `the$install_pkg_type` (set by `install()` / `update()`) and passes it to all three available-packages lookups in the function.
- Adds a test verifying the type argument is forwarded correctly.

## Test plan

- [x] Existing `test-graph.R` tests pass
- [x] New test traces `renv_available_packages_entry` to verify `type = "source"` is used by default and `type = "binary"` is forwarded when `install_pkg_type` is set
- [x] `test-available-packages.R` and `test-install.R` suites still pass