### PR TITLE
unify binary and source install to use R CMD INSTALL

### DIFF
--- a/R/graph.R
+++ b/R/graph.R
@@ -1275,19 +1275,12 @@ renv_graph_install <- function(descriptions) {
   }
 
   # ── Phase 2: Classify all packages ────────────────────────────
-  # Separating binaries from source up front lets us install all
-  # binaries before the wave loop (they're just file copies with no
-  # build-time dependency ordering).  This can collapse waves: a
-  # source package whose deps are all binary no longer needs to wait.
-  # To revert to wave-ordered binary installs, remove Phase 2a/2b
-  # and restore the binary branch inside the wave loop.
-  #
-  # Classification uses download metadata or archive listings
-  # (without extracting), so no archives are unpacked here.
-  # Unpacking is deferred to the install phases (2a / 2b).
+  # Classify each package as binary or source so R CMD INSTALL
+  # receives the right flags.  Classification uses download metadata
+  # or archive listings (without extracting), so no archives are
+  # unpacked here.  Unpacking is deferred to the install phase.
 
-  binaries <- list()
-  sources <- list()
+  entries <- list()
 
   for (package in sort(setdiff(remaining, failed$data()))) {
 
@@ -1297,111 +1290,36 @@ renv_graph_install <- function(descriptions) {
       next
     }
 
-    entry <- list(record = record)
     type <- renv_graph_install_classify(record)
-    if (identical(type, "binary"))
-      binaries[[package]] <- entry
-    else
-      sources[[package]] <- entry
+    entries[[package]] <- list(record = record, type = type)
 
   }
 
   showstatus <- !testing() && !verbose && !ci()
 
-  # ── Phase 2a: Install all binaries up front ─────────────────
-  # Binary installs are plain file copies with no build-time deps,
-  # so they don't need wave ordering.
+  # ── Phase 2a: Install all packages in dependency order ──────
+  # All packages (binary and source) are installed via R CMD INSTALL
+  # in worker subprocesses, ordered by the dependency graph so that
+  # load tests succeed.  On R >= 4.0, a ready-queue event loop
+  # (live Kahn's algorithm) launches packages as soon as their
+  # dependencies complete.  On older R, a wave+batch fallback uses
+  # pipe-based collection.
+  # https://github.com/rstudio/renv/issues/2268
 
-  remaining <- names(binaries)
-
-  if (showstatus && length(remaining) > 0L) {
-    progress$reset("Installing", length(remaining))
-    progress$update(remaining)
-  }
-
-  for (package in names(binaries)) {
-
-    entry <- binaries[[package]]
-
-    # unpack (if needed) and prepare (deferred from Phase 2)
-    prepared <- catch(
-      renv_graph_install_unpack_and_prepare(
-        record  = entry$record,
-        type    = "binary",
-        staging = staging,
-        library = installdir
-      )
-    )
-
-    if (inherits(prepared, "error")) {
-      msg <- conditionMessage(prepared)
-      if (showstatus) progress$clear()
-      writef("- Failed to prepare '%s': %s", package, msg)
-      errors$push(list(package = package, message = msg))
-      failed$push(package)
-      if (showstatus) progress$tick()
-      remaining <- setdiff(remaining, package)
-      if (showstatus && length(remaining) > 0L)
-        progress$update(remaining)
-      next
-    }
-
-    entry$prepared <- prepared
-
-    t0 <- Sys.time()
-    result <- catch(renv_graph_install_binary(prepared))
-    t1 <- Sys.time()
-
-    if (showstatus) {
-      progress$clear()
-      progress$tick()
-    }
-
-    if (inherits(result, "error")) {
-      msg <- conditionMessage(result)
-      renv_install_step_error(entry$record)
-      errors$push(list(package = package, message = msg))
-      failed$push(package)
-      remaining <- setdiff(remaining, package)
-      if (showstatus && length(remaining) > 0L)
-        progress$update(remaining)
-      next
-    }
-
-    renv_install_step_ok(
-      message = "installed binary",
-      record  = entry$record,
-      elapsed = difftime(t1, t0, units = "auto")
-    )
-
-    renv_graph_install_finalize(entry$record, prepared, installdir, project, linkable)
-    all[[package]] <- entry$record
-    remaining <- setdiff(remaining, package)
-    if (showstatus && length(remaining) > 0L)
-      progress$update(remaining)
-
-  }
-
-  # ── Phase 2b: Install source packages ─────────────────────
-  # Source packages require build-time dependency ordering.
-  # On R >= 4.0, a ready-queue event loop (live Kahn's algorithm)
-  # launches packages as soon as their dependencies complete,
-  # keeping all worker slots busy.  On older R, a wave+batch
-  # fallback uses pipe-based collection.
-
-  sourcenames <- setdiff(names(sources), failed$data())
-  sourcedescs <- descriptions[intersect(sourcenames, names(descriptions))]
+  allnames <- setdiff(names(entries), failed$data())
+  alldescs <- descriptions[intersect(allnames, names(descriptions))]
 
   # shared closure for processing one completed package;
   # callbacks accumulates per-package backup-restore functions
   callbacks <- list()
 
   handle <- function(pkg, result) {
-    entry <- sources[[pkg]]
+    entry <- entries[[pkg]]
     installpath <- file.path(installdir, pkg)
 
     if (result$success && file.exists(installpath)) {
-      renv_install_step_ok("built from source", entry$record, elapsed = result$elapsed)
+      message <- if (identical(entry$type, "binary")) "installed binary" else "built from source"
+      renv_install_step_ok(message, entry$record, elapsed = result$elapsed)
       renv_graph_install_finalize(entry$record, entry$prepared, installdir, project, linkable)
       all[[pkg]] <<- entry$record
     } else {
@@ -1418,7 +1336,7 @@ renv_graph_install <- function(descriptions) {
   if (getRversion() >= "4.0") {
 
     # ready-queue event loop (live Kahn's algorithm)
-    graph <- renv_graph_adjacency(sourcedescs)
+    graph <- renv_graph_adjacency(alldescs)
     indegree <- graph$indegree
     revadj <- graph$revadj
 
@@ -1429,7 +1347,7 @@ renv_graph_install <- function(descriptions) {
     active <- list()
 
     if (showstatus)
-      progress$reset("Building", length(sourcenames))
+      progress$reset("Installing", length(allnames))
 
     timeout <- getOption("renv.install.timeout", default = 3600L)
     deadline <- Sys.time() + timeout
@@ -1441,10 +1359,9 @@ renv_graph_install <- function(descriptions) {
         pkg <- ready[1L]
         ready <- ready[-1L]
 
-        # unpack (if needed) and prepare (deferred from Phase 2)
-        entry <- sources[[pkg]]
+        entry <- entries[[pkg]]
         prepared <- catch(renv_graph_install_unpack_and_prepare(
-          entry$record, "source", staging, installdir
+          entry$record, entry$type, staging, installdir
         ))
         if (inherits(prepared, "error")) {
           msg <- conditionMessage(prepared)
@@ -1457,7 +1374,7 @@ renv_graph_install <- function(descriptions) {
         }
 
         entry$prepared <- prepared
-        sources[[pkg]] <- entry
+        entries[[pkg]] <- entry
 
         callbacks[[pkg]] <- renv_graph_install_backup(installdir, pkg)
         active[[pkg]] <- renv_graph_install_launch_socket(
@@ -1605,12 +1522,12 @@ renv_graph_install <- function(descriptions) {
   } else {
 
     # R < 4.0 fallback: wave-based, pipe-based collection
-    waves <- renv_graph_waves(sourcedescs)
+    waves <- renv_graph_waves(alldescs)
 
-    remaining <- sourcenames
+    remaining <- allnames
 
     if (showstatus && length(remaining) > 0L) {
-      progress$reset("Building", length(remaining))
+      progress$reset("Installing", length(remaining))
       progress$update(remaining)
     }
 
@@ -1621,21 +1538,20 @@ renv_graph_install <- function(descriptions) {
         next
 
       wave <- sort(wave)
-      sourcepkgs <- wave
+      wavepkgs <- wave
 
-      while (length(sourcepkgs) > 0L) {
+      while (length(wavepkgs) > 0L) {
 
-        batch <- head(sourcepkgs, jobs)
-        sourcepkgs <- tail(sourcepkgs, -length(batch))
+        batch <- head(wavepkgs, jobs)
+        wavepkgs <- tail(wavepkgs, -length(batch))
 
         workers <- list()
 
         for (pkg in batch) {
 
-          # unpack (if needed) and prepare (deferred from Phase 2)
-          entry <- sources[[pkg]]
+          entry <- entries[[pkg]]
           prepared <- catch(renv_graph_install_unpack_and_prepare(
-            entry$record, "source", staging, installdir
+            entry$record, entry$type, staging, installdir
           ))
           if (inherits(prepared, "error")) {
             msg <- conditionMessage(prepared)
@@ -1651,7 +1567,7 @@ renv_graph_install <- function(descriptions) {
           }
 
           entry$prepared <- prepared
-          sources[[pkg]] <- entry
+          entries[[pkg]] <- entry
 
           callbacks[[pkg]] <- renv_graph_install_backup(installdir, pkg)
           workers[[pkg]] <- renv_graph_install_launch(prepared)
@@ -1815,10 +1731,10 @@ renv_graph_install_unpack_and_prepare <- function(record, type, staging, library
   path <- record$Path
   isarchive <- identical(renv_file_info(path)$isdir, FALSE)
 
-  # archives can often be used directly: R CMD INSTALL handles source
-  # archives natively, and binary archives can be extracted straight
-  # into the library.  We only need to unpack up front when the
-  # package is nested (RemoteSubdir) or needs pre-building.
+  # archives can often be used directly: R CMD INSTALL handles both
+  # source and binary .tar.gz archives natively.  We only need to
+  # unpack up front when the package is nested (RemoteSubdir),
+  # the archive format isn't tar, or pre-building is needed.
   if (isarchive && !renv_graph_install_needs_unpack(record, type)) {
     return(renv_graph_install_prepare(record, path, library, type, isarchive = TRUE))
   }
@@ -1849,43 +1765,30 @@ renv_graph_install_prepare <- function(record, path, library, type, isarchive) {
 
   package <- record$Package
 
-  if (identical(type, "binary")) {
+  # R CMD INSTALL handles both source and binary packages
+  # (archives and directories); for source packages we pass
+  # additional flags for pre-cleaning and keeping source refs
+  args <- c(
+    "--vanilla",
+    "CMD", "INSTALL",
+    if (identical(type, "source")) c("--preclean", "--no-multiarch", "--with-keep.source"),
+    if (identical(type, "source")) r_cmd_install_option(package, "configure.args", TRUE),
+    if (identical(type, "source")) r_cmd_install_option(package, "configure.vars", TRUE),
+    r_cmd_install_option(package, c("install.opts", "INSTALL_opts"), FALSE),
+    "-l", renv_shell_path(library),
+    renv_shell_path(path)
+  )
 
-    # binary directory: copy into library
-    # binary archive: extract directly into library
-    list(
-      type    = "binary",
-      method  = if (isarchive) "extract" else "copy",
-      path    = path,
-      library = library,
-      package = package
-    )
+  command <- paste(renv_shell_path(R()), paste(args, collapse = " "))
 
-  } else {
-
-    # R CMD INSTALL handles both archives and directories
-    args <- c(
-      "--vanilla",
-      "CMD", "INSTALL", "--preclean", "--no-multiarch", "--with-keep.source",
-      r_cmd_install_option(package, "configure.args", TRUE),
-      r_cmd_install_option(package, "configure.vars", TRUE),
-      r_cmd_install_option(package, c("install.opts", "INSTALL_opts"), FALSE),
-      "-l", renv_shell_path(library),
-      renv_shell_path(path)
-    )
-
-    command <- paste(renv_shell_path(R()), paste(args, collapse = " "))
-
-    list(
-      type    = "source",
-      method  = "install",
-      command = command,
-      path    = path,
-      library = library,
-      package = package
-    )
-
-  }
+  list(
+    type    = type,
+    method  = "install",
+    command = command,
+    path    = path,
+    library = library,
+    package = package
+  )
 
 }
 
@@ -2029,45 +1932,10 @@ renv_graph_install_backup <- function(installdir, pkg) {
   callback
 }
 
-renv_graph_install_binary <- function(prepared) {
-
-  package <- prepared$package
-  library <- prepared$library
-  installpath <- file.path(library, package)
-
-  # back up existing installation
-  callback <- renv_file_backup(installpath)
-  defer(callback())
-
-  # remove broken symlinks
-  if (renv_file_broken(installpath))
-    renv_file_remove(installpath)
-
-  if (identical(prepared$method, "copy"))
-    renv_file_copy(prepared$path, installpath, overwrite = TRUE)
-  else
-    renv_archive_decompress(prepared$path, exdir = library)
-
-  invisible(installpath)
-
-}
-
 renv_graph_install_finalize <- function(record, prepared, library, project, linkable) {
 
   package <- record$Package
   installpath <- file.path(library, package)
-
-  # test loading; R CMD INSTALL already tests source packages,
-  # so we only need this for binaries (copy / extract)
-  if (identical(prepared$type, "binary")) {
-    tryCatch(
-      renv_install_test(package),
-      error = function(err) {
-        unlink(installpath, recursive = TRUE)
-        stop(err)
-      }
-    )
-  }
 
   # augment package metadata
   renv_package_augment(installpath, record)

--- a/R/graph.R
+++ b/R/graph.R
@@ -1297,7 +1297,7 @@ renv_graph_install <- function(descriptions) {
 
   showstatus <- !testing() && !verbose && !ci()
 
-  # ── Phase 2a: Install all packages in dependency order ──────
+  # ── Phase 3: Install all packages in dependency order ───────
   # All packages (binary and source) are installed via R CMD INSTALL
   # in worker subprocesses, ordered by the dependency graph so that
   # load tests succeed.  On R >= 4.0, a ready-queue event loop

--- a/R/graph.R
+++ b/R/graph.R
@@ -1318,10 +1318,19 @@ renv_graph_install <- function(descriptions) {
     installpath <- file.path(installdir, pkg)
 
     if (result$success && file.exists(installpath)) {
-      message <- if (identical(entry$type, "binary")) "installed binary" else "built from source"
-      renv_install_step_ok(message, entry$record, elapsed = result$elapsed)
-      renv_graph_install_finalize(entry$record, entry$prepared, installdir, project, linkable)
-      all[[pkg]] <<- entry$record
+      finalized <- catch(
+        renv_graph_install_finalize(entry$record, entry$prepared, installdir, project, linkable)
+      )
+      if (inherits(finalized, "error")) {
+        msg <- conditionMessage(finalized)
+        renv_install_step_error(entry$record)
+        errors$push(list(package = pkg, message = msg))
+        failed$push(pkg)
+      } else {
+        message <- if (identical(entry$type, "binary")) "installed binary" else "built from source"
+        renv_install_step_ok(message, entry$record, elapsed = result$elapsed)
+        all[[pkg]] <<- entry$record
+      }
     } else {
       unlink(installpath, recursive = TRUE)
       renv_install_step_error(entry$record)
@@ -1771,11 +1780,13 @@ renv_graph_install_prepare <- function(record, path, library, type, isarchive) {
   # R CMD INSTALL handles both source and binary packages
   # (archives and directories); for source packages we pass
   # additional flags for pre-cleaning and keeping source refs.
-  # We always pass --no-test-load so that the test-load step
-  # is handled uniformly by renv_install_test() after install.
+  # R CMD INSTALL performs its own test-load for source packages;
+  # for binaries we pass --no-test-load and run renv_install_test()
+  # ourselves in renv_graph_install_finalize().
   args <- c(
     "--vanilla",
-    "CMD", "INSTALL", "--no-test-load",
+    "CMD", "INSTALL",
+    if (identical(type, "binary")) "--no-test-load",
     if (identical(type, "source")) c("--preclean", "--no-multiarch", "--with-keep.source"),
     if (identical(type, "source")) r_cmd_install_option(package, "configure.args", TRUE),
     if (identical(type, "source")) r_cmd_install_option(package, "configure.vars", TRUE),
@@ -1942,15 +1953,18 @@ renv_graph_install_finalize <- function(record, prepared, library, project, link
   package <- record$Package
   installpath <- file.path(library, package)
 
-  # test-load the package; R CMD INSTALL is invoked with
-  # --no-test-load so all packages go through the same path here
-  tryCatch(
-    renv_install_test(package),
-    error = function(err) {
-      unlink(installpath, recursive = TRUE)
-      stop(err)
-    }
-  )
+  # test-load binary packages; R CMD INSTALL already tests source
+  # packages, so we only need this for binaries (installed with
+  # --no-test-load since R CMD INSTALL doesn't test-load them)
+  if (identical(prepared$type, "binary")) {
+    tryCatch(
+      renv_install_test(package),
+      error = function(err) {
+        unlink(installpath, recursive = TRUE)
+        stop(err)
+      }
+    )
+  }
 
   # augment package metadata
   renv_package_augment(installpath, record)

--- a/R/graph.R
+++ b/R/graph.R
@@ -1400,12 +1400,12 @@ renv_graph_install <- function(descriptions) {
           elapsed <- difftime(
             Sys.time(), active[[pkg]]$start, units = "auto"
           )
+          renv_graph_install_worker_cleanup(active[[pkg]])
           handle(pkg, list(
             success = FALSE,
             output  = "worker process timed out",
             elapsed = elapsed
           ))
-          renv_graph_install_worker_cleanup(active[[pkg]])
         }
         active <- list()
         break
@@ -1430,13 +1430,13 @@ renv_graph_install <- function(descriptions) {
               progress$clear()
               progress$tick()
             }
+            renv_graph_install_worker_cleanup(active[[pkg]])
+            active[[pkg]] <- NULL
             handle(pkg, list(
               success = FALSE,
               output  = "worker failed to start",
               elapsed = as.difftime(elapsed, units = "secs")
             ))
-            renv_graph_install_worker_cleanup(active[[pkg]])
-            active[[pkg]] <- NULL
             if (showstatus && length(active) > 0L)
               progress$update(names(active))
           }
@@ -1493,9 +1493,12 @@ renv_graph_install <- function(descriptions) {
 
         result <- renv_graph_install_parse_result(data, elapsed)
 
-        handle(pkg, result)
+        # clean up worker connection before handle(), which can
+        # throw (e.g. if the post-install load test fails)
         renv_graph_install_worker_cleanup(active[[pkg]])
         active[[pkg]] <- NULL
+
+        handle(pkg, result)
 
         # decrement dependents' indegree and enqueue newly ready
         if (result$success) {

--- a/R/graph.R
+++ b/R/graph.R
@@ -1339,7 +1339,7 @@ renv_graph_install <- function(descriptions) {
       failed$push(pkg)
     }
 
-    callbacks[[pkg]]()
+    tryCatch(callbacks[[pkg]](), error = warnify)
   }
 
   if (getRversion() >= "4.0") {

--- a/R/graph.R
+++ b/R/graph.R
@@ -1767,10 +1767,12 @@ renv_graph_install_prepare <- function(record, path, library, type, isarchive) {
 
   # R CMD INSTALL handles both source and binary packages
   # (archives and directories); for source packages we pass
-  # additional flags for pre-cleaning and keeping source refs
+  # additional flags for pre-cleaning and keeping source refs.
+  # We always pass --no-test-load so that the test-load step
+  # is handled uniformly by renv_install_test() after install.
   args <- c(
     "--vanilla",
-    "CMD", "INSTALL",
+    "CMD", "INSTALL", "--no-test-load",
     if (identical(type, "source")) c("--preclean", "--no-multiarch", "--with-keep.source"),
     if (identical(type, "source")) r_cmd_install_option(package, "configure.args", TRUE),
     if (identical(type, "source")) r_cmd_install_option(package, "configure.vars", TRUE),
@@ -1936,6 +1938,16 @@ renv_graph_install_finalize <- function(record, prepared, library, project, link
 
   package <- record$Package
   installpath <- file.path(library, package)
+
+  # test-load the package; R CMD INSTALL is invoked with
+  # --no-test-load so all packages go through the same path here
+  tryCatch(
+    renv_install_test(package),
+    error = function(err) {
+      unlink(installpath, recursive = TRUE)
+      stop(err)
+    }
+  )
 
   # augment package metadata
   renv_package_augment(installpath, record)

--- a/tests/testthat/_snaps/sysreqs.md
+++ b/tests/testthat/_snaps/sysreqs.md
@@ -8,7 +8,7 @@
       The R packages depending on these system packages may fail to install.
       
       An administrator can install these packages with:
-      - sudo apt install blender
+      - sudo <installer> install blender
       
 
 # system requirements for alternate distributions are reported

--- a/tests/testthat/_snaps/sysreqs.md
+++ b/tests/testthat/_snaps/sysreqs.md
@@ -8,7 +8,7 @@
       The R packages depending on these system packages may fail to install.
       
       An administrator can install these packages with:
-      - sudo <installer> install blender
+      - sudo <install> blender
       
 
 # system requirements for alternate distributions are reported

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -190,12 +190,10 @@ test_that("ACLs set on packages in project library are reset", {
   # but before cache sync runs (which may reset them); we trace
   # renv_graph_install_finalize with an entry tracer so that ACLs are
   # modified before renv_cache_synchronize is called inside it
-  trace("renv_graph_install_finalize", tracer = quote({
+  renv_scope_trace(renv:::renv_graph_install_finalize, tracer = quote({
     installpath <- file.path(library, record$Package)
     system(paste("setfacl -m g::-", renv_shell_path(installpath)))
-  }), where = renv_envir_self(), print = FALSE)
-
-  defer(untrace("renv_graph_install_finalize", where = renv_envir_self()))
+  }))
 
   # use a custom cache
   cachedir <- renv_scope_tempfile("renv-cache-")

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -703,10 +703,11 @@ test_that("renv_graph_install_prepare omits source flags for binary packages", {
 
 })
 
-test_that("renv_graph_install_prepare always uses R CMD INSTALL with --no-test-load", {
+test_that("renv_graph_install_prepare uses --no-test-load only for binaries", {
 
-  # both source and binary packages should go through R CMD INSTALL
-  # with --no-test-load, since renv handles test-loading separately
+  # binary packages get --no-test-load because R CMD INSTALL doesn't
+  # test-load them; renv handles that in renv_graph_install_finalize.
+  # source packages rely on R CMD INSTALL's built-in test-load.
   for (type in c("source", "binary")) {
     prepared <- renv_graph_install_prepare(
       record    = list(Package = "mypkg"),
@@ -717,8 +718,12 @@ test_that("renv_graph_install_prepare always uses R CMD INSTALL with --no-test-l
     )
     expect_equal(prepared$method, "install", info = type)
     expect_true(grepl("CMD INSTALL", prepared$command), info = type)
-    expect_true(grepl("--no-test-load", prepared$command), info = type)
     expect_true(grepl("-l", prepared$command), info = type)
+    if (type == "binary") {
+      expect_true(grepl("--no-test-load", prepared$command))
+    } else {
+      expect_false(grepl("--no-test-load", prepared$command))
+    }
   }
 
 })

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -703,9 +703,10 @@ test_that("renv_graph_install_prepare omits source flags for binary packages", {
 
 })
 
-test_that("renv_graph_install_prepare always uses R CMD INSTALL", {
+test_that("renv_graph_install_prepare always uses R CMD INSTALL with --no-test-load", {
 
   # both source and binary packages should go through R CMD INSTALL
+  # with --no-test-load, since renv handles test-loading separately
   for (type in c("source", "binary")) {
     prepared <- renv_graph_install_prepare(
       record    = list(Package = "mypkg"),
@@ -716,6 +717,7 @@ test_that("renv_graph_install_prepare always uses R CMD INSTALL", {
     )
     expect_equal(prepared$method, "install", info = type)
     expect_true(grepl("CMD INSTALL", prepared$command), info = type)
+    expect_true(grepl("--no-test-load", prepared$command), info = type)
     expect_true(grepl("-l", prepared$command), info = type)
   }
 

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -643,6 +643,84 @@ test_that("renv_graph_install_needs_unpack returns FALSE for simple tar.gz sourc
 
 })
 
+test_that("renv_graph_install_needs_unpack returns TRUE for .zip archives", {
+
+  archive <- renv_scope_tempfile("renv-test-", fileext = ".zip")
+  file.create(archive)
+
+  record <- list(Package = "mypkg", Path = archive)
+  expect_true(renv_graph_install_needs_unpack(record, "binary"))
+
+})
+
+test_that("renv_graph_install_needs_unpack returns FALSE for binary tar.gz", {
+
+  archive <- renv_scope_tempfile("renv-test-", fileext = ".tar.gz")
+  file.create(archive)
+
+  record <- list(Package = "mypkg", Path = archive)
+  # install.build should not force unpack for binary packages
+  renv_scope_options(renv.config.install.build = TRUE)
+  expect_false(renv_graph_install_needs_unpack(record, "binary"))
+
+})
+
+# install prepare ----
+
+test_that("renv_graph_install_prepare includes source flags for source packages", {
+
+  prepared <- renv_graph_install_prepare(
+    record    = list(Package = "mypkg"),
+    path      = "/tmp/mypkg_1.0.0.tar.gz",
+    library   = "/tmp/lib",
+    type      = "source",
+    isarchive = TRUE
+  )
+
+  expect_equal(prepared$type, "source")
+  expect_equal(prepared$method, "install")
+  expect_true(grepl("--preclean", prepared$command))
+  expect_true(grepl("--no-multiarch", prepared$command))
+  expect_true(grepl("--with-keep.source", prepared$command))
+
+})
+
+test_that("renv_graph_install_prepare omits source flags for binary packages", {
+
+  prepared <- renv_graph_install_prepare(
+    record    = list(Package = "mypkg"),
+    path      = "/tmp/mypkg_1.0.0.tgz",
+    library   = "/tmp/lib",
+    type      = "binary",
+    isarchive = TRUE
+  )
+
+  expect_equal(prepared$type, "binary")
+  expect_equal(prepared$method, "install")
+  expect_false(grepl("--preclean", prepared$command))
+  expect_false(grepl("--no-multiarch", prepared$command))
+  expect_false(grepl("--with-keep.source", prepared$command))
+
+})
+
+test_that("renv_graph_install_prepare always uses R CMD INSTALL", {
+
+  # both source and binary packages should go through R CMD INSTALL
+  for (type in c("source", "binary")) {
+    prepared <- renv_graph_install_prepare(
+      record    = list(Package = "mypkg"),
+      path      = "/tmp/mypkg_1.0.0.tar.gz",
+      library   = "/tmp/lib",
+      type      = type,
+      isarchive = TRUE
+    )
+    expect_equal(prepared$method, "install", info = type)
+    expect_true(grepl("CMD INSTALL", prepared$command), info = type)
+    expect_true(grepl("-l", prepared$command), info = type)
+  }
+
+})
+
 # install error reporting ----
 
 test_that("renv_graph_install_errors reports direct failures", {

--- a/tests/testthat/test-sysreqs.R
+++ b/tests/testthat/test-sysreqs.R
@@ -50,11 +50,19 @@ test_that("system requirements are reported as expected", {
   skip_if(!renv_platform_linux())
 
   # check a package that is unlikely to be installed
-  status <- system("dpkg-query -W blender 2> /dev/null")
+  status <- suppressWarnings(
+    system("dpkg-query -W blender 2> /dev/null")
+  )
+
   skip_if(status == 0L)
 
   sysreqs <- list("<unknown>" = "blender")
-  expect_snapshot(. <- renv_sysreqs_check(sysreqs, FALSE))
+  expect_snapshot(
+    . <- renv_sysreqs_check(sysreqs, FALSE),
+    transform = function(x) {
+      sub("sudo \\S+ install", "sudo <installer> install", x)
+    }
+  )
 
 })
 

--- a/tests/testthat/test-sysreqs.R
+++ b/tests/testthat/test-sysreqs.R
@@ -60,7 +60,7 @@ test_that("system requirements are reported as expected", {
   expect_snapshot(
     . <- renv_sysreqs_check(sysreqs, FALSE),
     transform = function(x) {
-      sub("sudo \\S+ install", "sudo <installer> install", x)
+      sub("sudo \\S+ \\S+", "sudo <install>", x)
     }
   )
 


### PR DESCRIPTION
## Summary
- Consolidate the separate binary (copy/extract) and source (R CMD INSTALL) install paths into a single R CMD INSTALL path for both package types, with source-specific flags applied conditionally
- Remove `renv_graph_install_binary` and the binary-specific load test in `renv_graph_install_finalize`
- Add `renv_graph_install_needs_unpack` check for non-tar archive formats (e.g. `.zip`)
- Add unit tests covering the unified prepare function and needs-unpack edge cases

## Test plan
- [x] `devtools::test(filter = "graph")` passes (195 tests, 0 failures)
- [ ] Verify binary package installs work end-to-end on macOS (binary .tgz from CRAN)
- [ ] Verify source package installs still apply `--preclean`, configure args, etc.