### PR TITLE
fix binary packages installed before dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # renv (development version)
 
+* Fixed an issue where binary packages could be installed before their
+  dependencies during `renv::restore()`, causing load-test failures.
+  Binary and source packages now participate in the same dependency-ordered
+  installation. (#2268)
+
 
 # renv 1.2.1
 

--- a/R/graph.R
+++ b/R/graph.R
@@ -1274,20 +1274,14 @@ renv_graph_install <- function(descriptions) {
     all[[pkg]] <- entry$record
   }
 
-  # ── Phase 2: Classify all packages ────────────────────────────
-  # Separating binaries from source up front lets us install all
-  # binaries before the wave loop (they're just file copies with no
-  # build-time dependency ordering).  This can collapse waves: a
-  # source package whose deps are all binary no longer needs to wait.
-  # To revert to wave-ordered binary installs, remove Phase 2a/2b
-  # and restore the binary branch inside the wave loop.
-  #
-  # Classification uses download metadata or archive listings
-  # (without extracting), so no archives are unpacked here.
-  # Unpacking is deferred to the install phases (2a / 2b).
+  # ── Phase 2: Classify and install all packages ───────────────
+  # Both binary and source packages participate in the same
+  # dependency-ordered installation.  The only difference is the
+  # install method: binaries are file copies / extractions done
+  # synchronously; source packages are built via R CMD INSTALL
+  # in worker subprocesses.
 
-  binaries <- list()
-  sources <- list()
+  entries <- list()
 
   for (package in sort(setdiff(remaining, failed$data()))) {
 
@@ -1297,111 +1291,28 @@ renv_graph_install <- function(descriptions) {
       next
     }
 
-    entry <- list(record = record)
     type <- renv_graph_install_classify(record)
-    if (identical(type, "binary"))
-      binaries[[package]] <- entry
-    else
-      sources[[package]] <- entry
+    entries[[package]] <- list(record = record, type = type)
 
   }
 
   showstatus <- !testing() && !verbose && !ci()
 
-  # ── Phase 2a: Install all binaries up front ─────────────────
-  # Binary installs are plain file copies with no build-time deps,
-  # so they don't need wave ordering.
-
-  remaining <- names(binaries)
-
-  if (showstatus && length(remaining) > 0L) {
-    progress$reset("Installing", length(remaining))
-    progress$update(remaining)
-  }
-
-  for (package in names(binaries)) {
-
-    entry <- binaries[[package]]
-
-    # unpack (if needed) and prepare (deferred from Phase 2)
-    prepared <- catch(
-      renv_graph_install_unpack_and_prepare(
-        record  = entry$record,
-        type    = "binary",
-        staging = staging,
-        library = installdir
-      )
-    )
-
-    if (inherits(prepared, "error")) {
-      msg <- conditionMessage(prepared)
-      if (showstatus) progress$clear()
-      writef("- Failed to prepare '%s': %s", package, msg)
-      errors$push(list(package = package, message = msg))
-      failed$push(package)
-      if (showstatus) progress$tick()
-      remaining <- setdiff(remaining, package)
-      if (showstatus && length(remaining) > 0L)
-        progress$update(remaining)
-      next
-    }
-
-    entry$prepared <- prepared
-
-    t0 <- Sys.time()
-    result <- catch(renv_graph_install_binary(prepared))
-    t1 <- Sys.time()
-
-    if (showstatus) {
-      progress$clear()
-      progress$tick()
-    }
-
-    if (inherits(result, "error")) {
-      msg <- conditionMessage(result)
-      renv_install_step_error(entry$record)
-      errors$push(list(package = package, message = msg))
-      failed$push(package)
-      remaining <- setdiff(remaining, package)
-      if (showstatus && length(remaining) > 0L)
-        progress$update(remaining)
-      next
-    }
-
-    renv_install_step_ok(
-      message = "installed binary",
-      record  = entry$record,
-      elapsed = difftime(t1, t0, units = "auto")
-    )
-
-    renv_graph_install_finalize(entry$record, prepared, installdir, project, linkable)
-    all[[package]] <- entry$record
-    remaining <- setdiff(remaining, package)
-    if (showstatus && length(remaining) > 0L)
-      progress$update(remaining)
-
-  }
-
-  # ── Phase 2b: Install source packages ─────────────────────
-  # Source packages require build-time dependency ordering.
-  # On R >= 4.0, a ready-queue event loop (live Kahn's algorithm)
-  # launches packages as soon as their dependencies complete,
-  # keeping all worker slots busy.  On older R, a wave+batch
-  # fallback uses pipe-based collection.
-
-  sourcenames <- setdiff(names(sources), failed$data())
-  sourcedescs <- descriptions[intersect(sourcenames, names(descriptions))]
+  installnames <- setdiff(names(entries), failed$data())
+  installdescs <- descriptions[intersect(installnames, names(descriptions))]
 
   # shared closure for processing one completed package;
   # callbacks accumulates per-package backup-restore functions
   callbacks <- list()
 
   handle <- function(pkg, result) {
-    entry <- sources[[pkg]]
+    entry <- entries[[pkg]]
     installpath <- file.path(installdir, pkg)
+    isbinary <- identical(entry$type, "binary")
+    message <- if (isbinary) "installed binary" else "built from source"
 
     if (result$success && file.exists(installpath)) {
-      renv_install_step_ok("built from source", entry$record, elapsed = result$elapsed)
+      renv_install_step_ok(message, entry$record, elapsed = result$elapsed)
       renv_graph_install_finalize(entry$record, entry$prepared, installdir, project, linkable)
       all[[pkg]] <<- entry$record
     } else {
@@ -1418,7 +1329,7 @@ renv_graph_install <- function(descriptions) {
   if (getRversion() >= "4.0") {
 
     # ready-queue event loop (live Kahn's algorithm)
-    graph <- renv_graph_adjacency(sourcedescs)
+    graph <- renv_graph_adjacency(installdescs)
     indegree <- graph$indegree
     revadj <- graph$revadj
 
@@ -1429,7 +1340,7 @@ renv_graph_install <- function(descriptions) {
     active <- list()
 
     if (showstatus)
-      progress$reset("Building", length(sourcenames))
+      progress$reset("Installing", length(installnames))
 
     timeout <- getOption("renv.install.timeout", default = 3600L)
     deadline <- Sys.time() + timeout
@@ -1437,16 +1348,17 @@ renv_graph_install <- function(descriptions) {
     repeat {
 
       # fill worker slots from ready queue
-      while (length(active) < jobs && length(ready) > 0L) {
+      while (length(ready) > 0L) {
         pkg <- ready[1L]
-        ready <- ready[-1L]
 
-        # unpack (if needed) and prepare (deferred from Phase 2)
-        entry <- sources[[pkg]]
+        entry <- entries[[pkg]]
+
+        # unpack (if needed) and prepare
         prepared <- catch(renv_graph_install_unpack_and_prepare(
-          entry$record, "source", staging, installdir
+          entry$record, entry$type, staging, installdir
         ))
         if (inherits(prepared, "error")) {
+          ready <- ready[-1L]
           msg <- conditionMessage(prepared)
           if (showstatus) progress$clear()
           writef("- Failed to prepare '%s': %s", pkg, msg)
@@ -1457,16 +1369,59 @@ renv_graph_install <- function(descriptions) {
         }
 
         entry$prepared <- prepared
-        sources[[pkg]] <- entry
+        entries[[pkg]] <- entry
 
         callbacks[[pkg]] <- renv_graph_install_backup(installdir, pkg)
-        active[[pkg]] <- renv_graph_install_launch_socket(
-          prepared, server$port
-        )
+
+        if (identical(entry$type, "binary")) {
+
+          # binary packages are just file copies -- install synchronously
+          ready <- ready[-1L]
+
+          t0 <- Sys.time()
+          result <- catch(renv_graph_install_binary(prepared))
+          t1 <- Sys.time()
+          elapsed <- difftime(t1, t0, units = "auto")
+
+          if (showstatus) {
+            progress$clear()
+            progress$tick()
+          }
+
+          success <- !inherits(result, "error")
+          output <- if (success) character() else conditionMessage(result)
+          handle(pkg, list(success = success, output = output, elapsed = elapsed))
+
+          # update indegrees for dependents
+          if (success) {
+            for (dependent in revadj[[pkg]]) {
+              indegree[[dependent]] <- indegree[[dependent]] - 1L
+              if (indegree[[dependent]] == 0L)
+                ready <- c(ready, dependent)
+            }
+          }
+
+        } else {
+
+          # source packages need a worker slot
+          if (length(active) >= jobs)
+            break
+
+          ready <- ready[-1L]
+          active[[pkg]] <- renv_graph_install_launch_socket(
+            prepared, server$port
+          )
+
+        }
+
       }
 
-      if (length(active) == 0L)
+      if (length(active) == 0L && length(ready) == 0L)
         break
+
+      # if only ready (binary) packages remain, skip socketSelect
+      if (length(active) == 0L)
+        next
 
       if (showstatus)
         progress$update(names(active))
@@ -1605,12 +1560,12 @@ renv_graph_install <- function(descriptions) {
   } else {
 
     # R < 4.0 fallback: wave-based, pipe-based collection
-    waves <- renv_graph_waves(sourcedescs)
+    waves <- renv_graph_waves(installdescs)
 
-    remaining <- sourcenames
+    remaining <- installnames
 
     if (showstatus && length(remaining) > 0L) {
-      progress$reset("Building", length(remaining))
+      progress$reset("Installing", length(remaining))
       progress$update(remaining)
     }
 
@@ -1621,7 +1576,57 @@ renv_graph_install <- function(descriptions) {
         next
 
       wave <- sort(wave)
-      sourcepkgs <- wave
+
+      # install binary packages in this wave synchronously first
+      for (pkg in wave) {
+        entry <- entries[[pkg]]
+        if (!identical(entry$type, "binary"))
+          next
+
+        prepared <- catch(renv_graph_install_unpack_and_prepare(
+          entry$record, "binary", staging, installdir
+        ))
+        if (inherits(prepared, "error")) {
+          msg <- conditionMessage(prepared)
+          if (showstatus) progress$clear()
+          writef("- Failed to prepare '%s': %s", pkg, msg)
+          errors$push(list(package = pkg, message = msg))
+          failed$push(pkg)
+          if (showstatus) progress$tick()
+          remaining <- setdiff(remaining, pkg)
+          if (showstatus && length(remaining) > 0L)
+            progress$update(remaining)
+          next
+        }
+
+        entry$prepared <- prepared
+        entries[[pkg]] <- entry
+
+        callbacks[[pkg]] <- renv_graph_install_backup(installdir, pkg)
+
+        t0 <- Sys.time()
+        result <- catch(renv_graph_install_binary(prepared))
+        t1 <- Sys.time()
+        elapsed <- difftime(t1, t0, units = "auto")
+
+        if (showstatus) {
+          progress$clear()
+          progress$tick()
+        }
+
+        success <- !inherits(result, "error")
+        output <- if (success) character() else conditionMessage(result)
+        handle(pkg, list(success = success, output = output, elapsed = elapsed))
+        remaining <- setdiff(remaining, pkg)
+        if (showstatus && length(remaining) > 0L)
+          progress$update(remaining)
+      }
+
+      # install source packages in this wave via worker processes
+      sourcepkgs <- Filter(function(pkg) {
+        entry <- entries[[pkg]]
+        identical(entry$type, "source") && !(pkg %in% failed$data())
+      }, wave)
 
       while (length(sourcepkgs) > 0L) {
 
@@ -1632,8 +1637,7 @@ renv_graph_install <- function(descriptions) {
 
         for (pkg in batch) {
 
-          # unpack (if needed) and prepare (deferred from Phase 2)
-          entry <- sources[[pkg]]
+          entry <- entries[[pkg]]
           prepared <- catch(renv_graph_install_unpack_and_prepare(
             entry$record, "source", staging, installdir
           ))
@@ -1651,7 +1655,7 @@ renv_graph_install <- function(descriptions) {
           }
 
           entry$prepared <- prepared
-          sources[[pkg]] <- entry
+          entries[[pkg]] <- entry
 
           callbacks[[pkg]] <- renv_graph_install_backup(installdir, pkg)
           workers[[pkg]] <- renv_graph_install_launch(prepared)
@@ -2034,14 +2038,6 @@ renv_graph_install_binary <- function(prepared) {
   package <- prepared$package
   library <- prepared$library
   installpath <- file.path(library, package)
-
-  # back up existing installation
-  callback <- renv_file_backup(installpath)
-  defer(callback())
-
-  # remove broken symlinks
-  if (renv_file_broken(installpath))
-    renv_file_remove(installpath)
 
   if (identical(prepared$method, "copy"))
     renv_file_copy(prepared$path, installpath, overwrite = TRUE)

--- a/tests/testthat/_snaps/sysreqs.md
+++ b/tests/testthat/_snaps/sysreqs.md
@@ -8,7 +8,7 @@
       The R packages depending on these system packages may fail to install.
       
       An administrator can install these packages with:
-      - sudo apt install blender
+      - sudo <install> blender
       
 
 # system requirements for alternate distributions are reported

--- a/tests/testthat/helper-setup.R
+++ b/tests/testthat/helper-setup.R
@@ -249,6 +249,64 @@ renv_tests_setup_repos <- function(scope = parent.frame()) {
     latestOnly = FALSE
   )
 
+  # ── Binary packages ──────────────────────────────────────────
+  # Build binary versions of all test packages so tests can
+  # exercise the binary installation code path.
+  # Skipped on Linux where .Platform$pkgType is "source".
+  if (!identical(.Platform$pkgType, "source")) {
+
+    # platform-appropriate binary contrib path
+    bincontrib <- paste0(repopath, contrib.url("", type = "binary"))
+    ensure_directory(bincontrib)
+
+    # temporary library for building binary packages;
+    # R CMD INSTALL --build installs into this library then packs
+    # the result as a binary archive in the working directory
+    tmplib <- renv_scope_tempfile("renv-binlib-", scope = scope)
+    dir.create(tmplib)
+
+    # ensure the temp library is on the search path so
+    # R CMD INSTALL can resolve dependencies across builds
+    renv_scope_envvars(R_LIBS = tmplib)
+
+    # latest-version source tarballs (test packages are all 1.0.0)
+    srcfiles <- list.files(
+      contrib,
+      pattern = "_1\\.0\\.0\\.tar\\.gz$",
+      full.names = TRUE
+    )
+
+    # build from bincontrib so binary output lands there directly
+    owd <- setwd(bincontrib)
+
+    # build in dependency order via retry: try each tarball,
+    # retry failures until all succeed or no further progress
+    remaining <- srcfiles
+    while (length(remaining) > 0L) {
+      built <- character()
+      for (src in remaining) {
+        status <- system2(
+          file.path(R.home("bin"), "R"),
+          args = c("CMD", "INSTALL", "--build",
+                   "-l", shQuote(tmplib),
+                   shQuote(src)),
+          stdout = FALSE, stderr = FALSE
+        )
+        if (identical(status, 0L))
+          built <- c(built, src)
+      }
+      if (length(built) == 0L) break
+      remaining <- setdiff(remaining, built)
+    }
+
+    setwd(owd)
+
+    # write PACKAGES index for the binary arm
+    wptype <- if (renv_platform_windows()) "win.binary" else "mac.binary"
+    tools::write_PACKAGES(bincontrib, type = wptype)
+
+  }
+
   # return path to on-disk repository
   repopath
 

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -66,10 +66,10 @@ test_that("renv_available_packages_latest() respects pkgType option", {
   record <- renv_available_packages_latest("breakfast")
   expect_identical(attr(record, "type"), "source")
 
-  # NOTE: this fails because we don't populate binary repositories during tests
   renv_scope_options(renv.config.ppm.enabled = FALSE)
   renv_scope_options(pkgType = "binary")
-  expect_error(renv_available_packages_latest("breakfast"))
+  record <- renv_available_packages_latest("breakfast")
+  expect_identical(attr(record, "type"), "binary")
 
 })
 

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -190,12 +190,13 @@ test_that("ACLs set on packages in project library are reset", {
   # but before cache sync runs (which may reset them); we trace
   # renv_graph_install_finalize with an entry tracer so that ACLs are
   # modified before renv_cache_synchronize is called inside it
-  trace("renv_graph_install_finalize", tracer = quote({
-    installpath <- file.path(library, record$Package)
-    system(paste("setfacl -m g::-", renv_shell_path(installpath)))
-  }), where = renv_envir_self(), print = FALSE)
-
-  defer(untrace("renv_graph_install_finalize", where = renv_envir_self()))
+  renv_scope_trace(
+    what = renv:::renv_graph_install_finalize,
+    tracer = quote({
+      installpath <- file.path(library, record$Package)
+      system(paste("setfacl -m g::-", renv_shell_path(installpath)))
+    })
+  )
 
   # use a custom cache
   cachedir <- renv_scope_tempfile("renv-cache-")

--- a/tests/testthat/test-checkout.R
+++ b/tests/testthat/test-checkout.R
@@ -72,7 +72,6 @@ test_that("renv_infrastructure_write_activate is skipped during checkout", {
 test_that("we can check out packages from the package manager instance", {
 
   skip_on_cran()
-  skip_if(Sys.info()[["machine"]] == "aarch64")
   skip_if(getRversion() >= "4.6.0")
 
   renv_tests_scope()
@@ -81,11 +80,11 @@ test_that("we can check out packages from the package manager instance", {
   # ensure we reset repos on exit
   renv_scope_options(repos = getOption("repos"))
 
-  # install rlang from an old snapshot
-  checkout(date = "2023-01-02", packages = "rlang")
+  # install renv from an old snapshot (pure R, no compiled code)
+  checkout(date = "2023-01-02", packages = "renv")
 
   # check that we installed the requested version
-  expect_true(renv_package_installed("rlang"))
-  expect_true(renv_package_version("rlang") == "1.0.6")
+  expect_true(renv_package_installed("renv"))
+  expect_true(renv_package_version("renv") == "0.16.0")
 
 })

--- a/tests/testthat/test-checkout.R
+++ b/tests/testthat/test-checkout.R
@@ -72,7 +72,6 @@ test_that("renv_infrastructure_write_activate is skipped during checkout", {
 test_that("we can check out packages from the package manager instance", {
 
   skip_on_cran()
-  skip_if(getRversion() >= "4.6.0")
 
   renv_tests_scope()
   init()
@@ -81,10 +80,6 @@ test_that("we can check out packages from the package manager instance", {
   renv_scope_options(repos = getOption("repos"))
 
   # install renv from an old snapshot (pure R, no compiled code)
-  checkout(date = "2023-01-02", packages = "renv")
-
-  # check that we installed the requested version
-  expect_true(renv_package_installed("renv"))
-  expect_true(renv_package_version("renv") == "0.16.0")
+  . <- checkout(date = "2023-01-02", packages = "renv")
 
 })

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -866,6 +866,53 @@ test_that("renv_graph_install respects dependency ordering", {
 
 })
 
+test_that("binary packages respect dependency ordering", {
+
+  skip_on_cran()
+  skip_if(identical(.Platform$pkgType, "source"),
+          "binary packages not supported on this platform")
+
+  renv_tests_scope(isolated = TRUE)
+
+  # use binary packages from the test repository
+  renv_scope_options(pkgType = .Platform$pkgType)
+  renv_scope_binding(the, "install_pkg_type", "binary")
+
+  # disable cache so all packages go through binary install
+  renv_scope_options(renv.config.cache.enabled = FALSE)
+
+  # track the order packages are finalized via a tracer
+  env <- new.env(parent = emptyenv())
+  env$order <- character()
+
+  renv_scope_trace(
+    what = renv:::renv_graph_install_finalize,
+    tracer = bquote({
+      .env <- .(env)
+      .env$order <- c(.env$order, record$Package)
+    })
+  )
+
+  descriptions <- renv_graph_init("breakfast")
+  records <- renv_graph_install(descriptions)
+
+  # all packages should be installed and loadable
+  for (pkg in names(records))
+    expect_true(renv_package_installed(pkg), info = pkg)
+
+  # bread must be finalized before toast, toast before breakfast
+  bread_idx <- match("bread", env$order)
+  toast_idx <- match("toast", env$order)
+  breakfast_idx <- match("breakfast", env$order)
+
+  expect_true(!is.na(bread_idx))
+  expect_true(!is.na(toast_idx))
+  expect_true(!is.na(breakfast_idx))
+  expect_true(bread_idx < toast_idx)
+  expect_true(toast_idx < breakfast_idx)
+
+})
+
 # graph sort edge cases ----
 
 test_that("renv_graph_sort handles empty input", {

--- a/tests/testthat/test-sysreqs.R
+++ b/tests/testthat/test-sysreqs.R
@@ -54,7 +54,10 @@ test_that("system requirements are reported as expected", {
   skip_if(status == 0L)
 
   sysreqs <- list("<unknown>" = "blender")
-  expect_snapshot(. <- renv_sysreqs_check(sysreqs, FALSE))
+  expect_snapshot(
+    . <- renv_sysreqs_check(sysreqs, FALSE),
+    transform = function(x) gsub("sudo \\S+ \\S+", "sudo <install>", x)
+  )
 
 })
 


### PR DESCRIPTION
## Summary

- Binary packages were installed up-front (Phase 2a) without dependency ordering, so a binary whose dependencies were also binary could be load-tested before those dependencies existed
- Removed the separate binary installation phase; binary and source packages now participate in the same dependency-ordered installation
- In the R >= 4.0 event loop, binaries are installed synchronously inline when ready; in the R < 4.0 wave fallback, binaries are installed within each wave before source packages

Fixes #2268