### PR TITLE
fix pkgType = "both" on linux extracting source tarballs as binary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 
 # renv (development version)
 
+* Fixed an issue where setting `options(pkgType = "both")` on Linux could
+  cause `renv::restore()` to extract a source tarball into the library as
+  if it were a pre-built binary, skipping `R CMD INSTALL` and producing
+  "has no 'package.rds' in Meta/" load-test failures. (#2275)
+
 # renv 1.2.2
 
 * Fixed an issue where `renv::install()` failed with named remotes in

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -716,6 +716,14 @@ renv_available_packages_latest_repos <- function(package,
   type <- type %||% getOption("pkgType")
   repos <- repos %||% getOption("repos")
 
+  # on platforms where only source packages are supported, `type = "both"` has
+  # no meaningful distinction from source: base R rejects it outright, and
+  # `contrib.url(repos, "binary")` simply collapses to the source URL. treating
+  # it as "both" here would tag a source tarball as binary and cause the
+  # installer to skip `R CMD INSTALL` (#2275).
+  if (identical(.Platform$pkgType, "source") && identical(type, "both"))
+    type <- "source"
+
   # detect requests for only source packages
   if (identical(type, "source"))
     return(renv_available_packages_latest_repos_impl(package, "source", repos))

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -73,6 +73,19 @@ test_that("renv_available_packages_latest() respects pkgType option", {
 
 })
 
+test_that("pkgType = 'both' on source-only platforms yields a source record (#2275)", {
+
+  skip_on_cran()
+  skip_if_not(.Platform$pkgType == "source")
+
+  renv_tests_scope()
+
+  renv_scope_options(pkgType = "both")
+  record <- renv_available_packages_latest("breakfast")
+  expect_identical(attr(record, "type"), "source")
+
+})
+
 test_that("local sources are preferred when available", {
 
   skip_on_cran()


### PR DESCRIPTION
## Summary

- On Linux, `options(pkgType = "both")` caused `renv_available_packages_latest_repos` to run both source and binary queries. Because `contrib.url(repos, "binary")` collapses to the source URL on Linux (`.Platform\$pkgType == "source"`), both queries returned the same data, and `renv_available_packages_latest_select` tagged the record as `type = "binary"`.
- The install pipeline trusts `attr(record, "type")` in `renv_graph_install_classify`, so the installer took the binary branch (`method = "extract"`) and untarred the source `.tar.gz` straight into the library — skipping `R CMD INSTALL` and producing `has no 'package.rds' in Meta/` + `undefined exports: ...` load-test failures.
- Normalize `type = "both"` to `"source"` in `renv_available_packages_latest_repos` when `.Platform\$pkgType == "source"`, matching base R's own constraint (`install.packages(type = "both")` errors on Linux).

Fixes #2275.

## Test plan

- [x] New regression test in `tests/testthat/test-available-packages.R` asserts that on source-only platforms `pkgType = "both"` yields a record tagged `"source"`.
- [x] `devtools::test(filter = "available-packages")` passes.
- [x] `devtools::test(filter = "retrieve")` and `devtools::test(filter = "graph")` pass with no new failures.