### PR TITLE
fix graph resolver using latest deps for pinned older versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,16 @@
   archive, rather than trusting the `type` passed to
   `available.packages()`.
 
+* Fixed an issue where `renv::restore()` and `renv::install()` could resolve
+  dependency constraints against the wrong version's `DESCRIPTION`. When a
+  lockfile-pinned version was not available from the configured repositories
+  (e.g. only the latest version is indexed, as on
+  `packagemanager.posit.co/cran/latest`), the graph resolver substituted the
+  latest version's `Depends`/`Imports`/`LinkingTo` fields in place of the
+  pinned version's, which could force spurious upgrades of unrelated
+  dependencies. The resolver now consults crandb for the pinned version's
+  actual requirements before falling back to the latest entry. (#2278)
+
 * Fixed an issue where setting `options(pkgType = "both")` on Linux could
   cause `renv::restore()` to extract a source tarball into the library as
   if it were a pre-built binary, skipping `R CMD INSTALL` and producing

--- a/R/graph.R
+++ b/R/graph.R
@@ -245,9 +245,20 @@ renv_graph_description_repository <- function(record) {
       return(as.list(latest))
   }
 
-  # if the package exists in configured repos at a different version, use
-  # the full-field entry with overridden version; renv_available_packages_entry
-  # without filter returns complete dependency fields unlike latest
+  # the requested version wasn't found in configured repos; try crandb for the
+  # specific version's dependency fields. this must come before any fallback
+  # that reuses the latest entry's fields with an overridden version, since
+  # dependency constraints can change between versions (e.g. #2278)
+  if (!is.null(version)) {
+    crandb <- catch(renv_graph_description_crandb(package, version))
+    if (!inherits(crandb, "error"))
+      return(as.list(crandb))
+  }
+
+  # last-resort fallback when crandb is unreachable: use the latest entry's
+  # full fields with the requested version substituted. this may return stale
+  # dependency constraints if they changed between versions, but is better
+  # than failing outright.
   if (!is.null(version) && !inherits(latest, "error")) {
     full <- catch(renv_available_packages_entry(package, type = type))
     if (!inherits(full, "error")) {
@@ -255,13 +266,6 @@ renv_graph_description_repository <- function(record) {
       desc$Version <- version
       return(desc)
     }
-  }
-
-  # fall back to crandb for archived versions not in any configured repo
-  if (!is.null(version)) {
-    crandb <- catch(renv_graph_description_crandb(package, version))
-    if (!inherits(crandb, "error"))
-      return(as.list(crandb))
   }
 
   # if we found any entry at all (e.g. version filter excluded it),

--- a/tests/testthat/helper-scope.R
+++ b/tests/testthat/helper-scope.R
@@ -8,6 +8,10 @@ renv_tests_scope <- function(packages = character(),
   # use private repositories in this scope
   renv_tests_scope_repos(scope = scope)
 
+  # disable network-backed crandb lookups; test fixture packages
+  # (e.g. "breakfast") collide with real CRAN package names
+  renv_tests_scope_crandb(enabled = FALSE, scope = scope)
+
   # use sandbox in this scope, to guard against packages like 'bread'
   # being installed into the system library
   renv_scope_sandbox(scope = scope)
@@ -68,6 +72,22 @@ renv_tests_scope_repos <- function(scope = parent.frame()) {
     pkgType = "source",
     repos   = repos,
     scope   = scope
+  )
+
+}
+
+renv_tests_scope_crandb <- function(enabled = FALSE, scope = parent.frame()) {
+
+  if (enabled)
+    return(invisible())
+
+  renv_scope_binding(
+    envir       = asNamespace("renv"),
+    symbol      = "renv_graph_description_crandb",
+    replacement = function(package, version) {
+      stop("crandb disabled in renv_tests_scope")
+    },
+    scope       = scope
   )
 
 }

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -1069,6 +1069,36 @@ test_that("renv_graph_description_repository respects install_pkg_type", {
 
 })
 
+# https://github.com/rstudio/renv/issues/2278
+test_that("repository graph prefers crandb over latest-with-overridden-version", {
+
+  renv_tests_scope()
+
+  # stub crandb lookup so we don't touch the network, and so we can verify
+  # which path was taken: the stub returns a marker Depends field that
+  # differs from anything in the test repository
+  crandb_called <- FALSE
+  renv_scope_binding(
+    envir = asNamespace("renv"),
+    symbol = "renv_graph_description_crandb",
+    replacement = function(package, version) {
+      crandb_called <<- TRUE
+      list(Package = package, Version = version, Depends = "crandb-marker")
+    }
+  )
+
+  # ask for bread at a version that isn't in the test repository (which has
+  # 1.0.0); step 1 (version-filtered entry) and step 2 (latest matching) will
+  # both fail, so resolution must fall through to crandb
+  record <- list(Package = "bread", Version = "0.1.0", Source = "Repository")
+  desc <- renv_graph_description_repository(record)
+
+  expect_true(crandb_called)
+  expect_equal(desc$Version, "0.1.0")
+  expect_equal(desc$Depends, "crandb-marker")
+
+})
+
 # https://github.com/rstudio/renv/issues/2249
 test_that("gitlab DESCRIPTION path handles empty RemoteSubdir", {
 


### PR DESCRIPTION
## Summary

Closes #2278.

`renv_graph_description_repository()` needs a DESCRIPTION-like list (Depends / Imports / LinkingTo) for each record when building the dependency graph. When the lockfile-pinned version is not available from the configured repositories — as happens with `packagemanager.posit.co/cran/latest`, which only indexes the newest version of each package — the resolver fell through to a fallback that fetched the **latest** entry's full fields and overwrote only the `Version` field with the pinned one.

The returned pseudo-DESCRIPTION therefore claimed to be, say, `ggiraph 0.9.0` but carried `ggiraph 0.9.1+`'s `Imports: ggplot2 (>= 4.0.0)`. The requirements checker at `R/graph.R:63–85` would then see `ggplot2 3.5.2` violating that (fake) constraint and force an upgrade — exactly the symptom reported: restoring `ggplot2 3.5.2` against PPM latest ended up repairing it to `4.0.3`.

The existing crandb fallback at the per-version endpoint (`https://crandb.r-pkg.org/<pkg>/<version>`) already returns the correct archived DESCRIPTION, but it ran *after* the buggy path and so never got a chance.

## Change

- Swap the two fallback blocks in `R/graph.R` so the crandb lookup runs first. The latest-with-overridden-version path is retained only as a last resort for when crandb is unreachable, with an updated comment explaining why it can lie.
- Added a regression test that stubs `renv_graph_description_crandb` with a marker value and asserts the resolver returns it when asked for a version not present in the configured repo.
- NEWS entry referencing #2278.

## Test plan

- [x] `devtools::test(filter = "graph|restore|install")` — 362 passing, 6 skipped (platform/slow), 0 failing
- [x] New test `repository graph prefers crandb over latest-with-overridden-version` passes

## Notes / possible follow-up

With this change, restoring a large lockfile against `cran/latest` will make one crandb HTTP request per pinned-older-than-latest package. `renv_graph_description_crandb` at `R/graph.R:298` is not memoized, unlike the sibling `/all`-endpoint helper at `R/available-packages.R:642`. If this proves slow in practice, a follow-up could reuse the memoized `/all` response and filter in-process — but that's orthogonal to the correctness fix here.