### PR TITLE
fix restore(clean = TRUE) ignored when pak is enabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,12 @@
   dependencies, even when `pak.enabled = TRUE`. The install path used
   during init now delegates to pak when it is enabled. (#2282)
 
+* Fixed an issue where `renv::restore(clean = TRUE)` did not remove
+  unused packages when `RENV_CONFIG_PAK_ENABLED=TRUE` (or
+  `config$pak.enabled()` was otherwise set). The pak code path now honors
+  `clean = TRUE` and drops packages from the project library that are not
+  recorded in the lockfile, before delegating installs to pak. (#2280)
+
 * New `install.keep.source` configuration option controls whether renv
   invokes `R CMD INSTALL` with `--with-keep.source`. Defaults to `TRUE`,
   matching existing behaviour; set to `FALSE` to install with

--- a/R/pak.R
+++ b/R/pak.R
@@ -237,3 +237,46 @@ renv_pak_restore <- function(lockfile,
 
 }
 
+renv_pak_restore_clean <- function(lockfile,
+                                   libpaths,
+                                   library,
+                                   project,
+                                   packages,
+                                   exclude)
+{
+  current <- snapshot(
+    project  = project,
+    library  = libpaths,
+    lockfile = NULL,
+    type     = "all"
+  )
+
+  diff <- renv_lockfile_diff_packages(current, lockfile)
+  removes <- diff[diff == "remove"]
+  if (!length(removes))
+    return(invisible(NULL))
+
+  # only remove packages from the project library
+  ispkg <- map_lgl(names(removes), function(package) {
+    path <- find.package(package, lib.loc = libpaths, quiet = TRUE)
+    identical(dirname(path), library)
+  })
+  removes <- removes[ispkg]
+
+  # don't remove ignored packages
+  ignored <- renv_project_ignored_packages(project = project)
+  removes <- removes[renv_vector_diff(names(removes), ignored)]
+
+  # restrict to requested packages, matching restore()'s main path
+  selected <- if (is.null(packages))
+    setdiff(names(removes), exclude)
+  else
+    setdiff(packages, exclude)
+  removes <- removes[intersect(names(removes), selected)]
+
+  enumerate(removes, function(package, action) {
+    renv_restore_remove(project, package, current)
+  })
+
+  invisible(removes)
+}

--- a/R/pak.R
+++ b/R/pak.R
@@ -242,7 +242,8 @@ renv_pak_restore_clean <- function(lockfile,
                                    library,
                                    project,
                                    packages,
-                                   exclude)
+                                   exclude,
+                                   prompt)
 {
   current <- snapshot(
     project  = project,
@@ -267,12 +268,24 @@ renv_pak_restore_clean <- function(lockfile,
   ignored <- renv_project_ignored_packages(project = project)
   removes <- removes[renv_vector_diff(names(removes), ignored)]
 
-  # restrict to requested packages, matching restore()'s main path
+  # restrict to user-requested packages. unlike the main restore() path we
+  # don't expand `packages` via renv_graph_init() here, since the install
+  # graph's transitive deps come from the lockfile and so won't appear in
+  # the remove diff anyway.
   selected <- if (is.null(packages))
     setdiff(names(removes), exclude)
   else
     setdiff(packages, exclude)
   removes <- removes[intersect(names(removes), selected)]
+
+  if (!length(removes))
+    return(invisible(NULL))
+
+  # report planned removals and confirm before mutating the library
+  if (prompt || renv_verbose()) {
+    renv_restore_report_actions(removes, current, lockfile)
+    cancel_if(prompt && !proceed())
+  }
 
   enumerate(removes, function(package, action) {
     renv_restore_remove(project, package, current)

--- a/R/restore.R
+++ b/R/restore.R
@@ -140,7 +140,7 @@ restore <- function(project = NULL,
     # unused packages from the project library ourselves before delegating
     # the install to pak
     if (clean)
-      renv_pak_restore_clean(lockfile, libpaths, library, project, packages, exclude)
+      renv_pak_restore_clean(lockfile, libpaths, library, project, packages, exclude, prompt)
 
     records <- renv_pak_restore(
       lockfile = lockfile,

--- a/R/restore.R
+++ b/R/restore.R
@@ -135,6 +135,13 @@ restore <- function(project = NULL,
   if (config$pak.enabled() && !recursing()) {
 
     renv_pak_init()
+
+    # pak doesn't handle package removals, so when clean = TRUE we drop
+    # unused packages from the project library ourselves before delegating
+    # the install to pak
+    if (clean)
+      renv_pak_restore_clean(lockfile, libpaths, library, project, packages, exclude)
+
     records <- renv_pak_restore(
       lockfile = lockfile,
       packages = packages,

--- a/tests/testthat/test-pak.R
+++ b/tests/testthat/test-pak.R
@@ -181,5 +181,6 @@ test_that("restore(clean = TRUE) removes unused packages with pak enabled", {
 
   quietly(restore(clean = TRUE))
   expect_false(renv_package_installed("bread"))
+  expect_true(renv_package_installed("oatmeal"))
 
 })

--- a/tests/testthat/test-pak.R
+++ b/tests/testthat/test-pak.R
@@ -184,3 +184,63 @@ test_that("restore(clean = TRUE) removes unused packages with pak enabled", {
   expect_true(renv_package_installed("oatmeal"))
 
 })
+
+test_that("restore(clean = TRUE) aborts when prompt is declined on pak path", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  renv_tests_scope("oatmeal")
+  init()
+
+  renv_scope_options(renv.config.auto.snapshot = FALSE)
+  install("bread")
+  expect_true(renv_package_installed("bread"))
+
+  local_mocked_bindings(proceed = function(...) FALSE)
+  expect_error(quietly(restore(clean = TRUE, prompt = TRUE)))
+  expect_true(renv_package_installed("bread"))
+  expect_true(renv_package_installed("oatmeal"))
+
+})
+
+test_that("restore(clean = TRUE) honors `exclude` on pak path", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  renv_tests_scope("oatmeal")
+  init()
+
+  renv_scope_options(renv.config.auto.snapshot = FALSE)
+  install("bread")
+  expect_true(renv_package_installed("bread"))
+
+  quietly(restore(clean = TRUE, exclude = "bread"))
+  expect_true(renv_package_installed("bread"))
+  expect_true(renv_package_installed("oatmeal"))
+
+})
+
+test_that("restore(clean = TRUE) honors `packages` on pak path", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  renv_tests_scope("oatmeal")
+  init()
+
+  renv_scope_options(renv.config.auto.snapshot = FALSE)
+  install("bread")
+  expect_true(renv_package_installed("bread"))
+
+  # cleanup is scoped to the named packages; bread is unused but not named,
+  # so it should survive.
+  quietly(restore(clean = TRUE, packages = "oatmeal"))
+  expect_true(renv_package_installed("bread"))
+  expect_true(renv_package_installed("oatmeal"))
+
+})

--- a/tests/testthat/test-pak.R
+++ b/tests/testthat/test-pak.R
@@ -165,3 +165,21 @@ test_that("hydrate() propagates pak install errors", {
   expect_error(quietly(hydrate(prompt = FALSE, report = FALSE)), "pak failed")
 
 })
+
+test_that("restore(clean = TRUE) removes unused packages with pak enabled", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  renv_tests_scope("oatmeal")
+  init()
+
+  renv_scope_options(renv.config.auto.snapshot = FALSE)
+  install("bread")
+  expect_true(renv_package_installed("bread"))
+
+  quietly(restore(clean = TRUE))
+  expect_false(renv_package_installed("bread"))
+
+})


### PR DESCRIPTION
## Summary

- When `config$pak.enabled()` is `TRUE`, `restore()` short-circuits to `renv_pak_restore()` and never forwards `clean` — and `renv_pak_restore()` doesn't take a `clean` parameter or remove anything (pak only installs).
- The pak branch now calls `renv_pak_restore_clean()` when `clean = TRUE` to drop unused packages from the project library before delegating installs to pak. The cleanup mirrors the non-pak path: snapshots the library, diffs against the lockfile, restricts to packages in the project library, honors ignored packages and the `packages`/`exclude` filters, and removes via the existing `renv_restore_remove()`.

Closes #2280.

## Test plan

- [ ] `devtools::test_file("tests/testthat/test-pak.R")` with `pak` installed (the new test is skipped on CRAN/Windows and when pak is unavailable)
- [ ] Manual reproduction from #2280: with `RENV_CONFIG_PAK_ENABLED=TRUE`, lockfile listing only `renv`, library populated with extra packages — confirm `renv::restore(clean = TRUE)` removes the extras
- [ ] Existing `restore(clean = TRUE)` test in `test-restore.R` still passes (non-pak path unchanged)