### PR TITLE
fix install(include = ...) ignored when pak is enabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # renv (development version)
 
+* Fixed an issue where `renv::snapshot()` would fail to install missing
+  packages when `pak` was enabled and the user selected the "Install the
+  packages, then snapshot" option at the prompt. `renv::install()` now
+  forwards its `include` and `exclude` arguments to the pak backend, so
+  `install(include = missing)` reliably installs the requested packages
+  rather than falling through to a no-op project update. (#2281)
+
 * New `install.keep.source` configuration option controls whether renv
   invokes `R CMD INSTALL` with `--with-keep.source`. Defaults to `TRUE`,
   matching existing behaviour; set to `FALSE` to install with

--- a/R/install.R
+++ b/R/install.R
@@ -175,6 +175,8 @@ install <- function(packages = NULL,
     return(
       renv_pak_install(
         packages = packages,
+        include  = include,
+        exclude  = exclude,
         library  = libpaths,
         type     = type,
         rebuild  = rebuild,

--- a/R/pak.R
+++ b/R/pak.R
@@ -105,7 +105,9 @@ renv_pak_install <- function(packages,
                              type,
                              rebuild,
                              prompt,
-                             project)
+                             project,
+                             include = NULL,
+                             exclude = NULL)
 {
   pak <- renv_namespace_load("pak")
 
@@ -126,6 +128,15 @@ renv_pak_install <- function(packages,
      names(packages)
   else
     as.character(packages)
+
+  # if no packages were specified but the caller restricted installation
+  # to an explicit include set, install those (e.g. install(include = ...))
+  # https://github.com/rstudio/renv/issues/2281
+  if (length(packages) == 0L && length(include))
+    packages <- as.character(include)
+
+  if (length(exclude))
+    packages <- setdiff(packages, exclude)
 
   # if no packages were specified, treat this as a request to
   # install / update packages used in the project

--- a/R/pak.R
+++ b/R/pak.R
@@ -129,14 +129,19 @@ renv_pak_install <- function(packages,
   else
     as.character(packages)
 
-  # if no packages were specified but the caller restricted installation
-  # to an explicit include set, install those (e.g. install(include = ...))
+  # apply include / exclude consistently with the non-pak install path,
+  # so the semantics of these arguments don't depend on the installer.
+  # if no packages were specified positionally but include was, treat it
+  # as the request set (e.g. install(include = ...))
   # https://github.com/rstudio/renv/issues/2281
   if (length(packages) == 0L && length(include))
     packages <- as.character(include)
 
   if (length(exclude))
     packages <- setdiff(packages, exclude)
+
+  if (length(include))
+    packages <- intersect(packages, include)
 
   # if no packages were specified, treat this as a request to
   # install / update packages used in the project

--- a/R/pak.R
+++ b/R/pak.R
@@ -129,6 +129,11 @@ renv_pak_install <- function(packages,
   else
     as.character(packages)
 
+  # remember whether the caller explicitly scoped this install so we can
+  # distinguish "no scope at all" (let pak update the project) from "explicit
+  # scope filtered to empty" (no-op, matching the non-pak path)
+  explicit <- length(packages) > 0L || length(include) > 0L || length(exclude) > 0L
+
   # apply include / exclude consistently with the non-pak install path,
   # so the semantics of these arguments don't depend on the installer.
   # if no packages were specified positionally but include was, treat it
@@ -143,10 +148,16 @@ renv_pak_install <- function(packages,
   if (length(include))
     packages <- intersect(packages, include)
 
-  # if no packages were specified, treat this as a request to
-  # install / update packages used in the project
-  if (length(packages) == 0L)
+  # if no packages remain, fall through to a project-wide update only when
+  # the caller did not provide an explicit scope; otherwise treat this as
+  # a no-op so we don't surprise the user with an unintended update
+  if (length(packages) == 0L) {
+    if (explicit) {
+      writef("- There are no packages to install.")
+      return(invisible(list()))
+    }
     return(renv_pak_update(project, library, prompt))
+  }
   
   # pak doesn't support ':' as a sub-directory separator, so try to
   # repair that here

--- a/tests/testthat/test-pak.R
+++ b/tests/testthat/test-pak.R
@@ -36,6 +36,24 @@ test_that("install(include = ...) installs requested packages with pak (#2281)",
 
 })
 
+test_that("install(include = ...) filters positional packages with pak (#2281)", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  pak <- renv_namespace_load("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  project <- renv_tests_scope()
+
+  # 'bread' and 'oatmeal' are leaf packages with no shared dependencies;
+  # include should filter the positional list down to just 'bread', matching
+  # the behavior of the non-pak install path
+  quietly(install(c("bread", "oatmeal"), include = "bread"))
+  expect_true(renv_package_installed("bread"))
+  expect_false(renv_package_installed("oatmeal"))
+
+})
+
 test_that("renv::update() works in projects using pak", {
   
   skip_on_cran()

--- a/tests/testthat/test-pak.R
+++ b/tests/testthat/test-pak.R
@@ -20,6 +20,22 @@ test_that("renv::install() works in projects using pak", {
   
 })
 
+test_that("install(include = ...) installs requested packages with pak (#2281)", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  pak <- renv_namespace_load("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  project <- renv_tests_scope()
+
+  # install(include = ...) with no positional packages should install the
+  # named packages rather than fall through to renv_pak_update().
+  quietly(install(include = "breakfast"))
+  expect_true(renv_package_installed("breakfast"))
+
+})
+
 test_that("renv::update() works in projects using pak", {
   
   skip_on_cran()

--- a/tests/testthat/test-pak.R
+++ b/tests/testthat/test-pak.R
@@ -54,6 +54,44 @@ test_that("install(include = ...) filters positional packages with pak (#2281)",
 
 })
 
+test_that("install(exclude = ...) filters positional packages with pak (#2281)", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  pak <- renv_namespace_load("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  project <- renv_tests_scope()
+
+  # exclude should drop the named packages from the positional list,
+  # matching the behavior of the non-pak install path
+  quietly(install(c("bread", "oatmeal"), exclude = "oatmeal"))
+  expect_true(renv_package_installed("bread"))
+  expect_false(renv_package_installed("oatmeal"))
+
+})
+
+test_that("install() with an explicit scope filtered to empty is a no-op with pak (#2281)", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  pak <- renv_namespace_load("pak")
+  renv_scope_options(
+    renv.config.pak.enabled = TRUE,
+    renv.verbose = TRUE
+  )
+  project <- renv_tests_scope()
+
+  # when the caller provides an explicit scope and filtering empties it,
+  # we should report "no packages" and return — not fall through to the
+  # project-wide pak update path
+  output <- capture.output(install("bread", exclude = "bread"))
+  expect_match(paste(output, collapse = "\n"), "no packages to install", fixed = TRUE)
+  expect_false(renv_package_installed("bread"))
+
+})
+
 test_that("renv::update() works in projects using pak", {
   
   skip_on_cran()


### PR DESCRIPTION
## Summary

- When pak is enabled, `install()` delegated to `renv_pak_install()` *before* the `include` / `exclude` filters were applied, so those arguments were silently dropped.
- This broke `renv::snapshot()`'s "Install the packages, then snapshot" prompt, which calls `install(include = missing, prompt = FALSE)`. With pak enabled, no `packages` were passed positionally, so `renv_pak_install()` saw an empty list and fell through to `renv_pak_update()`, which (in projects without a `DESCRIPTION`) only re-checks already-installed packages — producing the "1 pkg: kept 1" / "lockfile is already up to date" symptom from #2281.
- Fix: forward `include` and `exclude` from `install()` into `renv_pak_install()`, and have it use `include` as the package list when no positional packages are given. The `renv::install()` (no args) → pak full-project resolver behavior is preserved.

Closes #2281.

## Test plan

- [ ] Existing pak tests (`tests/testthat/test-pak.R`) continue to pass.
- [ ] New test confirms `install(include = "breakfast")` actually installs `breakfast` when pak is enabled (rather than falling through to `renv_pak_update`).
- [ ] Manual repro from the issue: `renv::snapshot()` → choose "2: Install the packages, then snapshot" → tidyverse is installed and recorded in the lockfile.