### PR TITLE
fix renv reinstalling packages already in user / site library

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # renv (development version)
 
+* Fixed a regression where `renv::restore()` and `renv::install()` would
+  re-download packages that were already installed in the user or site
+  library, instead of reusing the existing installation. (#2288)
+
 * Fixed an issue where `renv::snapshot()` would fail to install missing
   packages when `pak` was enabled and the user selected the "Install the
   packages, then snapshot" option at the prompt. `renv::install()` now

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -626,12 +626,12 @@ renv_retrieve_libpaths_impl <- function(record, libpath) {
     return(FALSE)
 
   # check that it was built for a compatible version of R
-  built <- desc[["Built"]]
-  if (is.null(built))
+  version <- catch(renv_description_built_version(desc))
+  if (inherits(version, "error") || is.na(version))
     return(FALSE)
 
-  ok <- catch(renv_description_built_version(desc))
-  if (!identical(ok, TRUE))
+  ok <- catch(renv_version_compare(version, getRversion(), 2L) == 0)
+  if (!isTRUE(ok))
     return(FALSE)
 
   # check that this package has a known source

--- a/tests/testthat/test-retrieve.R
+++ b/tests/testthat/test-retrieve.R
@@ -418,3 +418,84 @@ test_that("we can use retrieve() to download packages without installing", {
   expect_equal(result, c(bread = "./bread_1.0.0.tar.gz"))
 
 })
+
+test_that("renv_retrieve_libpaths_impl reuses a compatible installed package", {
+
+  # https://github.com/rstudio/renv/issues/2288 — the built-version check used
+  # to compare a version string to TRUE, which always failed, so the user /
+  # site library shortcut never fired and renv would needlessly download.
+  renv_tests_scope()
+
+  # install bread 1.0.0 into a temporary "user library"
+  userlib <- renv_scope_tempfile("renv-userlib-")
+  ensure_directory(userlib)
+  install("bread", library = userlib)
+
+  # set up restore state so renv_retrieve_successful() has somewhere to record
+  templib <- renv_scope_tempfile("renv-library-")
+  ensure_directory(templib)
+  renv_scope_libpaths(c(templib, .libPaths()))
+
+  record <- list(
+    Package    = "bread",
+    Version    = "1.0.0",
+    Source     = "Repository",
+    Repository = "CRAN"
+  )
+
+  renv_scope_restore(
+    project   = getwd(),
+    library   = templib,
+    records   = list(bread = record),
+    packages  = "bread",
+    recursive = TRUE
+  )
+
+  expect_true(renv_retrieve_libpaths_impl(record, userlib))
+
+  state <- renv_restore_state()
+  expect_true(state$install$contains("bread"))
+  expect_equal(state$install$get("bread")$Path, file.path(userlib, "bread"))
+
+})
+
+test_that("renv_retrieve_libpaths_impl rejects packages built for a different R version", {
+
+  renv_tests_scope()
+
+  # the file-backed DESCRIPTION cache would otherwise return the original
+  # Built field after we mutate the file below
+  renv_scope_options(renv.config.filebacked.cache = FALSE)
+
+  userlib <- renv_scope_tempfile("renv-userlib-")
+  ensure_directory(userlib)
+  install("bread", library = userlib)
+
+  # rewrite the Built field to claim an R version we definitely aren't using
+  descpath <- file.path(userlib, "bread", "DESCRIPTION")
+  text <- readLines(descpath)
+  text <- sub("^Built: R [0-9.]+", "Built: R 0.0.0", text)
+  writeLines(text, descpath)
+
+  templib <- renv_scope_tempfile("renv-library-")
+  ensure_directory(templib)
+  renv_scope_libpaths(c(templib, .libPaths()))
+
+  record <- list(
+    Package    = "bread",
+    Version    = "1.0.0",
+    Source     = "Repository",
+    Repository = "CRAN"
+  )
+
+  renv_scope_restore(
+    project   = getwd(),
+    library   = templib,
+    records   = list(bread = record),
+    packages  = "bread",
+    recursive = TRUE
+  )
+
+  expect_false(renv_retrieve_libpaths_impl(record, userlib))
+
+})


### PR DESCRIPTION
## Summary

- `renv_retrieve_libpaths_impl()` had a broken built-version check — `renv_description_built_version()` returns a version string, but the call site compared its result against `TRUE`. The check always failed, so the user / site library shortcut never fired and `restore()` / `install()` would re-download packages that were already installed locally. Regression introduced in b9bcf65fa (May 2021).
- Restored the major-minor R version comparison that was lost when the helper was extracted, mirroring what `renv_cache_diagnose_wrong_built_version()` does.
- Added two unit tests for `renv_retrieve_libpaths_impl()`: one that verifies a compatible installed package is reused (this is the regression test — it fails on the buggy code), and one that verifies a package built for a different R version is rejected.

The shortcut is gated by `!renv_tests_running()` in `renv_retrieve_impl_one()`, which is why the suite never caught this — the shortcut path is intentionally skipped in renv's own tests.

Fixes #2288.

## Test plan

- [x] `devtools::test(filter = "retrieve")` — 24 PASS
- [x] `devtools::test(filter = "install")` — 85 PASS
- [x] `devtools::test(filter = "restore")` — 88 PASS
- [x] `devtools::test(filter = "cache")` — 20 PASS
- [x] Confirmed the new regression test fails on `main` and passes with the fix