### PR TITLE
fix vulns() docs to match PPM behavior

### DIFF
--- a/R/vulns.R
+++ b/R/vulns.R
@@ -27,9 +27,6 @@
 #'   field is an empty list when the package has no known vulnerabilities,
 #'   and otherwise holds one or more vulnerability records.
 #'
-#'   To restrict the result to packages with known vulnerabilities, filter
-#'   on `length(x$vulns) > 0`.
-#'
 #' @keywords internal
 #' @export
 vulns <- function(packages = NULL,

--- a/R/vulns.R
+++ b/R/vulns.R
@@ -21,8 +21,14 @@
 #' @param verbose Boolean; when `TRUE`, verbose information from the `curl`
 #'   web request will be printed to the console.
 #'
-#' @returns An \R list of vulnerability information. Only packages which
-#'   have known vulnerabilities will be included in the resulting data object.
+#' @returns An \R list with one entry per requested package. Each entry
+#'   contains metadata returned by Posit Package Manager (e.g. `name`,
+#'   `version`, `licenses`, `blocked`), plus a `vulns` field. The `vulns`
+#'   field is an empty list when the package has no known vulnerabilities,
+#'   and otherwise holds one or more vulnerability records.
+#'
+#'   To restrict the result to packages with known vulnerabilities, filter
+#'   on `length(x$vulns) > 0`.
 #'
 #' @keywords internal
 #' @export
@@ -119,6 +125,11 @@ vulns <- function(packages = NULL,
     msg <- sprintf(fmt, error, as.character(code))
     stop(msg, call. = FALSE)
   }
+
+  # PPM omits the vulns field when a package has no known vulnerabilities;
+  # normalize so callers can uniformly inspect record[["vulns"]].
+  for (i in seq_along(data))
+    data[[i]][["vulns"]] <- data[[i]][["vulns"]] %||% list()
 
   data
 }

--- a/man/vulns.Rd
+++ b/man/vulns.Rd
@@ -34,8 +34,14 @@ be used. If no project is currently active, then the current working
 directory is used instead.}
 }
 \value{
-An \R list of vulnerability information. Only packages which
-have known vulnerabilities will be included in the resulting data object.
+An \R list with one entry per requested package. Each entry
+contains metadata returned by Posit Package Manager (e.g. \code{name},
+\code{version}, \code{licenses}, \code{blocked}), plus a \code{vulns} field. The \code{vulns}
+field is an empty list when the package has no known vulnerabilities,
+and otherwise holds one or more vulnerability records.
+
+To restrict the result to packages with known vulnerabilities, filter
+on \code{length(x$vulns) > 0}.
 }
 \description{
 This function acts as an interface to Posit Package Manager's vulnerability

--- a/man/vulns.Rd
+++ b/man/vulns.Rd
@@ -39,9 +39,6 @@ contains metadata returned by Posit Package Manager (e.g. \code{name},
 \code{version}, \code{licenses}, \code{blocked}), plus a \code{vulns} field. The \code{vulns}
 field is an empty list when the package has no known vulnerabilities,
 and otherwise holds one or more vulnerability records.
-
-To restrict the result to packages with known vulnerabilities, filter
-on \code{length(x$vulns) > 0}.
 }
 \description{
 This function acts as an interface to Posit Package Manager's vulnerability


### PR DESCRIPTION
## Summary

- PPM's `__api__/filter/packages` endpoint returns one record per requested package; the `vulns` field is only present (and non-empty) for packages with known vulnerabilities. The previous `@returns` doc claimed only vulnerable packages would be included, which never matched the implementation.
- Update the `@returns` block on `vulns()` to describe the actual return shape and show how to filter to vulnerable entries via `Filter(function(x) length(x$vulns) > 0, result)`.
- Normalize the response so every record has a `vulns` element (empty `list()` when clean), so downstream code can uniformly inspect `record$vulns`.

Fixes #2292.

## Test plan

- [x] `renv::vulns(c("curl==7.1.0", "jsonlite==1.8.7", "gh==1.4.1"), repos = "https://packagemanager.posit.co/cran/latest")` returns three records; `curl` has `vulns = list()`, `jsonlite` and `gh` have populated `vulns`.
- [x] `Filter(function(x) length(x$vulns) > 0, result)` keeps only the vulnerable entries.