### PR TITLE
fix record() writing fewer fields than snapshot()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,16 @@
 
 # renv (development version)
 
+* `renv::record()` now enriches each resolved record with the same
+  DESCRIPTION-derived fields that `renv::snapshot()` writes (e.g.
+  `Depends`, `Imports`, `Suggests`, `LinkingTo`, `License`), instead of
+  producing a minimal record with only `Package`, `Version`, `Source`,
+  and `Repository`. The metadata is fetched from the active package
+  repositories (and crandb, when enabled, for CRAN packages) without
+  reading the local library. Set `enrich = FALSE` to opt out and keep
+  the previous minimal-record behavior. The `Hash` field is not computed
+  for enriched records. (#2294)
+
 * Fixed a regression where `renv::restore()` and `renv::install()` would
   re-download packages that were already installed in the user or site
   library, instead of reusing the existing installation. (#2288)

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,11 @@
   repositories (and crandb, when enabled, for CRAN packages) without
   reading the local library. Set `enrich = FALSE` to opt out and keep
   the previous minimal-record behavior. The `Hash` field is not computed
-  for enriched records. (#2294)
+  for enriched records. Enriched records also store `Repository` as the
+  named form (e.g. `CRAN`) that `renv::snapshot()` writes, rather than
+  the contrib URL returned by `available.packages()`, so `renv::status()`
+  no longer reports a spurious repository mismatch after a version-pinned
+  `record()` call. (#2294)
 
 * Fixed a regression where `renv::restore()` and `renv::install()` would
   re-download packages that were already installed in the user or site

--- a/R/record.R
+++ b/R/record.R
@@ -19,11 +19,25 @@
 #' @param records A list of named records, mapping package names to a definition
 #'   of their source. See **Records** for more details.
 #'
+#' @param enrich Should resolved records be enriched with the DESCRIPTION
+#'   fields that `snapshot()` would write (`Depends`, `Imports`, `Suggests`,
+#'   `LinkingTo`, `License`, etc.)? Defaults to `TRUE`. When `TRUE`,
+#'   `record()` consults the active package repositories (and crandb, when
+#'   enabled, for CRAN packages) to fill in the additional fields, erroring
+#'   if the remote source is unreachable. The `Hash` field is not computed
+#'   for enriched records. Additional DESCRIPTION-only fields (`Title`,
+#'   `Description`, `Author`, `Maintainer`) are only included when the
+#'   source can supply them -- typically when crandb is reachable for CRAN
+#'   packages, or when the source is a Git host (GitHub, GitLab, Bitbucket).
+#'   Set to `FALSE` to keep the minimal record (`Package`, `Version`,
+#'   `Source`, `Repository`) produced by remote resolution.
+#'
 #' @example examples/examples-record.R
 #' @export
 record <- function(records,
                    lockfile = NULL,
-                   project  = NULL)
+                   project  = NULL,
+                   enrich   = TRUE)
 {
   renv_scope_error_handler()
 
@@ -37,6 +51,12 @@ record <- function(records,
     is.list(records)      ~ renv_records_resolve(records, latest = TRUE),
     ~ stopf("unexpected records format '%s'", typeof(records))
   )
+
+  if (enrich) {
+    records <- lapply(records, function(record) {
+      if (is.null(record)) record else renv_record_enrich(record)
+    })
+  }
 
   names(records) <- enum_chr(records, function(package, record) {
     if (is.null(package) || is.na(package) || !nzchar(package))
@@ -122,4 +142,71 @@ renv_record_placeholder <- function() {
 renv_record_cranlike <- function(record) {
   type <- record[["RemoteType"]]
   is.null(type) || tolower(type) %in% c("cran", "repository", "standard")
+}
+
+# enrich a resolved record with DESCRIPTION-level fields so the record
+# matches what snapshot() would write. delegates the actual DESCRIPTION
+# fetch to renv_graph_description(), which reuses the same infrastructure
+# the restore graph uses (available.packages metadata + crandb fallback,
+# Git host APIs, etc.). enrichment never reads the local library: we
+# always trust the remote description. Hash is not computed.
+renv_record_enrich <- function(record) {
+
+  source <- renv_record_source(record, normalize = TRUE)
+
+  enrichable <- c(
+    "repository", "bioconductor",
+    "github", "gitlab", "bitbucket", "git"
+  )
+
+  if (!source %in% enrichable)
+    return(record)
+
+  key <- paste(
+    record[["Package"]]    %||% "",
+    record[["Version"]]    %||% "",
+    record[["Repository"]] %||% "",
+    record[["RemoteSha"]]  %||% "",
+    sep = "|"
+  )
+
+  memoize(
+    key   = key,
+    value = renv_record_enrich_impl(record),
+    scope = "record-enrich"
+  )
+
+}
+
+renv_record_enrich_impl <- function(record) {
+
+  package <- record[["Package"]]
+  if (is.null(package) || !nzchar(package))
+    stopf("cannot enrich record: missing 'Package' field")
+
+  # delegate to the graph description fetcher; it handles every source
+  # type we recognize and errors loudly when the source is unreachable
+  desc <- renv_graph_description(record)
+
+  # carry forward fields from the resolved record (Source, Repository,
+  # Remote*) so they aren't lost if the description-fetcher didn't set them
+  for (field in names(record))
+    if (is.null(desc[[field]]))
+      desc[[field]] <- record[[field]]
+
+  # apply the v2 snapshot transform so output matches what snapshot() writes
+  enriched <- renv_snapshot_description_impl_v2(desc, path = NULL)
+
+  # restore Source / Repository from the input record. for repository-sourced
+  # records the description fetcher reports Repository as a URL; we want the
+  # repository name from the original record (e.g. "CRAN").
+  enriched[["Source"]] <- record[["Source"]] %||% enriched[["Source"]]
+  if (!is.null(record[["Repository"]]))
+    enriched[["Repository"]] <- record[["Repository"]]
+
+  # Hash is not computed for enriched records; see ?record
+  enriched[["Hash"]] <- NULL
+
+  enriched
+
 }

--- a/R/record.R
+++ b/R/record.R
@@ -46,16 +46,24 @@ record <- function(records,
 
   lockfile <- lockfile %||% renv_lockfile_path(project)
 
-  records <- case(
-    is.character(records) ~ lapply(records, renv_remotes_resolve, latest = TRUE),
-    is.list(records)      ~ renv_records_resolve(records, latest = TRUE),
-    ~ stopf("unexpected records format '%s'", typeof(records))
-  )
+  # track which entries came from a character spec; only those entries
+  # are enriched, so caller-supplied list records pass through unchanged
+  # (and offline, since enrichment otherwise requires a reachable source)
+  if (is.character(records)) {
+    enrichable <- rep_len(TRUE, length(records))
+    records <- lapply(records, renv_remotes_resolve, latest = TRUE)
+  } else if (is.list(records)) {
+    enrichable <- map_lgl(records, is.character)
+    records <- renv_records_resolve(records, latest = TRUE)
+  } else {
+    stopf("unexpected records format '%s'", typeof(records))
+  }
 
   if (enrich) {
-    records <- lapply(records, function(record) {
-      if (is.null(record)) record else renv_record_enrich(record)
-    })
+    for (i in seq_along(records)) {
+      if (enrichable[[i]] && !is.null(records[[i]]))
+        records[[i]] <- renv_record_enrich(records[[i]])
+    }
   }
 
   names(records) <- enum_chr(records, function(package, record) {
@@ -162,12 +170,17 @@ renv_record_enrich <- function(record) {
   if (!source %in% enrichable)
     return(record)
 
+  # include every field that contributes to source identity. plain git
+  # remotes (Source = "git") have no RemoteSha, so distinct URLs would
+  # otherwise alias to the same cache slot.
+  key_fields <- c(
+    "Package", "Version", "Source", "Repository",
+    "RemoteType", "RemoteHost", "RemoteUrl", "RemoteUsername",
+    "RemoteRepo", "RemoteRef", "RemoteSha", "RemoteSubdir"
+  )
   key <- paste(
-    record[["Package"]]    %||% "",
-    record[["Version"]]    %||% "",
-    record[["Repository"]] %||% "",
-    record[["RemoteSha"]]  %||% "",
-    sep = "|"
+    map_chr(key_fields, function(field) record[[field]] %||% ""),
+    collapse = "|"
   )
 
   memoize(

--- a/R/record.R
+++ b/R/record.R
@@ -197,12 +197,19 @@ renv_record_enrich_impl <- function(record) {
   # apply the v2 snapshot transform so output matches what snapshot() writes
   enriched <- renv_snapshot_description_impl_v2(desc, path = NULL)
 
-  # restore Source / Repository from the input record. for repository-sourced
-  # records the description fetcher reports Repository as a URL; we want the
-  # repository name from the original record (e.g. "CRAN").
+  # prefer the named form of Repository (e.g. "CRAN") that snapshot() writes
+  # when reading an installed DESCRIPTION. the description fetcher leaves
+  # Repository as the contrib URL from available.packages(); use the input
+  # record's value if set, else the Name stamped onto the entry by
+  # renv_available_packages_entry().
   enriched[["Source"]] <- record[["Source"]] %||% enriched[["Source"]]
-  if (!is.null(record[["Repository"]]))
-    enriched[["Repository"]] <- record[["Repository"]]
+  enriched[["Repository"]] <-
+    record[["Repository"]] %||%
+    desc[["Name"]] %||%
+    enriched[["Repository"]]
+
+  # Name is a remnant of the available.packages entry, not a lockfile field
+  enriched[["Name"]] <- NULL
 
   # Hash is not computed for enriched records; see ?record
   enriched[["Hash"]] <- NULL

--- a/R/record.R
+++ b/R/record.R
@@ -170,24 +170,41 @@ renv_record_enrich <- function(record) {
   if (!source %in% enrichable)
     return(record)
 
+  memoize(
+    key   = renv_record_enrich_key(record, source = source),
+    value = renv_record_enrich_impl(record),
+    scope = "record-enrich"
+  )
+
+}
+
+renv_record_enrich_key <- function(record, source = NULL) {
+
+  source <- source %||% renv_record_source(record, normalize = TRUE)
+
   # include every field that contributes to source identity. plain git
   # remotes (Source = "git") have no RemoteSha, so distinct URLs would
   # otherwise alias to the same cache slot.
-  key_fields <- c(
+  fields <- c(
     "Package", "Version", "Source", "Repository",
     "RemoteType", "RemoteHost", "RemoteUrl", "RemoteUsername",
     "RemoteRepo", "RemoteRef", "RemoteSha", "RemoteSubdir"
   )
-  key <- paste(
-    map_chr(key_fields, function(field) record[[field]] %||% ""),
-    collapse = "|"
-  )
+  parts <- map_chr(fields, function(field) record[[field]] %||% "")
 
-  memoize(
-    key   = key,
-    value = renv_record_enrich_impl(record),
-    scope = "record-enrich"
-  )
+  # for repository / bioconductor sources, the description fetcher reads
+  # from options('repos'); include that in the key so the cache invalidates
+  # when repos change mid-session. version-pinned specs in particular have
+  # no Repository field, so without this the key collapses across repos.
+  if (source %in% c("repository", "bioconductor")) {
+    repos <- getOption("repos")
+    parts <- c(
+      parts,
+      paste(names(repos) %||% "", repos, sep = "=", collapse = ",")
+    )
+  }
+
+  paste(parts, collapse = "|")
 
 }
 

--- a/man/record.Rd
+++ b/man/record.Rd
@@ -4,7 +4,7 @@
 \alias{record}
 \title{Update package records in a lockfile}
 \usage{
-record(records, lockfile = NULL, project = NULL)
+record(records, lockfile = NULL, project = NULL, enrich = TRUE)
 }
 \arguments{
 \item{records}{A list of named records, mapping package names to a definition
@@ -16,6 +16,19 @@ of their source. See \strong{Records} for more details.}
 \item{project}{The project directory. If \code{NULL}, then the active project will
 be used. If no project is currently active, then the current working
 directory is used instead.}
+
+\item{enrich}{Should resolved records be enriched with the DESCRIPTION
+fields that \code{snapshot()} would write (\code{Depends}, \code{Imports}, \code{Suggests},
+\code{LinkingTo}, \code{License}, etc.)? Defaults to \code{TRUE}. When \code{TRUE},
+\code{record()} consults the active package repositories (and crandb, when
+enabled, for CRAN packages) to fill in the additional fields, erroring
+if the remote source is unreachable. The \code{Hash} field is not computed
+for enriched records. Additional DESCRIPTION-only fields (\code{Title},
+\code{Description}, \code{Author}, \code{Maintainer}) are only included when the
+source can supply them -- typically when crandb is reachable for CRAN
+packages, or when the source is a Git host (GitHub, GitLab, Bitbucket).
+Set to \code{FALSE} to keep the minimal record (\code{Package}, \code{Version},
+\code{Source}, \code{Repository}) produced by remote resolution.}
 }
 \description{
 Use \code{record()} to record a new entry within an existing renv lockfile.

--- a/tests/testthat/_snaps/status.md
+++ b/tests/testthat/_snaps/status.md
@@ -64,8 +64,8 @@
       The following package(s) are out of sync [lockfile != library]:
       
       # CRAN ---
-      - egg       [repo: * != CRAN; ver: 2.0.0 != 1.0.0]
-      - oatmeal   [repo: * != CRAN; ver: 0.9.0 != 1.0.0]
+      - egg       [2.0.0 != 1.0.0]
+      - oatmeal   [0.9.0 != 1.0.0]
       
       See `?renv::status` for advice on resolving these issues.
 

--- a/tests/testthat/test-record.R
+++ b/tests/testthat/test-record.R
@@ -101,6 +101,33 @@ test_that("record(enrich = FALSE) keeps minimal records", {
 
 })
 
+test_that("record() does not enrich caller-supplied list records", {
+
+  # a fully-resolved list record should pass through untouched: no
+  # network access, no field rewrite. this matches the documented "record
+  # this entry as provided" behavior and lets users seed unusual entries
+  # (custom fields, sources renv doesn't understand) without round-tripping
+  # through the snapshot transform.
+  renv_tests_scope()
+  snapshot()
+
+  custom <- list(
+    Package    = "fictional",
+    Version    = "9.9.9",
+    Source     = "Repository",
+    Repository = "CRAN",
+    Custom     = "preserved"
+  )
+  record(list(fictional = custom))
+
+  lockfile <- renv_lockfile_read("renv.lock")
+  fictional <- renv_lockfile_records(lockfile)$fictional
+
+  expect_identical(fictional$Version, "9.9.9")
+  expect_identical(fictional$Custom, "preserved")
+
+})
+
 test_that("record() stores Repository as the named form, not the URL", {
 
   # version-pinned specs skip the 'latest' branch in

--- a/tests/testthat/test-record.R
+++ b/tests/testthat/test-record.R
@@ -111,10 +111,10 @@ test_that("enrich cache key varies with options('repos')", {
     Package = "foo", Version = "1.0.0", Source = "Repository"
   )
 
-  withr::local_options(repos = c(CRAN = "https://cran.example/a"))
+  renv_scope_options(repos = c(CRAN = "https://cran.example/a"))
   before <- renv_record_enrich_key(cranlike)
 
-  withr::local_options(repos = c(CRAN = "https://cran.example/b"))
+  renv_scope_options(repos = c(CRAN = "https://cran.example/b"))
   after <- renv_record_enrich_key(cranlike)
 
   expect_false(identical(before, after))
@@ -126,10 +126,10 @@ test_that("enrich cache key varies with options('repos')", {
     RemoteUsername = "user", RemoteRepo = "repo", RemoteSha = "abc"
   )
 
-  withr::local_options(repos = c(CRAN = "https://cran.example/a"))
+  renv_scope_options(repos = c(CRAN = "https://cran.example/a"))
   before <- renv_record_enrich_key(github)
 
-  withr::local_options(repos = c(CRAN = "https://cran.example/b"))
+  renv_scope_options(repos = c(CRAN = "https://cran.example/b"))
   after <- renv_record_enrich_key(github)
 
   expect_identical(before, after)

--- a/tests/testthat/test-record.R
+++ b/tests/testthat/test-record.R
@@ -101,6 +101,41 @@ test_that("record(enrich = FALSE) keeps minimal records", {
 
 })
 
+test_that("enrich cache key varies with options('repos')", {
+
+  # the description fetcher reads from options('repos'), so the memoize
+  # key must too. version-pinned repository specs have no Repository
+  # field, so without this guard a record('pkg@1.0.0') call would return
+  # cached data fetched against a different repos config.
+  cranlike <- list(
+    Package = "foo", Version = "1.0.0", Source = "Repository"
+  )
+
+  withr::local_options(repos = c(CRAN = "https://cran.example/a"))
+  before <- renv_record_enrich_key(cranlike)
+
+  withr::local_options(repos = c(CRAN = "https://cran.example/b"))
+  after <- renv_record_enrich_key(cranlike)
+
+  expect_false(identical(before, after))
+
+  # github (and other non-repository sources) carry full source identity
+  # on the record itself; their key should not depend on options('repos')
+  github <- list(
+    Package = "foo", Version = "1.0.0", Source = "GitHub",
+    RemoteUsername = "user", RemoteRepo = "repo", RemoteSha = "abc"
+  )
+
+  withr::local_options(repos = c(CRAN = "https://cran.example/a"))
+  before <- renv_record_enrich_key(github)
+
+  withr::local_options(repos = c(CRAN = "https://cran.example/b"))
+  after <- renv_record_enrich_key(github)
+
+  expect_identical(before, after)
+
+})
+
 test_that("record() does not enrich caller-supplied list records", {
 
   # a fully-resolved list record should pass through untouched: no
@@ -140,9 +175,9 @@ test_that("record() stores Repository as the named form, not the URL", {
   record("egg@2.0.0")
 
   lockfile <- renv_lockfile_read("renv.lock")
-  rec_record <- renv_lockfile_records(lockfile)$egg
+  egg <- renv_lockfile_records(lockfile)$egg
 
-  expect_identical(rec_record$Repository, "CRAN")
-  expect_null(rec_record$Name)
+  expect_identical(egg$Repository, "CRAN")
+  expect_null(egg$Name)
 
 })

--- a/tests/testthat/test-record.R
+++ b/tests/testthat/test-record.R
@@ -100,3 +100,22 @@ test_that("record(enrich = FALSE) keeps minimal records", {
   )
 
 })
+
+test_that("record() stores Repository as the named form, not the URL", {
+
+  # version-pinned specs skip the 'latest' branch in
+  # renv_remotes_resolve_repository(), so the resolved record has no
+  # Repository field. enrichment must still produce the named form (e.g.
+  # 'CRAN') that snapshot() writes -- otherwise status() will report a
+  # spurious repo mismatch against an installed library.
+  renv_tests_scope("egg")
+  init()
+  record("egg@2.0.0")
+
+  lockfile <- renv_lockfile_read("renv.lock")
+  rec_record <- renv_lockfile_records(lockfile)$egg
+
+  expect_identical(rec_record$Repository, "CRAN")
+  expect_null(rec_record$Name)
+
+})

--- a/tests/testthat/test-record.R
+++ b/tests/testthat/test-record.R
@@ -53,3 +53,50 @@ test_that("record(<package>) also records version", {
   expect_identical(breakfast$Version, "1.0.0")
 
 })
+
+test_that("record() enriches resolved records with DESCRIPTION fields", {
+
+  renv_tests_scope("breakfast")
+  init()
+
+  # snapshot record (built from the installed DESCRIPTION) is the
+  # baseline for what an "enriched" record should look like
+  lockfile <- renv_lockfile_read("renv.lock")
+  snap_record <- renv_lockfile_records(lockfile)$breakfast
+
+  record("breakfast")
+
+  lockfile <- renv_lockfile_read("renv.lock")
+  rec_record <- renv_lockfile_records(lockfile)$breakfast
+
+  # record() must produce more than the minimal four fields
+  minimal <- c("Package", "Version", "Source", "Repository")
+  expect_true(length(setdiff(names(rec_record), minimal)) > 0L)
+
+  # the standard PACKAGES-derived dep / license fields should be present
+  # and agree with what snapshot() wrote
+  shared <- c("Package", "Version", "Source", "Repository",
+              "Depends", "Suggests", "License")
+  shared <- intersect(shared, names(snap_record))
+  for (field in shared)
+    expect_identical(rec_record[[field]], snap_record[[field]],
+                     info = sprintf("field '%s' differs", field))
+
+})
+
+test_that("record(enrich = FALSE) keeps minimal records", {
+
+  renv_tests_scope("breakfast")
+  init()
+
+  record("breakfast", enrich = FALSE)
+
+  lockfile <- renv_lockfile_read("renv.lock")
+  rec_record <- renv_lockfile_records(lockfile)$breakfast
+
+  expect_setequal(
+    names(rec_record),
+    c("Package", "Version", "Source", "Repository")
+  )
+
+})


### PR DESCRIPTION
## Summary

- `record()` previously produced a minimal four-field record (`Package`, `Version`, `Source`, `Repository`) for repository-sourced packages, diverging from `snapshot()` which writes the full set of DESCRIPTION-derived fields introduced in #2059 (`Depends`, `Imports`, `Suggests`, `LinkingTo`, `License`, etc.).
- `record()` now enriches each resolved record via the existing `renv_graph_description()` infrastructure (the same fetcher used by graph resolution) and runs the result through `renv_snapshot_description_impl_v2()` so the field shape matches `snapshot()`. Repository / Bioconductor sources go through `available.packages` + crandb fallback; GitHub / GitLab / Bitbucket / git fetch DESCRIPTION at the resolved ref.
- The local library is never consulted (we always trust the remote DESCRIPTION). Unreachable sources are a hard error. `Hash` is not computed for enriched records. Set `enrich = FALSE` to opt back into the previous minimal-record behavior.

Fixes #2294.

## Notes / limitations

DESCRIPTION-only fields like `Title`, `Description`, `Author`, `Maintainer` are not present in the standard `PACKAGES` index, so they are filled in only when the source can supply them -- e.g. when crandb is reachable for CRAN packages, or when the source is a Git host. This is documented in `?record`.

## Test plan

- [x] `devtools::test(filter = "record")` -- 41 PASS (includes two new tests)
- [x] `devtools::test(filter = "snapshot")` -- 76 PASS (2 pre-existing skips)
- [x] `devtools::test(filter = "lockfile")` -- 30 PASS
- [x] `devtools::test(filter = "graph")` -- 189 PASS
- [ ] Wider CI run via GitHub Actions