### PR TITLE
treat rsconnect folder as dev dependency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # renv (development version)
 
+* The presence of an `rsconnect/` folder in a project is now treated as a
+  development dependency on the `rsconnect` package, rather than a runtime
+  dependency. This means `rsconnect` will no longer be automatically
+  recorded by `renv::snapshot()` unless the project actually uses it at
+  run time (or `settings$snapshot.dev(TRUE)` is set). (#2290)
+
 * Fixed a regression where `renv::restore()` and `renv::install()` would
   re-download packages that were already installed in the user or site
   library, instead of reusing the existing installation. (#2288)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -725,7 +725,7 @@ renv_dependencies_discover_plumber_server <- function(path) {
 }
 
 renv_dependencies_discover_rsconnect <- function(path) {
-  renv_dependencies_list(path, "rsconnect")
+  renv_dependencies_list(path, "rsconnect", dev = TRUE)
 }
 
 renv_dependencies_discover_multimode <- function(path, mode) {

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -121,11 +121,19 @@ test_that("renv_dependencies_requires warns once", {
   expect_false(renv_dependencies_require("nosuchpackage", "test"))
 })
 
-test_that("the presence of an rsconnect folder forces dependency on rsconnect", {
+test_that("an rsconnect folder infers a dev dependency on rsconnect", {
   renv_tests_scope()
   dir.create("rsconnect")
+
+  # rsconnect is treated as a dev dependency, so it is not picked up by
+  # default
   deps <- dependencies()
+  expect_false("rsconnect" %in% deps$Package)
+
+  # but it is picked up when dev dependencies are requested
+  deps <- dependencies(dev = TRUE)
   expect_true("rsconnect" %in% deps$Package)
+  expect_true(deps$Dev[deps$Package == "rsconnect"])
 })
 
 test_that("dependencies can accept multiple files", {


### PR DESCRIPTION
## Summary

- An `rsconnect/` folder in a project is usually just used for
  deployment, so infer a development dependency on the `rsconnect`
  package rather than a runtime dependency.
- `rsconnect` is now only auto-discovered when callers request dev
  dependencies (e.g. via `dependencies(dev = TRUE)`, or when
  `settings$snapshot.dev(TRUE)` is set).
- Fixes #2290.

## Test plan

- [x] Updated `test-dependencies.R` to assert rsconnect is excluded by
  default and included (with `Dev == TRUE`) under `dev = TRUE`.
- [x] `devtools::test(filter = "dependencies")` passes locally.