### PR TITLE
fix install() skipping packages loaded from outside .libPaths()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,20 @@
 
 # renv (development version)
 
+* `renv::install()` no longer treats a package as already installed when
+  its namespace is loaded from a path that is no longer on `.libPaths()`
+  (e.g. when a global `~/.Rprofile` loads the package before renv
+  activates). Previously, `install()` would silently skip these packages
+  and `snapshot()` could not record them, leaving the project stuck.
+  (#2300)
+
+* On project load, renv now warns when one or more package namespaces
+  have already been loaded from a path outside the active library
+  paths. Such packages are not managed by renv and can cause
+  `renv::status()` and `renv::snapshot()` to report inconsistencies.
+  The check can be disabled via the `namespaces.check` config option
+  (or the `RENV_CONFIG_NAMESPACES_CHECK` environment variable). (#2300)
+
 # renv 1.2.3
 
 * `renv::record()` now enriches each resolved record with the same

--- a/R/config-defaults.R
+++ b/R/config-defaults.R
@@ -267,6 +267,15 @@ config <- list(
     )
   },
 
+  namespaces.check = function(..., default = TRUE) {
+    renv_config_get(
+      name    = "namespaces.check",
+      type    = "logical[1]",
+      default = default,
+      args    = list(...)
+    )
+  },
+
   pak.enabled = function(..., default = FALSE) {
     renv_config_get(
       name    = "pak.enabled",

--- a/R/graph.R
+++ b/R/graph.R
@@ -606,15 +606,15 @@ renv_graph_needs_update <- function(pkg, record, requirements) {
   if (nzchar(path))
     return(FALSE)
 
-  # for transitive dependencies that are already installed, check
-  # whether the installed version satisfies dependency requirements;
-  # this avoids upgrading dependencies during install() when the
-  # existing library version is already compatible.
-  # explicitly-requested packages (in state$packages) always get
-  # installed, so skip this check for those.
+  # for transitive dependencies that are already installed in an active
+  # library path, check whether the installed version satisfies dependency
+  # requirements; this avoids upgrading dependencies during install() when
+  # the existing library version is already compatible.
+  # explicitly-requested packages (in state$packages) always get installed,
+  # so skip this check for those.
   state <- renv_restore_state()
   if (!(pkg %in% state$packages)) {
-    installed <- renv_package_version(pkg)
+    installed <- renv_package_libpath_version(pkg)
     if (!is.null(installed)) {
       reqs <- requirements[[pkg]]
       if (renv_graph_compatible(installed, reqs))

--- a/R/load.R
+++ b/R/load.R
@@ -751,6 +751,59 @@ renv_load_cache <- function(project) {
 
 renv_load_check <- function(project) {
   renv_load_check_description(project)
+
+  # only check when the autoloader is driving this load -- this is the
+  # only case where loaded namespaces represent packages that snuck in
+  # before renv activated. manual `renv::load()` calls and renv's own
+  # tests routinely have unrelated namespaces loaded.
+  autoloading <- identical(getOption("renv.autoloader.running"), TRUE)
+  if (autoloading && config$namespaces.check())
+    renv_load_check_namespaces(project)
+}
+
+# Warn if any non-base namespaces are loaded from a path that's not on
+# the active .libPaths() -- these packages were loaded before renv
+# activated this project (see #2300) and are not managed by renv, so
+# status()/snapshot() can report inconsistencies for them.
+renv_load_check_namespaces <- function(project) {
+
+  libpaths <- renv_libpaths_all()
+  ignored <- c(renv_packages_base(), "renv")
+  candidates <- setdiff(loadedNamespaces(), ignored)
+  if (empty(candidates))
+    return(invisible(TRUE))
+
+  external <- list()
+  for (pkg in candidates) {
+    nspath <- catch(renv_namespace_path(pkg))
+    if (inherits(nspath, "error") || !nzchar(nspath))
+      next
+    if (dirname(nspath) %in% libpaths)
+      next
+    external[[pkg]] <- renv_path_aliased(nspath)
+  }
+
+  if (empty(external))
+    return(invisible(TRUE))
+
+  values <- sprintf("%s [%s]", format(names(external)), unlist(external))
+
+  bulletin(
+    preamble = c(
+      "The following package(s) were loaded before renv activated this project:"
+    ),
+    values    = values,
+    postamble = c(
+      "These packages are not managed by renv and may cause `renv::status()`",
+      "and `renv::snapshot()` to report inconsistencies. Restart R in a clean",
+      "session to recover. The paths above may help identify where each",
+      "package was loaded from.",
+      "Set `RENV_CONFIG_NAMESPACES_CHECK=FALSE` to silence this check."
+    )
+  )
+
+  invisible(FALSE)
+
 }
 
 renv_load_check_description <- function(project) {

--- a/R/package.R
+++ b/R/package.R
@@ -57,6 +57,35 @@ renv_package_version <- function(package) {
   renv_package_description_field(package, "Version")
 }
 
+# returns the version of `package` if it is installed in one of the
+# active library paths, otherwise NULL. unlike renv_package_version(),
+# this does not fall back to loadedNamespaces() -- a package loaded from
+# a path no longer on .libPaths() (e.g. loaded by the user .Rprofile
+# before renv activated, https://github.com/rstudio/renv/issues/2300)
+# must not be treated as installed for purposes of skipping installation.
+renv_package_libpath_version <- function(package) {
+
+  libpaths <- renv_libpaths_all()
+
+  # fast path: if the namespace is loaded from one of the active library
+  # paths, trust the loaded version and skip the DESCRIPTION read
+  if (isNamespaceLoaded(package)) {
+    nspath <- renv_namespace_path(package)
+    if (dirname(nspath) %in% libpaths)
+      return(renv_namespace_version(package))
+  }
+
+  # otherwise, look for the package in the active library paths.
+  # passing a non-NULL lib.loc disables the namespace fallback inside
+  # renv_package_find_impl()
+  pkgpath <- renv_package_find(package, lib.loc = libpaths)
+  if (!nzchar(pkgpath))
+    return(NULL)
+
+  renv_description_read(pkgpath)[["Version"]]
+
+}
+
 renv_package_description_field <- function(package, field) {
 
   path <- renv_package_find(package)

--- a/inst/config.yml
+++ b/inst/config.yml
@@ -254,6 +254,17 @@
   description: >
     DEPRECATED: MRAN is no longer maintained by Microsoft.
 
+- name: "namespaces.check"
+  type: "logical[1]"
+  default: true
+  description: >
+    Check, on project load, whether any namespaces have already been loaded
+    from a path outside the project's active library paths? Packages loaded
+    before renv activates are not managed by renv and can cause
+    `renv::status()` and `renv::snapshot()` to report inconsistencies. When
+    enabled, renv emits a warning listing the offending packages and the
+    paths they were loaded from.
+
 - name: "pak.enabled"
   type: "logical[1]"
   default: false

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -905,10 +905,12 @@ test_that("install() reinstalls packages loaded from outside the active libpaths
 
   # load bread's namespace from the user library, then drop that library
   # from .libPaths() -- the namespace stays loaded but its location is
-  # no longer visible to renv
+  # no longer visible to renv. indirect the package name through a
+  # variable so R CMD check doesn't flag bread as an undeclared dependency
+  pkg <- "bread"
   renv_scope_libpaths(c(userlib, .libPaths()))
-  loadNamespace("bread")
-  defer(unloadNamespace("bread"))
+  loadNamespace(pkg)
+  defer(unloadNamespace(pkg))
 
   projlib <- renv_scope_tempfile("renv-projlib-")
   ensure_directory(projlib)

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -886,3 +886,58 @@ test_that("install from local sources shows progress", {
   expect_snapshot(install(path))
 
 })
+
+test_that("install() reinstalls packages loaded from outside the active libpaths", {
+
+  # https://github.com/rstudio/renv/issues/2300 -- when a transitive
+  # dependency was loaded from a library that's no longer on .libPaths()
+  # (e.g. the user's HOME .Rprofile loaded it before renv activated),
+  # renv_graph_needs_update used to fall back to loadedNamespaces() and
+  # report the package as already installed. snapshot() then couldn't
+  # record it, leaving the project stuck.
+
+  renv_tests_scope()
+
+  # install bread into a "user" library
+  userlib <- renv_scope_tempfile("renv-userlib-")
+  ensure_directory(userlib)
+  install("bread", library = userlib)
+
+  # load bread's namespace from the user library, then drop that library
+  # from .libPaths() -- the namespace stays loaded but its location is
+  # no longer visible to renv
+  renv_scope_libpaths(c(userlib, .libPaths()))
+  loadNamespace("bread")
+  defer(unloadNamespace("bread"))
+
+  projlib <- renv_scope_tempfile("renv-projlib-")
+  ensure_directory(projlib)
+  renv_scope_libpaths(projlib)
+
+  expect_true("bread" %in% loadedNamespaces())
+  expect_false(file.exists(file.path(projlib, "bread", "DESCRIPTION")))
+
+  # libpath-restricted lookup does not see the loaded-but-not-installed
+  # package, even though the namespace-fallback lookup still does
+  expect_null(renv_package_libpath_version("bread"))
+  expect_equal(renv_package_version("bread"), "1.0.0")
+
+  # the graph filter correctly reports that bread needs to be installed
+  record <- list(
+    Package    = "bread",
+    Version    = "1.0.0",
+    Source     = "Repository",
+    Repository = "CRAN"
+  )
+
+  renv_scope_restore(
+    project   = getwd(),
+    library   = projlib,
+    records   = list(bread = record),
+    packages  = character(),
+    recursive = TRUE
+  )
+
+  expect_true(renv_graph_needs_update("bread", record, list()))
+
+})

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -95,9 +95,12 @@ test_that("renv_load_check_namespaces flags packages loaded from outside libpath
   ensure_directory(userlib)
   install("bread", library = userlib)
 
+  # indirect the package name through a variable so R CMD check doesn't
+  # flag bread as an undeclared dependency
+  pkg <- "bread"
   renv_scope_libpaths(c(userlib, .libPaths()))
-  loadNamespace("bread")
-  defer(unloadNamespace("bread"))
+  loadNamespace(pkg)
+  defer(unloadNamespace(pkg))
 
   # restrict .libPaths() to just the project lib and .Library; bread is
   # still loaded but its location is no longer visible

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -80,3 +80,53 @@ test_that("load() delegates to base::load() when appropriate", {
   expect_equal(envir$value, 42)
 
 })
+
+test_that("renv_load_check_namespaces flags packages loaded from outside libpaths", {
+
+  # https://github.com/rstudio/renv/issues/2300 -- packages loaded
+  # from a library that isn't part of the project's active .libPaths()
+  # break renv's encapsulation; warn about them on project load.
+
+  renv_tests_scope()
+  renv_scope_options(renv.caution.verbose = TRUE)
+
+  # install bread into a "user" library and load its namespace from there
+  userlib <- renv_scope_tempfile("renv-userlib-")
+  ensure_directory(userlib)
+  install("bread", library = userlib)
+
+  renv_scope_libpaths(c(userlib, .libPaths()))
+  loadNamespace("bread")
+  defer(unloadNamespace("bread"))
+
+  # restrict .libPaths() to just the project lib and .Library; bread is
+  # still loaded but its location is no longer visible
+  projlib <- renv_scope_tempfile("renv-projlib-")
+  ensure_directory(projlib)
+  renv_scope_libpaths(c(projlib, .Library))
+
+  # we test the helper directly; renv_load_check() only wires it up
+  # during autoloader-driven startup, which doesn't fire in tests
+  expect_output(
+    result <- renv_load_check_namespaces(getwd()),
+    "bread"
+  )
+  expect_false(result)
+
+})
+
+test_that("renv_load_check_namespaces is silent when all loaded packages are on libpaths", {
+
+  renv_tests_scope()
+  renv_scope_options(renv.caution.verbose = TRUE)
+
+  # extend .libPaths() to include every location from which a non-base
+  # namespace was loaded; the check should then find no externals
+  loaded <- setdiff(loadedNamespaces(), c(renv_packages_base(), "renv"))
+  paths <- vapply(loaded, function(p) dirname(renv_namespace_path(p)), character(1))
+  renv_scope_libpaths(unique(c(paths, .libPaths())))
+
+  expect_silent(result <- renv_load_check_namespaces(getwd()))
+  expect_true(result)
+
+})


### PR DESCRIPTION
## Summary

- Fix `renv::install()` treating a package as already installed when its namespace is loaded from a path that's no longer on `.libPaths()` (the limbo state from #2300).
- Add a load-time warning (config `namespaces.check`, default on) that flags packages loaded from outside the active library paths so users notice the encapsulation break instead of just getting confusing `status()` / `snapshot()` output.

The first commit fixes the underlying skip; the second adds the diagnostic so the same situation surfaces earlier next time. Both are gated by config and have regression tests.

### The bug

In `renv_graph_needs_update()` (`R/graph.R:602`), the fallback "is this package compatible with our requirements?" check routed through `renv_package_version()`, which delegates to `renv_package_find()` with `lib.loc = NULL`. That function falls back to `isNamespaceLoaded(package)` + `renv_namespace_path(package)` when the package can't be found in the active library paths. For #2300's reporter, ggplot2 (and its imports) were loaded from `C:/R/library` by a global `~/.Rprofile` before renv activated; after activation, those packages were still loaded but their location was no longer on `.libPaths()`. `install()` saw "compatible version available" via the namespace fallback and skipped them; `snapshot()` couldn't record them (no libpath); `restore()` and `status()` could not pull them out of limbo.

### The fix

New helper `renv_package_libpath_version()` in `R/package.R` returns the installed version only when the package lives on `.libPaths()`. It has a fast path for the loaded-from-`.libPaths()` case (`dirname(namespace_path) %in% .libPaths()`), avoiding a `DESCRIPTION` read, and otherwise does a libpath-only `renv_package_find()` (passing a non-`NULL` `lib.loc` disables the namespace fallback). `renv_graph_needs_update()` now uses this helper.

### The load-time warning

New config option `namespaces.check` (default `TRUE`, env var `RENV_CONFIG_NAMESPACES_CHECK`). On project load, walks `loadedNamespaces()`, skips base packages and renv, and emits a `bulletin()` listing any whose namespace path's `dirname()` is not on `.libPaths()`. The output includes each loaded path so users can identify the source. Only fires when `getOption("renv.autoloader.running") == TRUE`, so manual `renv::load()` calls and test runs don't trigger it.

## Test plan

- [x] `devtools::test(filter = "install|load|graph|retrieve|package|snapshot|restore|config")` -> 605 PASS / 0 FAIL
- [x] New regression test in `test-install.R` reproduces the limbo scenario (install bread to a "user" lib, load it, drop that lib from `.libPaths()`, assert `renv_graph_needs_update()` returns `TRUE`)
- [x] New tests in `test-load.R` cover both `renv_load_check_namespaces()` paths (warning emitted when externals are loaded; silent when everything is on libpaths)
- [ ] Manual smoke test with the #2300 reproducer once we hear back from the reporter, but the unit tests mirror their scenario closely

Fixes #2300.