### PR TITLE
fix install(type = "source") installing binaries from ppm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # renv (development version)
 
+* `renv::install(<package>, type = "source")` once again installs from
+  source when a binary Posit Package Manager (PPM) repository is
+  configured. Previously, the dependency graph was resolved against the
+  un-transformed (binary) repository URL, so a binary package could be
+  installed even though source was requested. (#2303)
+
 * `renv::install()` no longer treats a package as already installed when
   its namespace is loaded from a path that is no longer on `.libPaths()`
   (e.g. when a global `~/.Rprofile` loads the package before renv

--- a/R/graph.R
+++ b/R/graph.R
@@ -1,6 +1,12 @@
 
 renv_graph_init <- function(remotes, records = list(), project = NULL, scope = parent.frame()) {
 
+  # set up the retrieve environment (repos, PPM transform, user agent) before
+  # resolving descriptions; otherwise resolution queries the un-transformed
+  # repositories and may pin packages to a binary PPM URL even when the user
+  # requested type = "source" (#2303)
+  renv_graph_scope_retrieve(scope = scope)
+
   # create an environment to track resolved descriptions (avoids cycles/dupes)
   project <- project %||% renv_project_resolve()
   envir <- new.env(parent = emptyenv())

--- a/R/graph.R
+++ b/R/graph.R
@@ -1,11 +1,11 @@
 
 renv_graph_init <- function(remotes, records = list(), project = NULL, scope = parent.frame()) {
 
-  # set up the retrieve environment (repos, PPM transform, user agent) before
+  # set up the repository environment (repos, PPM transform, user agent) before
   # resolving descriptions; otherwise resolution queries the un-transformed
   # repositories and may pin packages to a binary PPM URL even when the user
   # requested type = "source" (#2303)
-  renv_graph_scope_retrieve(scope = scope)
+  renv_graph_scope_setup(scope = scope)
 
   # create an environment to track resolved descriptions (avoids cycles/dupes)
   project <- project %||% renv_project_resolve()
@@ -992,10 +992,11 @@ renv_graph_url_cellar <- function(desc) {
 
 }
 
-renv_graph_scope_retrieve <- function(scope = parent.frame()) {
+renv_graph_scope_setup <- function(scope = parent.frame()) {
 
-  # prepare retrieve environment (repos, PPM, user agent);
-  # this setup is normally done inside renv_retrieve_impl —
+  # prepare the repository environment (repos, PPM, user agent) used when
+  # querying package repositories during both resolution and retrieval;
+  # this setup is also done inside renv_retrieve_impl --
   # we replicate it here so parallel / forked processes inherit these options
   repos <- renv_repos_normalize()
   if (renv_ppm_enabled())
@@ -1028,7 +1029,7 @@ renv_graph_install <- function(descriptions) {
     recursive = FALSE
   )
 
-  renv_graph_scope_retrieve()
+  renv_graph_scope_setup()
 
   # prepare install environment (inherited by subprocesses)
   rlibs <- paste(renv_libpaths_all(), collapse = .Platform$path.sep)

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -1069,6 +1069,49 @@ test_that("renv_graph_description_repository respects install_pkg_type", {
 
 })
 
+# https://github.com/rstudio/renv/issues/2303
+test_that("renv_graph_init normalizes PPM URLs when installing from source", {
+
+  skip_on_cran()
+
+  renv_tests_scope()
+
+  # pretend to be Ubuntu so PPM transformation kicks in
+  renv_scope_envvars(
+    RENV_PPM_OS = "__linux__",
+    RENV_PPM_PLATFORM = "jammy"
+  )
+
+  # use a binary PPM URL as the active repository
+  binurl <- "https://packagemanager.posit.co/cran/__linux__/jammy/latest"
+  renv_scope_options(repos = c(CRAN = binurl))
+
+  # simulate install(..., type = "source")
+  renv_scope_binding(the, "install_pkg_type", "source")
+
+  # capture the repositories seen during description resolution
+  env <- new.env(parent = emptyenv())
+  env$repos <- character()
+
+  renv_scope_trace(
+    what   = renv:::renv_available_packages_entry,
+    tracer = bquote({
+      .env <- .(env)
+      .env$repos <- c(.env$repos, repos %||% getOption("repos"))
+    })
+  )
+
+  # resolution will fail (the URL isn't reachable in tests); we only care
+  # about the repositories that were queried during graph resolution
+  catch(renv_graph_init("bread", project = tempfile()))
+
+  # the binary segment should have been stripped before resolution, so a
+  # source package is resolved rather than a binary one
+  expect_true(length(env$repos) > 0L)
+  expect_false(any(grepl("__linux__", env$repos)))
+
+})
+
 # https://github.com/rstudio/renv/issues/2278
 test_that("repository graph prefers crandb over latest-with-overridden-version", {
 


### PR DESCRIPTION
Fixes #2303.

## Problem

`renv::install("KernSmooth", type = "source")` installs a binary instead of source when a binary Posit Package Manager (PPM) repository is configured. This is a regression from the graph-based parallel install (#2224), which shipped in 1.2.3.

## Root cause

renv normalizes binary PPM URLs to source URLs (stripping the `/__linux__/<platform>/` segment) via `renv_ppm_transform()` whenever `the$install_pkg_type == "source"`. That transform was only applied in `renv_graph_scope_retrieve()`, which runs inside `renv_graph_install()` -- the *download* phase.

The *resolution* phase (`renv_graph_init()`) builds the dependency graph and pins each package's `Repository` field **before** any PPM transform, so it queries the un-transformed binary URL. Since PPM serves binaries at that URL's `src/contrib` path, the package is resolved/tagged from the binary repo and the installer ends up installing a binary despite `type = "source"`.

Confirmed via tracing `renv_available_packages_entry`:

```
install_pkg_type: source
repos passed to available_packages_entry:
  CRAN: "https://packagemanager.posit.co/cran/__linux__/jammy/latest"   # binary
```

## Fix

Apply the retrieve scope (including the PPM transform) at the start of `renv_graph_init()`, so resolution uses the same source-normalized repos as the download phase. This mirrors the pre-graph `renv_retrieve_impl()`, which transformed repos before resolving. After the fix the same trace shows `https://packagemanager.posit.co/cran/latest`.

## Testing

- New regression test in `test-graph.R` (verified it fails without the fix, passes with it).
- `graph`, `ppm`, `install`, and `restore` suites all pass.