### PR TITLE
guard dcf/properties readers against pcre utf mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # renv (development version)
 
+* renv's internal DCF and properties readers now match their (ASCII)
+  regular expressions with `useBytes = TRUE`. This avoids forcing PCRE
+  into UTF mode, which could fail with "this version of PCRE is compiled
+  without UTF support" -- in some environments preventing renv from even
+  loading -- when R is linked against a PCRE library lacking UTF support
+  or left in a state where it believes UTF is unsupported.
+
 * `renv::install(<package>, type = "source")` once again installs from
   source when a binary Posit Package Manager (PPM) repository is
   configured. Previously, the dependency graph was resolved against the

--- a/R/dcf.R
+++ b/R/dcf.R
@@ -9,10 +9,18 @@ renv_dcf_read <- function(file, text = NULL, ...) {
   contents <- text %||% renv_dcf_read_impl(file, ...)
 
   # split on newlines
-  parts <- strsplit(contents, "\\r?\\n(?=\\S)", perl = TRUE)[[1L]]
+  #
+  # NOTE: we use 'useBytes = TRUE' here to avoid forcing PCRE into UTF mode,
+  # which can fail when R is linked against a PCRE library compiled without
+  # UTF support (or left in a bad state where it believes this is the case).
+  # the patterns are pure ASCII, and operating on bytes is safe for UTF-8
+  # content (continuation bytes are non-whitespace), so we just re-declare
+  # the encoding afterwards.
+  parts <- strsplit(contents, "\\r?\\n(?=\\S)", perl = TRUE, useBytes = TRUE)[[1L]]
 
   # remove embedded newlines
-  parts <- gsub("\\r?\\n\\s*", " ", parts, perl = TRUE)
+  parts <- gsub("\\r?\\n\\s*", " ", parts, perl = TRUE, useBytes = TRUE)
+  Encoding(parts) <- "UTF-8"
 
   # split into key / value pairs
   index <- regexpr(":", parts, fixed = TRUE)

--- a/R/dcf.R
+++ b/R/dcf.R
@@ -8,19 +8,20 @@ renv_dcf_read <- function(file, text = NULL, ...) {
   # read file
   contents <- text %||% renv_dcf_read_impl(file, ...)
 
+  # NOTE: we use 'useBytes = TRUE' for the perl regexps below to avoid forcing
+  # PCRE into UTF mode, which can fail when R is linked against a PCRE library
+  # compiled without UTF support (or left in a bad state where it believes this
+  # is the case). the patterns are pure ASCII, and operating on bytes is safe
+  # for UTF-8 content (continuation bytes are non-whitespace), so we just
+  # preserve the original encoding afterwards. see also renv_properties_read().
+  encoding <- Encoding(contents)
+
   # split on newlines
-  #
-  # NOTE: we use 'useBytes = TRUE' here to avoid forcing PCRE into UTF mode,
-  # which can fail when R is linked against a PCRE library compiled without
-  # UTF support (or left in a bad state where it believes this is the case).
-  # the patterns are pure ASCII, and operating on bytes is safe for UTF-8
-  # content (continuation bytes are non-whitespace), so we just re-declare
-  # the encoding afterwards.
   parts <- strsplit(contents, "\\r?\\n(?=\\S)", perl = TRUE, useBytes = TRUE)[[1L]]
 
   # remove embedded newlines
   parts <- gsub("\\r?\\n\\s*", " ", parts, perl = TRUE, useBytes = TRUE)
-  Encoding(parts) <- "UTF-8"
+  Encoding(parts) <- encoding
 
   # split into key / value pairs
   index <- regexpr(":", parts, fixed = TRUE)

--- a/R/properties.R
+++ b/R/properties.R
@@ -10,11 +10,19 @@ renv_properties_read <- function(path = NULL,
   # read file
   contents <- paste(text %||% readLines(path, warn = FALSE), collapse = "\n")
 
+  # NOTE: we use 'useBytes = TRUE' for the perl regexps below to avoid forcing
+  # PCRE into UTF mode, which can fail when R is linked against a PCRE library
+  # compiled without UTF support. the patterns are pure ASCII and operate on
+  # ASCII structure (newlines, comment markers), so byte-wise matching is safe;
+  # we just preserve the original encoding afterwards. see also renv_dcf_read().
+  encoding <- Encoding(contents)
+
   # split on newlines; allow spaces to continue a value
-  parts <- strsplit(contents, "\\n(?=\\S)", perl = TRUE)[[1L]]
+  parts <- strsplit(contents, "\\n(?=\\S)", perl = TRUE, useBytes = TRUE)[[1L]]
+  Encoding(parts) <- encoding
 
   # remove comments and blank lines
-  parts <- grep("^\\s*(?:#|$)", parts, perl = TRUE, value = TRUE, invert = TRUE)
+  parts <- grep("^\\s*(?:#|$)", parts, perl = TRUE, value = TRUE, invert = TRUE, useBytes = TRUE)
 
   # split into key / value pairs
   index <- regexpr(delimiter, parts, fixed = TRUE)
@@ -30,7 +38,8 @@ renv_properties_read <- function(path = NULL,
   # trim whitespace when requested
   if (trim) {
     keys <- trimws(keys)
-    vals <- gsub("\n\\s*", " ", trimws(vals), perl = TRUE)
+    vals <- gsub("\n\\s*", " ", trimws(vals), perl = TRUE, useBytes = TRUE)
+    Encoding(vals) <- encoding
   }
 
   # strip quotes if requested

--- a/tests/testthat/test-dcf.R
+++ b/tests/testthat/test-dcf.R
@@ -38,6 +38,18 @@ test_that("we can read a latin-1 DESCRIPTION file", {
 
 })
 
+test_that("we can read latin-1 content passed via 'text'", {
+
+  # a caller may pass non-UTF-8 'text' directly; make sure we preserve its
+  # encoding rather than forcing UTF-8 (which would mis-mark the bytes)
+  contents <- "Dessert: crème brûlée"
+  latin1 <- iconv(enc2utf8(contents), from = "UTF-8", to = "latin1")
+
+  dcf <- renv_dcf_read(text = latin1)
+  expect_equal(dcf$Dessert, "crème brûlée")
+
+})
+
 test_that("we can read a custom encoded DESCRIPTION file", {
 
   skip_if(!"CP936" %in% iconvlist())


### PR DESCRIPTION
## Problem

On some systems, loading renv fails at `.onLoad()` with:

```
PCRE pattern compilation error
'this version of PCRE is compiled without UTF support'
at '\r?\n(?=\S)'
```

The failing pattern lives in `renv_dcf_read()`, which runs during
`.onLoad()` (reading renv's own `DESCRIPTION`), so the package cannot load
at all.

## Cause

`renv_dcf_read_impl()` returns `contents` marked as UTF-8 (via
`iconv(..., to = "UTF-8")`). When `strsplit(..., perl = TRUE)` runs on a
UTF-8-marked subject, R compiles the PCRE pattern in UTF mode. If R is
linked against a PCRE library built without UTF support -- or left in a
state where it believes UTF is unsupported -- the compile fails. This has
been observed for R 3.6.x under interactive RStudio sessions, where the
session can be left in such a state before the first console command.

This is not specific to `strsplit`: every `perl = TRUE` regex shares the
same `use_UTF8` -> `PCRE2_UTF` compile path. The trigger is a non-ASCII /
UTF-8-marked *subject*, not the particular function. renv's other
`perl = TRUE` calls operate on structurally-ASCII inputs (package names,
versions, configure flags, DCF field names), so R auto-selects byte mode
for them and they are unaffected. The only calls that parse free-form,
possibly-non-ASCII content are the two DCF/properties readers.

## Fix

Match the (pure-ASCII) patterns in `renv_dcf_read()` and
`renv_properties_read()` with `useBytes = TRUE`. This keeps PCRE in byte
mode and never requests UTF support. Byte-wise matching is correct here --
the patterns only match ASCII structure (newlines, delimiters, comment
markers), and UTF-8 continuation bytes are non-whitespace, so the
`(?=\S)` lookahead behaves identically. The original encoding is
re-declared on the results so non-ASCII field values (e.g. author names)
round-trip correctly.

## Testing

- Existing `test-dcf.R`, `test-properties.R`, `test-description.R` pass.
- Verified manually that non-ASCII content (e.g. `Tomáš`, `Café`)
  round-trips with the correct UTF-8 encoding and that continuation lines
  still join.
