### PR TITLE
don't treat biocViews as proof of bioconductor origin

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,19 @@
 
 # renv (development version)
 
+* renv no longer treats the mere presence of a `biocViews` field in a
+  package's `DESCRIPTION` as proof that the package came from Bioconductor.
+  Some CRAN packages declare `biocViews`, and Posit Package Manager can serve
+  Bioconductor packages from a CRAN-like "R repository"; in both cases renv
+  now uses the `Repository` field (and Bioconductor git provenance) to decide
+  where a package was obtained, so such packages are recorded as repository
+  packages and restored from the repository they came from. (#2128)
+
+* A new project setting, `settings$bioconductor.enabled()`, can be set to
+  `FALSE` to opt a project out of Bioconductor entirely. When disabled, renv
+  will not infer a Bioconductor source, activate Bioconductor repositories, or
+  write a Bioconductor entry into the lockfile. (#2128)
+
 * renv's internal DCF and properties readers now match their (ASCII)
   regular expressions with `useBytes = TRUE`. This avoids forcing PCRE
   into UTF mode, which could fail with "this version of PCRE is compiled

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -43,6 +43,18 @@ renv_description_bioconductor <- function(dcf) {
     if (grepl("Bioconductor", repository, ignore.case = TRUE))
       return(TRUE)
 
+    # otherwise, a 'Repository' that names CRAN, a known CRAN mirror, or one of
+    # the active repositories means the package came from there rather than from
+    # Bioconductor.
+    #
+    # NOTE: this repository-recognition logic parallels the matching done in
+    # renv_snapshot_description_source_custom(); the two are intentionally kept
+    # separate because they disagree on the bare name "CRAN". here we *trust*
+    # 'Repository: CRAN' as proof of CRAN origin, whereas _source_custom()
+    # deliberately *distrusts* a "CRAN" RemoteReposName (older renv versions
+    # mislabelled non-CRAN repositories as 'CRAN'; see #2104). if these ever
+    # need to share an implementation, extract a helper parameterised on whether
+    # the "CRAN" name should be honoured, rather than collapsing them outright.
     if (identical(repository, "CRAN"))
       return(FALSE)
 

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -219,6 +219,40 @@ renv_bioconductor_version <- function(project, refresh = FALSE) {
 
 }
 
+# does Bioconductor support the version of R currently running?
+#
+# BiocManager maps each version of R to one or more Bioconductor releases, each
+# with a status ('release', 'devel', 'out-of-date', or 'future'). when R is
+# newer than any usable Bioconductor release -- for example, on R-devel before
+# Bioconductor has caught up -- the only entry for that version of R is a
+# 'future' release, which has no installable packages yet.
+renv_bioconductor_supported <- function() {
+
+  if (!renv_package_available("BiocManager"))
+    return(FALSE)
+
+  # read BiocManager's R-to-Bioconductor version map
+  map <- catch({
+    BiocManager <- renv_scope_biocmanager()
+    BiocManager$.version_map()
+  })
+
+  ok <-
+    !inherits(map, "error") &&
+    is.data.frame(map) &&
+    all(c("R", "BiocStatus") %in% names(map))
+
+  if (!ok)
+    return(FALSE)
+
+  # require an entry for the running version of R whose Bioconductor release has
+  # a usable status (anything other than 'future', which has no packages yet)
+  rversion <- paste(getRversion()[1L, 1L:2L])
+  matches <- as.character(map$R) == rversion & as.character(map$BiocStatus) != "future"
+  any(matches)
+
+}
+
 # Returns the union of the inferred Bioconductor repositories, together with the
 # current value of the 'repos' R option. The Bioconductor repositories are
 # placed first in the repository list.

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -6,6 +6,69 @@ renv_bioconductor_manager <- function() {
     "BiocInstaller"
 }
 
+# whether Bioconductor integration is enabled for this project; when disabled,
+# renv will not infer a Bioconductor source, activate Bioconductor repositories,
+# or write a Bioconductor entry into the lockfile
+# https://github.com/rstudio/renv/issues/2128
+renv_bioconductor_enabled <- function(project = NULL) {
+  settings$bioconductor.enabled(project = project)
+}
+
+# determine whether a package's DESCRIPTION genuinely indicates a Bioconductor
+# origin. historically renv treated the mere presence of a 'biocViews' field as
+# proof, but some CRAN packages also declare 'biocViews', and Posit Package
+# Manager can serve Bioconductor packages from a CRAN-like "R repository". what
+# matters for restore is where the package was *obtained* (the 'Repository'
+# field), not where it originally came from (its git provenance).
+# https://github.com/rstudio/renv/issues/2128
+renv_description_bioconductor <- function(dcf) {
+
+  # packages from Bioconductor are normally tagged with a 'biocViews' entry;
+  # without one, this cannot be a Bioconductor package
+  if (!nzchar(dcf[["biocViews"]] %||% ""))
+    return(FALSE)
+
+  # the 'Repository' field records where the package was obtained, and so takes
+  # precedence over git provenance. Bioconductor stamps 'Bioconductor <ver>'; a
+  # CRAN-like repository (CRAN, a known mirror, or one of the active repos --
+  # including PPM "R repositories" that serve Bioconductor in a CRAN-like
+  # layout) means the package should be restored from that repository instead.
+  repository <- dcf[["Repository"]] %||% ""
+  if (nzchar(repository)) {
+
+    # Bioconductor stamps the release into the 'Repository' field (e.g.
+    # 'Bioconductor 3.18'); Posit Package Manager Bioconductor repositories
+    # likewise include 'Bioconductor' in the stamp, possibly alongside a custom
+    # repository name, so match it anywhere in the field
+    if (grepl("Bioconductor", repository, ignore.case = TRUE))
+      return(TRUE)
+
+    if (identical(repository, "CRAN"))
+      return(FALSE)
+
+    mirrors <- renv_cran_mirrors()
+    if (any(renv_repos_matches(repository, mirrors)))
+      return(FALSE)
+
+    repos <- as.list(getOption("repos"))
+    if (repository %in% names(repos) || any(renv_repos_matches(repository, repos)))
+      return(FALSE)
+
+  }
+
+  # no informative 'Repository'; fall back to Bioconductor git provenance, which
+  # Bioconductor-built tarballs carry pointing at the Bioconductor git server
+  git_url <- dcf[["git_url"]] %||% ""
+  if (grepl("bioconductor", git_url, ignore.case = TRUE))
+    return(TRUE)
+
+  # 'biocViews' present with no contradicting signal; preserve the historical
+  # behaviour of trusting it (e.g. a sources install of a real Bioconductor
+  # package that was never stamped with provenance fields)
+  TRUE
+
+}
+
 renv_bioconductor_versions <- function() {
 
   # map versions of Bioconductor to the versions of R they can be used with

--- a/R/graph.R
+++ b/R/graph.R
@@ -40,18 +40,17 @@ renv_graph_init <- function(remotes, records = list(), project = NULL, scope = p
   }
 
   # if any resolved description indicates Bioconductor is needed (via Source
-  # or biocViews), activate Bioconductor repos for the rest of resolution
+  # or Bioconductor provenance), activate Bioconductor repos for the rest of
+  # resolution -- unless Bioconductor is disabled for this project
+  project <- renv_restore_state(key = "project") %||% renv_project_resolve()
   resolved <- as.list(envir)
-  bioc <- map_lgl(resolved, function(desc) {
+  bioc <- renv_bioconductor_enabled(project = project) && any(map_lgl(resolved, function(desc) {
     source <- renv_record_source(desc, normalize = TRUE)
-    biocviews <- desc[["biocViews"]] %||% ""
-    identical(source, "bioconductor") || nzchar(biocviews)
-  })
+    identical(source, "bioconductor") || renv_description_bioconductor(desc)
+  }))
 
-  if (any(bioc)) {
-    project <- renv_restore_state(key = "project") %||% renv_project_resolve()
+  if (bioc)
     renv_scope_bioconductor(project = project, scope = scope)
-  }
 
   # phase 2: resolve transitive dependencies with default fields
   idx <- 1L

--- a/R/install.R
+++ b/R/install.R
@@ -217,7 +217,7 @@ install <- function(packages = NULL,
 
   # add bioconductor packages if necessary; scope bioconductor repos
   # so they're available for transitive dependency resolution in graph_init
-  if (renv_bioconductor_required(remotes)) {
+  if (renv_bioconductor_enabled(project = project) && renv_bioconductor_required(remotes)) {
     renv_scope_bioconductor(project = project)
     bioc <- c(renv_bioconductor_manager(), "BiocVersion")
     packages <- unique(c(packages, bioc))

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -89,6 +89,11 @@ renv_lockfile_fini <- function(lockfile, project) {
 
 renv_lockfile_fini_bioconductor <- function(lockfile, project) {
 
+  # nothing to record when Bioconductor is disabled for this project
+  # https://github.com/rstudio/renv/issues/2128
+  if (!renv_bioconductor_enabled(project = project))
+    return(NULL)
+
   # check for explicit version in settings
   version <- settings$bioconductor.version(project = project)
   if (length(version))

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -1208,7 +1208,7 @@ renv_retrieve_successful <- function(record, path, install = TRUE) {
   if (state$recursive && nrow(strongdeps)) local({
 
     # make sure bioconductor repositories are active before install if necessary
-    if (nzchar(desc[["biocViews"]] %||% "")) {
+    if (renv_bioconductor_enabled() && renv_description_bioconductor(desc)) {
       repos <- renv_bioconductor_repos()
       renv_scope_options(repos = repos)
     }
@@ -1226,7 +1226,7 @@ renv_retrieve_successful <- function(record, path, install = TRUE) {
   if (state$recursive && nrow(weakdeps)) local({
 
     # make sure bioconductor repositories are active before install if necessary
-    if (nzchar(desc[["biocViews"]] %||% "")) {
+    if (renv_bioconductor_enabled() && renv_description_bioconductor(desc)) {
       repos <- renv_bioconductor_repos()
       renv_scope_options(repos = repos)
     }

--- a/R/settings.R
+++ b/R/settings.R
@@ -337,6 +337,19 @@ renv_settings_impl <- function(name, default, scalar, validate, coerce, update) 
 #' `renv/settings.json`. You can also edit this file by hand, but you'll need
 #' to restart the session for those changes to take effect.
 #'
+#' ## `bioconductor.enabled`
+#'
+#' Should renv use Bioconductor with this project? When enabled (the default),
+#' renv will infer that packages tagged with a `biocViews` field (and stamped
+#' with Bioconductor provenance) come from Bioconductor, activate the
+#' Bioconductor repositories when required, and record the Bioconductor release
+#' in the lockfile. Set this to `FALSE` for projects that should be treated as
+#' repository-only -- for example, when all packages (including any that happen
+#' to carry a `biocViews` field) are served from a single CRAN-like repository
+#' such as a Posit Package Manager "R repository". When disabled, renv will
+#' never infer a Bioconductor source, activate Bioconductor repositories, or
+#' write a Bioconductor entry into the lockfile.
+#'
 #' ## `bioconductor.version`
 #'
 #' The Bioconductor version to be used with this project. Use this if you'd
@@ -480,6 +493,15 @@ renv_settings_impl <- function(name, default, scalar, validate, coerce, update) 
 #'
 #' }
 settings <- list(
+
+  bioconductor.enabled = renv_settings_impl(
+    name     = "bioconductor.enabled",
+    default  = TRUE,
+    scalar   = TRUE,
+    validate = is.logical,
+    coerce   = as.logical,
+    update   = NULL
+  ),
 
   bioconductor.version = renv_settings_impl(
     name     = "bioconductor.version",

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -369,6 +369,10 @@ renv_snapshot_validate_bioconductor <- function(project, lockfile, libpaths) {
 
   ok <- TRUE
 
+  # nothing to validate when Bioconductor is disabled for this project
+  if (!renv_bioconductor_enabled(project = project))
+    return(ok)
+
   # check whether any packages are installed from Bioconductor
   records <- renv_lockfile_records(lockfile)
   sources <- extract_chr(records, "Source")
@@ -757,7 +761,7 @@ renv_snapshot_description_impl_v1 <- function(dcf, path = NULL) {
   # if this is a standard remote for a bioconductor package,
   # remove the other remote fields
   bioc <-
-    nzchar(dcf[["biocViews"]] %||% "") &&
+    renv_description_bioconductor(dcf) &&
     identical(dcf[["RemoteType"]], "standard")
 
   if (bioc) {
@@ -829,7 +833,7 @@ renv_snapshot_description_impl_v2 <- function(dcf, path) {
   # if this is a standard remote for a bioconductor package,
   # remove the other remote fields
   bioc <-
-    nzchar(dcf[["biocViews"]] %||% "") &&
+    renv_description_bioconductor(dcf) &&
     identical(dcf[["RemoteType"]], "standard")
 
   if (bioc) {
@@ -885,7 +889,7 @@ renv_snapshot_description_source_custom <- function(dcf) {
     return(NULL)
 
   # if this package appears to be installed from Bioconductor, skip
-  if (nzchar(dcf[["biocViews"]] %||% ""))
+  if (renv_description_bioconductor(dcf))
     return(NULL)
 
   # if the declared repository appears to be a CRAN mirror, skip it
@@ -936,8 +940,10 @@ renv_snapshot_description_source <- function(dcf) {
   }
 
   # packages from Bioconductor are normally tagged with a 'biocViews' entry;
-  # use that to infer a Bioconductor source
-  if (nzchar(dcf[["biocViews"]] %||% ""))
+  # use that (together with stronger provenance signals) to infer a
+  # Bioconductor source, unless Bioconductor is disabled for this project
+  # https://github.com/rstudio/renv/issues/2128
+  if (renv_bioconductor_enabled() && renv_description_bioconductor(dcf))
     return(list(Source = "Bioconductor"))
 
   # check for a declared repository

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -912,6 +912,10 @@ renv_snapshot_description_source_custom <- function(dcf) {
   # other package repositories as 'CRAN'
   #
   # https://github.com/rstudio/renv/issues/2104
+  #
+  # NOTE: renv_description_bioconductor() performs similar repository
+  # recognition but instead *trusts* the 'CRAN' name; keep the two in sync if
+  # this logic changes.
   name <- dcf[["RemoteReposName"]]
   declared <- if (is.null(name) || identical(name, "CRAN"))
     renv_repos_matches(remoterepos, repos)

--- a/R/utils.R
+++ b/R/utils.R
@@ -632,3 +632,30 @@ exclude <- function(value, exclude) {
   value[match(value, exclude, 0L) == 0L]
 }
 
+# create a minimal but complete R package at 'path', suitable for building and
+# installing (e.g. in tests). additional DESCRIPTION fields may be supplied via
+# '...'. returns the package directory, invisibly.
+#
+# the skeleton is intentionally complete rather than e.g. a lone DESCRIPTION:
+# R CMD build in R-devel (>= r90095, PR#17549) fails to build a package whose
+# source tree contains only top-level files (the build directory is created
+# solely from the package's subdirectories), and R CMD INSTALL requires a
+# NAMESPACE once R code is present.
+renv_package_skeleton <- function(package, path, ...) {
+
+  ensure_directory(path)
+
+  fields <- modifyList(
+    list(Package = package, Type = "Package", Version = "0.1.0"),
+    list(...)
+  )
+  renv_dcf_write(fields, file = file.path(path, "DESCRIPTION"))
+
+  ensure_directory(file.path(path, "R"))
+  writeLines("f <- function() 1", con = file.path(path, "R", "sample.R"))
+  writeLines("export(f)", con = file.path(path, "NAMESPACE"))
+
+  invisible(path)
+
+}
+

--- a/man/settings.Rd
+++ b/man/settings.Rd
@@ -22,6 +22,20 @@ renv with your particular project.
 Settings are automatically persisted across project sessions by writing to
 \code{renv/settings.json}. You can also edit this file by hand, but you'll need
 to restart the session for those changes to take effect.
+\subsection{\code{bioconductor.enabled}}{
+
+Should renv use Bioconductor with this project? When enabled (the default),
+renv will infer that packages tagged with a \code{biocViews} field (and stamped
+with Bioconductor provenance) come from Bioconductor, activate the
+Bioconductor repositories when required, and record the Bioconductor release
+in the lockfile. Set this to \code{FALSE} for projects that should be treated as
+repository-only -- for example, when all packages (including any that happen
+to carry a \code{biocViews} field) are served from a single CRAN-like repository
+such as a Posit Package Manager "R repository". When disabled, renv will
+never infer a Bioconductor source, activate Bioconductor repositories, or
+write a Bioconductor entry into the lockfile.
+}
+
 \subsection{\code{bioconductor.version}}{
 
 The Bioconductor version to be used with this project. Use this if you'd

--- a/tests/testthat/helper-skip.R
+++ b/tests/testthat/helper-skip.R
@@ -4,6 +4,14 @@ skip_if_no_github_auth <- function() {
   skip_if(empty(token), "GITHUB_PAT is not set")
 }
 
+skip_if_no_bioconductor <- function() {
+  skip_if_not_installed("BiocManager")
+  skip_if_not(
+    renv_bioconductor_supported(),
+    "Bioconductor does not support this version of R"
+  )
+}
+
 skip_if_no_python <- function() {
   has_python <- Sys.which("python3") != "" || Sys.which("python") != ""
   skip_if_not(has_python, "python is not installed")

--- a/tests/testthat/test-bioconductor.R
+++ b/tests/testthat/test-bioconductor.R
@@ -23,6 +23,7 @@ test_that("packages can be installed, restored from Bioconductor", {
   skip_on_os("windows")
   skip_if(getRversion() < "3.5.0")
   skip_if(R.version$nickname == "Unsuffered Consequences")
+  skip_if_no_bioconductor()
 
   renv_tests_scope("Biobase")
   local({
@@ -72,7 +73,7 @@ test_that("install(<bioc>, rebuild = TRUE) works", {
   skip_on_os("windows")
   skip_if(getRversion() < "3.5.0")
   skip_if(R.version$nickname == "Unsuffered Consequences")
-  skip_if_not_installed("BiocManager")
+  skip_if_no_bioconductor()
 
   renv_tests_scope()
   defer(unloadNamespace("BiocManager"))
@@ -122,6 +123,8 @@ test_that("we can restore a lockfile using multiple Bioconductor releases", {
 
 test_that("Bioconductor packages add BiocManager as a dependency", {
 
+  skip_if_no_bioconductor()
+
   renv_tests_scope()
   defer(unloadNamespace("BiocManager"))
 
@@ -148,6 +151,7 @@ test_that("Bioconductor packages add BiocManager as a dependency", {
 
 test_that("remotes which depend on Bioconductor packages can be installed", {
   skip_on_cran()
+  skip_if_no_bioconductor()
 
   renv_tests_scope()
   renv_scope_options(repos = c(CRAN = "https://cloud.r-project.org"))
@@ -181,6 +185,7 @@ test_that("auto-bioc install happens silently", {
 
   # https://github.com/rstudio/renv/actions/runs/5326472190/jobs/9648557761#step:6:295
   skip_if(renv_platform_windows())
+  skip_if_no_bioconductor()
 
   renv_tests_scope()
   renv_tests_scope_system_cache()

--- a/tests/testthat/test-r.R
+++ b/tests/testthat/test-r.R
@@ -14,10 +14,7 @@ test_that("we can use R CMD build to build a package", {
 
   package <- "sample.package"
   pkgdir <- file.path(testdir, package)
-  ensure_directory(pkgdir)
-
-  data <- list(Package = package, Type = "Package", Version = "0.1.0")
-  renv_dcf_write(data, file = file.path(pkgdir, "DESCRIPTION"))
+  renv_package_skeleton(package, pkgdir)
   expect_equal(renv_project_type(pkgdir), "package")
 
   tarball <- r_cmd_build(package, pkgdir)

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -211,6 +211,114 @@ test_that("snapshot prefers RemoteType to biocViews", {
 
 })
 
+test_that("a CRAN package with biocViews is recorded as a Repository package", {
+
+  # some CRAN packages declare 'biocViews'; the CRAN 'Repository' stamp should
+  # take precedence over the biocViews heuristic
+  # https://github.com/rstudio/renv/issues/2128
+  desc <- list(
+    Package = "test",
+    Version = "1.0",
+    biocViews = "Biology",
+    Repository = "CRAN"
+  )
+
+  descfile <- renv_scope_tempfile()
+  renv_dcf_write(desc, file = descfile)
+  record <- renv_snapshot_description(descfile)
+  expect_identical(record$Source, "Repository")
+  expect_identical(record$Repository, "CRAN")
+
+})
+
+test_that("biocViews packages from a CRAN-like repository are not Bioconductor", {
+
+  # Posit Package Manager can serve Bioconductor packages from a CRAN-like
+  # "R repository"; such a package may still carry Bioconductor git provenance,
+  # but should be restored from the repository it was obtained from
+  # https://github.com/rstudio/renv/issues/2128
+  renv_scope_options(repos = c(MYREPO = "https://ppm.example.org/cran/latest"))
+
+  desc <- list(
+    Package    = "test",
+    Version    = "1.0",
+    biocViews  = "Biology",
+    Repository = "MYREPO",
+    git_url    = "https://git.bioconductor.org/packages/test"
+  )
+
+  descfile <- renv_scope_tempfile()
+  renv_dcf_write(desc, file = descfile)
+  record <- renv_snapshot_description(descfile)
+  expect_identical(record$Source, "Repository")
+  expect_identical(record$Repository, "MYREPO")
+
+})
+
+test_that("genuine Bioconductor packages are still recorded as Bioconductor", {
+
+  desc <- list(
+    Package    = "test",
+    Version    = "1.0",
+    biocViews  = "Infrastructure",
+    Repository = "Bioconductor 3.18",
+    git_url    = "https://git.bioconductor.org/packages/test"
+  )
+
+  descfile <- renv_scope_tempfile()
+  renv_dcf_write(desc, file = descfile)
+  record <- renv_snapshot_description(descfile)
+  expect_identical(record$Source, "Bioconductor")
+
+})
+
+test_that("a custom-named PPM Bioconductor repository is still Bioconductor", {
+
+  # Posit Package Manager Bioconductor repositories may use a custom name, but
+  # normally include 'Bioconductor' in the stamped 'Repository' field
+  desc <- list(
+    Package    = "test",
+    Version    = "1.0",
+    biocViews  = "Infrastructure",
+    Repository = "my-mirror Bioconductor 3.18"
+  )
+
+  descfile <- renv_scope_tempfile()
+  renv_dcf_write(desc, file = descfile)
+  record <- renv_snapshot_description(descfile)
+  expect_identical(record$Source, "Bioconductor")
+
+})
+
+test_that("bioconductor.enabled = FALSE disables Bioconductor inference", {
+
+  renv_tests_scope()
+  settings$bioconductor.enabled(FALSE, persist = FALSE)
+
+  # a package that would otherwise be inferred as Bioconductor is instead
+  # recorded against the repository it declares
+  # https://github.com/rstudio/renv/issues/2128
+  desc <- list(
+    Package    = "test",
+    Version    = "1.0",
+    biocViews  = "Infrastructure",
+    Repository = "Bioconductor 3.18",
+    git_url    = "https://git.bioconductor.org/packages/test"
+  )
+
+  descfile <- renv_scope_tempfile()
+  renv_dcf_write(desc, file = descfile)
+  record <- renv_snapshot_description(descfile)
+  expect_identical(record$Source, "Repository")
+
+  # and no Bioconductor entry is written into the lockfile
+  lockfile <- renv_lockfile_init(project = getwd())
+  lockfile$Packages <- list(test = record)
+  bioc <- renv_lockfile_fini_bioconductor(lockfile, project = getwd())
+  expect_null(bioc)
+
+})
+
 test_that("parse errors cause snapshot to abort", {
 
   renv_tests_scope()

--- a/vignettes/package-sources.Rmd
+++ b/vignettes/package-sources.Rmd
@@ -155,11 +155,63 @@ renv::settings$bioconductor.version("3.20")
 If you later choose to upgrade R, you may need to upgrade the version
 of Bioconductor used as well.
 
-If you want to override the Bioconductor repositories used by renv, you can
-also explicitly set the following option:
+### Bioconductor mirrors
+
+renv does not hard-code the Bioconductor repository URLs. Instead, it asks
+`BiocManager` for the repositories associated with the active Bioconductor
+release, and `BiocManager` in turn honors the `BioC_mirror` option
+(`getOption("BioC_mirror")`). This means a mirror -- for example, one provided
+by [Posit Package Manager](https://docs.posit.co/rspm/) -- is used
+automatically, provided it has been configured in the session.
+
+There are two different options that influence the repositories renv uses, and
+they operate at different levels:
+
+- `BioC_mirror` sets the **base URL** of the mirror (for example,
+  `options(BioC_mirror = "https://my.ppm.example/bioconductor")`). renv still
+  asks `BiocManager` to expand this into the full set of repositories for the
+  project's Bioconductor release, so the version you have pinned with
+  `bioconductor.version` continues to apply. This is the right option to reach
+  for when you simply want to point renv at a different mirror.
+
+- `renv.bioconductor.repos` sets the **fully-expanded, named repository
+  vector** directly (for example,
+  `options(renv.bioconductor.repos = c(BioCsoft = "...", BioCann = "..."))`).
+  When this option is set, renv uses it verbatim and skips `BiocManager`,
+  `BioC_mirror`, and its own release inference entirely -- so you become
+  responsible for ensuring those URLs (including the Bioconductor release
+  encoded in them) are correct. Reach for this only when you need to fully
+  override what renv would otherwise compute.
+
+If you use a Bioconductor mirror and want that choice to be reproducible, you
+have a couple of options:
+
+- Set `BioC_mirror` (or, if you need a full override, `renv.bioconductor.repos`)
+  in your project's `.Rprofile`, so that it is configured whenever the project
+  is loaded; or
+
+- Use a CRAN-like repository that also serves Bioconductor packages -- for
+  example, a Posit Package Manager "R repository". Because these repositories
+  are part of the normal `repos` option, renv records them in the lockfile
+  (under `R$Repositories`) and restores them automatically, with no extra
+  configuration required.
+
+### Disabling Bioconductor
+
+By default, renv treats a package tagged with a `biocViews` field (and stamped
+with Bioconductor provenance) as coming from Bioconductor. Some CRAN packages
+also declare `biocViews`, and a CRAN-like repository (such as a Posit Package
+Manager "R repository") might serve Bioconductor packages alongside CRAN
+packages. In these cases renv uses the `Repository` field to decide where a
+package was obtained, so such packages are recorded as ordinary repository
+packages.
+
+If you would like to opt a project out of Bioconductor entirely -- so that renv
+never infers a Bioconductor source, activates the Bioconductor repositories, or
+records a Bioconductor release in the lockfile -- you can disable it with:
 
 ```{r}
-options(renv.bioconductor.repos = c(...))
+renv::settings$bioconductor.enabled(FALSE)
 ```
 
 


### PR DESCRIPTION
## Problem

renv used the presence of a `biocViews` field in a package's `DESCRIPTION` as "proof" that the package came from Bioconductor (#2128, problem 1). But some CRAN packages legitimately declare `biocViews`, and Posit Package Manager can serve Bioconductor packages from a CRAN-like "R repository". In those cases renv misclassified the package: it recorded `Source: Bioconductor`, activated the Bioconductor repositories, and injected a `Bioconductor`/`BiocVersion` block into the lockfile -- pulling the package from `bioconductor.org` instead of the repository it actually came from.

## Approach

The key insight is that what matters for restore is *where a package was obtained* (the `Repository` field) rather than *where it originally came from* (its git provenance). A genuine Bioconductor package's `DESCRIPTION` carries `Repository: Bioconductor <ver>` (and `git_url: https://git.bioconductor.org/...`); a CRAN/PPM package carries `Repository: CRAN` (or a repo name).

- **New helper `renv_description_bioconductor(dcf)`** (`R/bioconductor.R`) decides origin by precedence:
  1. no `biocViews` -> not Bioconductor;
  2. `Repository` contains "Bioconductor" (matched anywhere, case-insensitive, so custom-named PPM Bioconductor repositories are recognized) -> Bioconductor;
  3. `Repository` is CRAN / a known mirror / one of the active repos -> **not** Bioconductor (covers CRAN packages and PPM CRAN-like "R repositories", even when they retain Bioconductor git provenance);
  4. otherwise fall back to `git_url` provenance, then to the historical behaviour of trusting `biocViews`.
- The snapshot classification, `_source_custom`, field-strip blocks, `retrieve.R` repo activation, `graph.R` resolution, `install.R`, and `lockfile.R` call sites are rewired to use this (and the new setting below) instead of a bare `nzchar(biocViews)` check. Because the lockfile `Bioconductor` block is driven by `Source == "Bioconductor"`, correcting classification also resolves the unwanted `BiocVersion`/repo injection (problem 2) for the misclassified case.

- **New `bioconductor.enabled` project setting** (logical, default `TRUE`, persisted in `renv/settings.json`). When `FALSE`, renv never infers a Bioconductor source, activates the Bioconductor repositories, or writes a Bioconductor entry into the lockfile -- a first-class opt-out for repository-only projects, replacing the `options(renv.bioconductor.repos = ...)` workaround.

## Notes on PPM / mirrors

renv does not hard-code Bioconductor URLs: it asks `BiocManager` (which honors `BioC_mirror`) for the repositories, or uses the `renv.bioconductor.repos` override verbatim. So a PPM Bioconductor mirror is used automatically when configured, and needs no special handling here. The vignette is updated to explain the `BioC_mirror` vs `renv.bioconductor.repos` distinction and the reproducibility options. Capturing the mirror in the lockfile was considered and deliberately left out of scope.

## Testing

Added snapshot tests covering: CRAN + `biocViews` -> `Repository`; a CRAN-like (PPM) repo + `biocViews` + bioc git provenance -> `Repository`; genuine `Repository: Bioconductor` and custom-named PPM bioc repos -> `Bioconductor`; and `bioconductor.enabled = FALSE` disabling inference and the lockfile entry.

All passing locally: snapshot, bioconductor, settings, lockfile, install, graph, retrieve, restore (0 failures).

Closes #2128.