### PR TITLE
infer implied dependencies (e.g. dbplyr) from package co-occurrence

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
 
 # renv (development version)
 
+* renv now infers some "implied" dependencies that cannot be discovered via
+  static analysis because they are loaded indirectly at runtime by another
+  package. For example, dplyr lazily loads dbplyr when working with a database
+  backend, so dbplyr is now recorded when a project uses both dplyr and a DBI
+  backend (e.g. RSQLite, RPostgres, duckdb). The rules are configurable via the
+  `renv.dependencies.implied` R option; set it to an empty list to disable this
+  inference entirely. (#2308)
+
 * `renv::restore()` gains a `retry` argument, controlling whether packages
   that fail to install successfully are retried with their latest available
   versions. This recovery was previously only offered via an interactive

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -36,6 +36,14 @@
 #' function requires the `stringr` package, but `stringr` is only suggested,
 #' not required, by `tidyr`.
 #'
+#' For a small number of common cases, renv infers these indirect dependencies
+#' from the combination of packages in use. For example, a project that uses
+#' `dplyr` together with a database backend (such as `DBI` and `RSQLite`) is
+#' assumed to also require `dbplyr`, which `dplyr` loads at runtime when working
+#' with databases. These rules are defined by the `renv.dependencies.implied`
+#' \R option; set it to an empty list (`options(renv.dependencies.implied =
+#' list())`) to disable this inference entirely.
+#'
 #' If you find that renv's dependency discovery misses one or more packages
 #' that you actually use in your project, one escape hatch is to include a file
 #' called `_dependencies.R` that includes straightforward library calls:
@@ -255,6 +263,9 @@ renv_dependencies_impl <- function(
 
   renv_condition_signal("renv.dependencies.elapsed_time", elapsed)
   renv_dependencies_report(errors)
+
+  # augment with packages that are only required indirectly
+  deps <- renv_dependencies_infer_implied(deps)
 
   if (empty(deps) || nrow(deps) == 0L) {
     result <- renv_dependencies_list_empty()
@@ -1909,6 +1920,66 @@ renv_dependencies_database <- function() {
     db$testthat$JunitReporter <- "xml2"
     db
   }
+}
+
+# rules describing packages that are required only indirectly, and so cannot
+# be discovered by static analysis of user code. each entry maps an implied
+# package to the set of packages whose joint presence implies it: every
+# package in 'all' must be used, plus at least one of the packages in 'any'
+# (when 'any' is non-empty).
+#
+# for example, dplyr loads dbplyr at runtime when used together with a
+# database backend, but neither dplyr nor the user's code ever references
+# dbplyr explicitly.
+renv_dependencies_implied <- function() {
+  getOption("renv.dependencies.implied", default = list(
+    dbplyr = list(
+      all = "dplyr",
+      any = c(
+        "DBI", "RSQLite", "RPostgres", "RPostgreSQL", "RMariaDB",
+        "RMySQL", "odbc", "bigrquery", "duckdb", "RJDBC"
+      )
+    )
+  ))
+}
+
+# given the set of dependencies discovered via static analysis, augment it
+# with any packages that are implied by the combination of packages in use.
+# see renv_dependencies_implied() for the rule format.
+renv_dependencies_infer_implied <- function(deps) {
+
+  if (empty(deps) || nrow(deps) == 0L)
+    return(deps)
+
+  rules <- renv_dependencies_implied()
+  packages <- unique(deps$Package)
+
+  implied <- character()
+  for (package in names(rules)) {
+
+    rule <- rules[[package]]
+
+    # skip packages we've already discovered (or just inferred)
+    if (package %in% c(packages, implied))
+      next
+
+    # require every 'all' package, plus at least one 'any' package
+    if (!all(rule$all %in% packages))
+      next
+
+    if (length(rule$any) && !any(rule$any %in% packages))
+      next
+
+    implied[[length(implied) + 1L]] <- package
+
+  }
+
+  if (empty(implied))
+    return(deps)
+
+  extra <- renv_dependencies_list(source = NA_character_, packages = implied)
+  bind(list(deps, extra))
+
 }
 
 renv_dependencies_list <- function(source,

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -575,6 +575,57 @@ test_that("dependencies() can infer an svglite dependency from ggsave", {
 
 })
 
+test_that("dependencies() infers dbplyr from dplyr used with a DBI backend", {
+
+  # https://github.com/rstudio/renv/issues/2308
+  document <- heredoc('
+    library(dplyr, warn.conflicts = FALSE)
+    con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+    copy_to(con, mtcars)
+    mtcars2 <- tbl(con, "mtcars")
+  ')
+
+  file <- renv_scope_tempfile("renv-test-", fileext = ".R")
+  writeLines(document, con = file)
+
+  deps <- dependencies(file, quiet = TRUE)
+  expect_contains(deps$Package, "dbplyr")
+
+})
+
+test_that("dependencies() does not infer dbplyr from dplyr alone", {
+
+  document <- heredoc('
+    library(dplyr, warn.conflicts = FALSE)
+    mtcars |> filter(mpg > 20)
+  ')
+
+  file <- renv_scope_tempfile("renv-test-", fileext = ".R")
+  writeLines(document, con = file)
+
+  deps <- dependencies(file, quiet = TRUE)
+  expect_false("dbplyr" %in% deps$Package)
+
+})
+
+test_that("implied dependency inference can be disabled", {
+
+  renv_scope_options(renv.dependencies.implied = list())
+
+  document <- heredoc('
+    library(dplyr, warn.conflicts = FALSE)
+    con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+    mtcars2 <- tbl(con, "mtcars")
+  ')
+
+  file <- renv_scope_tempfile("renv-test-", fileext = ".R")
+  writeLines(document, con = file)
+
+  deps <- dependencies(file, quiet = TRUE)
+  expect_false("dbplyr" %in% deps$Package)
+
+})
+
 test_that("dependencies() can handle calls", {
 
   document <- heredoc('


### PR DESCRIPTION
## Summary

Closes #2308.

renv discovers dependencies via static analysis, so it cannot see packages that are required only indirectly -- loaded at runtime by another package rather than referenced in user code. The motivating case from #2308 is `dbplyr`: dplyr lazily loads it when working with a database backend, so a script like

```r
library(dplyr)
con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
tbl(con, "mtcars")
```

never mentions `dbplyr`, and it was missing from snapshots (and from Posit Connect deployments).

The signal for `dbplyr` is non-local: it's the *combination* of using dplyr and a DBI backend, so the existing per-node heuristics (`renv.dependencies.database`, parsnip engines, etc.) don't fit. This PR adds a project-level co-occurrence inference pass instead.

## Changes

- `renv_dependencies_implied()` -- an extensible rule table backed by the `renv.dependencies.implied` R option. Each rule maps an implied package to the packages whose joint presence implies it: every package in `all`, plus at least one in `any`. Seeded with `dbplyr <- {all: dplyr, any: DBI/RSQLite/RPostgres/RMariaDB/RMySQL/odbc/bigrquery/duckdb/RJDBC/...}`.
- `renv_dependencies_infer_implied()` -- a post-aggregation pass in `renv_dependencies_impl()`, the single chokepoint shared by `dependencies()` and `snapshot()`. It adds implied packages whose rule conditions are satisfied and that aren't already discovered.
- Documented the behavior and the opt-out in `?dependencies`.

## Opt-out

Set the option to an empty list to disable inference entirely:

```r
options(renv.dependencies.implied = list())
```

## Testing

Added tests covering the positive case (dplyr + DBI backend infers dbplyr), the negative case (dplyr alone does not), and the opt-out. All `test-dependencies.R` tests pass.
