### PR TITLE
detect ragg dependency from knitr opts_chunk dev in YAML header

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -823,8 +823,9 @@ renv_dependencies_discover_rmd_yaml_header <- function(path, mode) {
     opts_chunk <- knitr[["opts_chunk"]]
     if (is.list(opts_chunk)) {
       dev <- opts_chunk[["dev"]]
-      if (is.character(dev) && any(grepl("^ragg_", dev)))
-        deps$push("ragg")
+      for (d in dev)
+        if (is.character(d) && grepl("^ragg_", d))
+          deps$push("ragg")
     }
   }
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -816,6 +816,18 @@ renv_dependencies_discover_rmd_yaml_header <- function(path, mode) {
   if (!inherits(theme, "error") && is.list(theme))
     deps$push("bslib")
 
+  # check for knitr opts_chunk dev in the YAML header
+  # e.g. knitr: opts_chunk: dev: "ragg_png" => ragg dependency
+  knitr <- yaml[["knitr"]]
+  if (is.list(knitr)) {
+    opts_chunk <- knitr[["opts_chunk"]]
+    if (is.list(opts_chunk)) {
+      dev <- opts_chunk[["dev"]]
+      if (is.character(dev) && nzchar(dev) && grepl("^ragg_", dev))
+        deps$push("ragg")
+    }
+  }
+
   # check for parameterized documents
   status <- catch(renv_dependencies_discover_rmd_yaml_header_params(yaml, deps))
   if (inherits(status, "error"))
@@ -1693,7 +1705,8 @@ renv_dependencies_discover_r_knitr <- function(node, envir) {
     return(FALSE)
 
   args <- as.list(node)
-  if (identical(args[["dev"]], "ragg_png")) {
+  dev <- args[["dev"]]
+  if (is.character(dev) && nzchar(dev) && grepl("^ragg_", dev)) {
     envir[["ragg"]] <- TRUE
     return(TRUE)
   }

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -823,7 +823,7 @@ renv_dependencies_discover_rmd_yaml_header <- function(path, mode) {
     opts_chunk <- knitr[["opts_chunk"]]
     if (is.list(opts_chunk)) {
       dev <- opts_chunk[["dev"]]
-      if (is.character(dev) && nzchar(dev) && grepl("^ragg_", dev))
+      if (is.character(dev) && any(grepl("^ragg_", dev)))
         deps$push("ragg")
     }
   }

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -660,6 +660,24 @@ test_that("dependencies() does not detect ragg without ragg_ device", {
 
 })
 
+test_that("dependencies() detects ragg in a vector of formats", {
+
+  # YAML header with multi-device vector
+  file <- renv_scope_tempfile("renv-test-", fileext = ".Rmd")
+  document <- heredoc('
+    ---
+    knitr:
+      opts_chunk:
+        dev: [png, ragg_png]
+    ---
+  ')
+  writeLines(document, con = file)
+
+  deps <- dependencies(file, quiet = TRUE)
+  expect_contains(deps$Package, "ragg")
+
+})
+
 test_that("dependencies() does not create 'object' in parent environment", {
   result <- dependencies("resources/code.R", quiet = TRUE)
   expect_false(exists("object", envir = environment(), inherits = FALSE))

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -608,9 +608,10 @@ test_that("dependencies() detects usages of Junit test reporters", {
 
 })
 
-test_that("dependencies() detects usage of ragg_png device", {
+test_that("dependencies() detects usage of ragg device via opts_chunk", {
 
-  check <- function(document) {
+  # check R code with opts_chunk$set
+  check_r <- function(document) {
 
     file <- renv_scope_tempfile("renv-test-", fileext = ".R")
     writeLines(document, con = file)
@@ -619,8 +620,43 @@ test_that("dependencies() detects usage of ragg_png device", {
     expect_contains(deps$Package, "ragg")
   }
 
-  check("opts_chunk$set(dev = \"ragg_png\")")
-  check("knitr::opts_chunk$set(dev = \"ragg_png\")")
+  check_r("opts_chunk$set(dev = \"ragg_png\")")
+  check_r("knitr::opts_chunk$set(dev = \"ragg_png\")")
+  check_r("opts_chunk$set(dev = \"ragg_pdf\")")
+
+})
+
+test_that("dependencies() detects ragg from knitr opts_chunk in YAML header", {
+
+  file <- renv_scope_tempfile("renv-test-", fileext = ".Rmd")
+  document <- heredoc('
+    ---
+    knitr:
+      opts_chunk:
+        dev: "ragg_png"
+    ---
+  ')
+  writeLines(document, con = file)
+
+  deps <- dependencies(file, quiet = TRUE)
+  expect_contains(deps$Package, "ragg")
+
+})
+
+test_that("dependencies() does not detect ragg without ragg_ device", {
+
+  file <- renv_scope_tempfile("renv-test-", fileext = ".Rmd")
+  document <- heredoc('
+    ---
+    knitr:
+      opts_chunk:
+        dev: "png"
+    ---
+  ')
+  writeLines(document, con = file)
+
+  deps <- dependencies(file, quiet = TRUE)
+  expect_false("ragg" %in% deps$Package)
 
 })
 


### PR DESCRIPTION
## Summary

Implements dependency discovery for `ragg` when a document declares a device of the form `ragg_*` in its knitr opts_chunk configuration.

This covers two cases:

1. **YAML header** — detects:
  ```yaml
  knitr:
    opts_chunk:
      dev: "ragg_png"
  ```
  and adds `ragg` as a dependency.

2. **R code** — also extends the existing code-path to match any `ragg_*` device (previously only matched the exact value `"ragg_png"`).

Refs: https://github.com/rstudio/renv/issues/2311
