### PR TITLE
resolve dependencies for packages installed from the cellar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # renv (development version)
 
+* Fixed a regression introduced in renv 1.2.0 where installing a package from
+  the cellar (via `install()` or `use()`) failed to install that package's
+  dependencies. The graph-based installer resolved cellar packages from
+  metadata that omitted their `Depends` / `Imports` / `LinkingTo` fields; renv
+  now reads the package's `DESCRIPTION` from the cellar archive so that its
+  dependencies are discovered and installed. (#2313)
+
 * renv now infers some "implied" dependencies that cannot be discovered via
   static analysis because they are loaded indirectly at runtime by another
   package. For example, dplyr lazily loads dbplyr when working with a database

--- a/R/download.R
+++ b/R/download.R
@@ -1168,7 +1168,7 @@ renv_download_local <- function(url, destfile, headers) {
 
 }
 
-renv_download_local_copy <- function(url, destfile, headers) {
+renv_url_local_path <- function(url) {
 
   # remove file prefix (to get path to local / server file)
   url <- case(
@@ -1184,6 +1184,15 @@ renv_download_local_copy <- function(url, destfile, headers) {
     if (badpath)
       url <- substring(url, 2L)
   }
+
+  url
+
+}
+
+renv_download_local_copy <- function(url, destfile, headers) {
+
+  # convert the file URI to a local path
+  url <- renv_url_local_path(url)
 
   # attempt to copy
   ensure_parent_directory(destfile)

--- a/R/graph.R
+++ b/R/graph.R
@@ -303,14 +303,7 @@ renv_graph_description_cellar <- function(record) {
 
   # the url points to the cellar directory; convert the file URI to a
   # local path and form the path to the package archive
-  dir <- case(
-    startsWith(url, "file:///") ~ substring(url, 8L),
-    startsWith(url, "file://")  ~ substring(url, 6L),
-    startsWith(url, "file:")    ~ substring(url, 6L),
-    TRUE                        ~ url
-  )
-
-  path <- file.path(dir, name)
+  path <- file.path(renv_url_local_path(url), name)
   if (!file.exists(path))
     return(record)
 

--- a/R/graph.R
+++ b/R/graph.R
@@ -243,11 +243,15 @@ renv_graph_description_repository <- function(record) {
   # try cellar via renv_available_packages_latest (includes cellar = TRUE);
   # cellar packages won't be found by renv_available_packages_entry.
   # NOTE: renv_available_packages_latest only returns limited fields
-  # (Package, Version, etc.) — no Depends/Imports/LinkingTo
+  # (Package, Version, etc.) -- no Depends/Imports/LinkingTo, so cellar
+  # records are supplemented from the archive DESCRIPTION below (#2313)
   latest <- catch(renv_available_packages_latest(package, type = type))
   if (!inherits(latest, "error")) {
-    if (is.null(version) || identical(latest$Version, version))
+    if (is.null(version) || identical(latest$Version, version)) {
+      if (identical(renv_record_source(latest, normalize = TRUE), "cellar"))
+        latest <- renv_graph_description_cellar(latest)
       return(as.list(latest))
+    }
   }
 
   # the requested version wasn't found in configured repos; try crandb for the
@@ -280,6 +284,48 @@ renv_graph_description_repository <- function(record) {
 
   # all lookups failed; signal an error so the caller can warn
   stopf("package '%s' is not available", package)
+
+}
+
+renv_graph_description_cellar <- function(record) {
+
+  # cellar metadata from available_packages only carries Package / Version,
+  # so locate the package archive in the cellar and read its DESCRIPTION to
+  # recover the dependency fields (Depends, Imports, LinkingTo) required for
+  # graph resolution. without this, packages installed from the cellar have
+  # their dependencies silently dropped (#2313)
+  url <- attr(record, "url", exact = TRUE)
+  if (is.null(url))
+    return(record)
+
+  type <- attr(record, "type", exact = TRUE) %||% "source"
+  name <- renv_retrieve_repos_archive_name(as.list(record), type)
+
+  # the url points to the cellar directory; convert the file URI to a
+  # local path and form the path to the package archive
+  dir <- case(
+    startsWith(url, "file:///") ~ substring(url, 8L),
+    startsWith(url, "file://")  ~ substring(url, 6L),
+    startsWith(url, "file:")    ~ substring(url, 6L),
+    TRUE                        ~ url
+  )
+
+  path <- file.path(dir, name)
+  if (!file.exists(path))
+    return(record)
+
+  desc <- catch(renv_description_read(path))
+  if (inherits(desc, "error"))
+    return(record)
+
+  # merge dependency (and any other) fields from the DESCRIPTION into the
+  # resolved record, keeping the record's Source and cellar tags so the
+  # package continues to be installed from the cellar
+  for (field in names(desc))
+    if (is.null(record[[field]]))
+      record[[field]] <- desc[[field]]
+
+  record
 
 }
 

--- a/tests/testthat/test-cellar.R
+++ b/tests/testthat/test-cellar.R
@@ -30,3 +30,46 @@ test_that("renv can find packages located in the cellar", {
   install("bread")
 
 })
+
+# https://github.com/rstudio/renv/issues/2313
+test_that("dependencies are resolved for packages installed from the cellar", {
+  skip_on_cran()
+  renv_tests_scope()
+
+  # build a package that lives only in the cellar (not in the test
+  # repositories), with a dependency on a package that does live in the
+  # repositories; the cellar record must still expose that dependency
+  cellar <- renv_paths_cellar()
+  ensure_directory(cellar)
+
+  pkgdir <- renv_scope_tempfile("renv-cellar-pkg-")
+  ensure_directory(file.path(pkgdir, "cellarpkg"))
+  writeLines(
+    c(
+      "Package: cellarpkg",
+      "Version: 1.0.0",
+      "Title: A Cellar Package",
+      "Description: Test.",
+      "Imports: bread",
+      "License: MIT"
+    ),
+    file.path(pkgdir, "cellarpkg", "DESCRIPTION")
+  )
+
+  renv_scope_wd(pkgdir)
+  tar(
+    tarfile     = file.path(cellar, "cellarpkg_1.0.0.tar.gz"),
+    files       = "cellarpkg",
+    compression = "gzip"
+  )
+
+  descriptions <- renv_graph_init("cellarpkg")
+
+  # cellarpkg should be resolved from the cellar ...
+  source <- renv_record_source(descriptions[["cellarpkg"]], normalize = TRUE)
+  expect_equal(source, "cellar")
+
+  # ... and its dependency must still be discovered (#2313)
+  expect_true("bread" %in% names(descriptions))
+
+})


### PR DESCRIPTION
Fixes #2313.

## Problem

Since renv 1.2.0, installing a package from the cellar (via `install()` or `use()`) installs the package itself but silently drops its dependencies.

This is a regression from the graph-based parallel install rewrite (#2224). When a package is resolved by name and lives in the cellar, dependency resolution runs through `renv_graph_description_repository()`. Cellar packages aren't returned by `renv_available_packages_entry()` (which doesn't pass `cellar = TRUE`), so they're resolved via `renv_available_packages_latest()`.

The cellar records produced by `renv_available_packages_cellar()` are built solely from the tarball filename and carry only `Package`, `Version`, and `Repository` -- the archive's `DESCRIPTION` is never read, so there are no `Depends` / `Imports` / `LinkingTo` fields. `renv_graph_deps()` therefore finds nothing and no dependencies are enqueued.

## Fix

When `renv_graph_description_repository()` resolves a record whose source is the cellar, it now reads the package's `DESCRIPTION` from the cellar archive (new helper `renv_graph_description_cellar()`) and merges in the missing dependency fields, preserving the record's `Source` and cellar tags so the package is still installed from the cellar. The helper degrades gracefully if the archive can't be located or read.

## Tests

Added a regression test in `tests/testthat/test-cellar.R` that builds a package living only in the cellar with a dependency on a repository package, then asserts it resolves with `Source == "cellar"` and that its dependency is discovered. Confirmed the test fails without the fix and passes with it; the existing graph and retrieve test suites still pass.