### PR TITLE
warn when pinned version deps fall back to latest version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # renv (development version)
 
+* When the graph resolver cannot determine the dependencies for a pinned
+  package version (because the version is absent from the configured
+  repositories and crandb is unreachable or has no record of it), it falls back
+  to the latest version's dependencies. renv now warns when this happens, since
+  those dependencies may differ from the pinned version's and could lead to an
+  incorrect install order. (#2315)
+
 * Fixed a regression introduced in renv 1.2.0 where installing a package from
   the cellar (via `install()` or `use()`) failed to install that package's
   dependencies. The graph-based installer resolved cellar packages from

--- a/R/graph.R
+++ b/R/graph.R
@@ -264,13 +264,15 @@ renv_graph_description_repository <- function(record) {
       return(as.list(crandb))
   }
 
-  # last-resort fallback when crandb is unreachable: use the latest entry's
-  # full fields with the requested version substituted. this may return stale
-  # dependency constraints if they changed between versions, but is better
-  # than failing outright.
+  # last-resort fallback when crandb is unreachable or lacks the version: use
+  # the latest entry's full fields with the requested version substituted. this
+  # may report stale dependency constraints if they changed between versions,
+  # so warn that the resolved dependencies may be inaccurate.
   if (!is.null(version) && !inherits(latest, "error")) {
     full <- catch(renv_available_packages_entry(package, type = type))
     if (!inherits(full, "error")) {
+      fmt <- "could not resolve dependencies for %s %s; using dependencies from the latest version (%s) instead"
+      warningf(fmt, package, version, full$Version)
       desc <- as.list(full)
       desc$Version <- version
       return(desc)

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -2,6 +2,9 @@
 
     Code
       install("bread@0.1.0")
+    Condition
+      Warning:
+      could not resolve dependencies for bread 0.1.0; using dependencies from the latest version (1.0.0) instead
     Output
       The following package(s) will be installed:
       - bread [0.1.0]


### PR DESCRIPTION
Addresses #2315.

## Background

During `restore()`, the graph resolver determines each package's dependencies (for install ordering) from a pinned record. For a version that is no longer current in the configured repositories, it resolves dependencies in this order:

1. current repository `PACKAGES` metadata (fails for non-current versions);
2. crandb, for the pinned version's actual dependency fields (#2278);
3. last-resort: reuse the *latest* version's fields with the version string overwritten.

The issue's exact case (CRAN `selectr 0.5-1`, which `Imports: stringr` whereas the current `0.6-0` does not) is already handled correctly by the crandb lookup shipped in 1.2.3 -- verified end-to-end.

## The remaining gap

The last-resort fallback (step 3) only fires when crandb is unreachable or has no record of the version -- e.g. an air-gapped environment, or a genuinely non-CRAN repository (internal Artifactory/Nexus). In that case it silently substitutes the latest version's dependencies, which can differ from the pinned version's and produce an incorrect install order, with no indication to the user.

I investigated cheaper authoritative sources for an archived version's dependencies and ruled them out:

- Reading the archived source tarball's `DESCRIPTION` would download the entire tarball (to a scratch tempfile that retrieve would not reuse -- a double download). Too expensive for resolution.
- The PPM API exposes dependency fields only for the *current* version; `?version=` returns an empty stub for archived versions, and `/history` lists versions without dependency metadata. So it offers no cheaper option than crandb here.

## This change

Rather than add an expensive fetch, surface the situation: when the resolver falls back to the latest version's dependencies, it now emits a `warning()` naming the package, the pinned version, and the version the dependencies were borrowed from. No behavior change in the common (CRAN / crandb-reachable) path.