### PR TITLE
list one package per line in install failure error

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -304,12 +304,12 @@ install <- function(packages = NULL,
     reasons <- vapply(failed, function(pkg) {
       attr(descriptions[[pkg]], "resolution_error") %||% ""
     }, character(1L))
-    labels <- ifelse(
+    lines <- ifelse(
       nzchar(reasons),
-      sprintf("%s (%s)", dQuote(failed), reasons),
-      dQuote(failed)
+      sprintf("- %s: %s", failed, reasons),
+      sprintf("- %s", failed)
     )
-    stopf("failed to install %s", paste(labels, collapse = ", "))
+    stop(paste(c("package installation failed", lines), collapse = "\n"))
   }
 
   # check loaded packages and inform user if out-of-sync

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -82,8 +82,9 @@
       You may need to manually download and install these packages.
       
     Condition
-      Error:
-      ! failed to install "missing" (package 'missing' is not available)
+      Error in `install()`:
+      ! package installation failed
+      - missing: package 'missing' is not available
 
 # install from local sources shows progress
 


### PR DESCRIPTION
## Summary

Reformats the error raised by `install()` when one or more explicitly-requested packages fail to resolve. Previously all failures were combined onto a single comma-separated line:

```
Error: failed to install "ok" (package 'ok' is not available), "notinstalled" (package 'notinstalled' is not available), "testConfigLoadAll" (package 'testConfigLoadAll' is not available)
```

Now each failure gets its own line, which is much easier to scan when several packages fail:

```
Error: package installation failed
- ok: package 'ok' is not available
- notinstalled: package 'notinstalled' is not available
- testConfigLoadAll: package 'testConfigLoadAll' is not available
```

Packages without a recorded resolution reason render as a bare `- <name>`.

## Notes

- The sibling message in `R/restore.R` was left alone since it only lists package names (no per-package reasons).

## Test plan

- Updated the affected snapshot in `tests/testthat/_snaps/install.md`.
- `devtools::test(filter = "install")` passes (FAIL 0).