### PR TITLE
use a longer socket accept timeout on CI

### DIFF
--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -196,9 +196,13 @@ test_that("ensure_directory() works even under contention", {
 
   file.create(waitfile)
 
+  # allow more time on CI, where spawning + loading renv in the child
+  # processes can take longer than it does locally
+  timeout <- if (ci()) 10 else 3
+
   responses <- stack()
   for (i in 1:n) local({
-    conn <- renv_socket_accept(server$socket, open = "rb", timeout = 3)
+    conn <- renv_socket_accept(server$socket, open = "rb", timeout = timeout)
     defer(close(conn))
     responses$push(unserialize(conn))
   })


### PR DESCRIPTION
## Summary

The `ensure_directory() works even under contention` test in `test-utils.R` spawns 4 R subprocesses that each load renv (via `summon()`) and connect back to a socket server. The parent accepts those connections with a fixed 3-second timeout.

On a loaded CI runner, cold-starting those subprocesses and loading renv can exceed 3 seconds, causing `renv_socket_accept()` to raise `"socket accept timed out"` and the test to fail spuriously. This was observed on macOS CI.

This bumps the accept timeout to 10 seconds when running on CI (detected via the existing `ci()` helper), while keeping the original 3-second timeout locally.

## Test plan

- `devtools::test(filter = "utils")` passes locally (FAIL 0).