### PR TITLE
point users at repair() when rehash() moves cached packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # renv (development version)
 
+* `renv::rehash()` now reminds you to run `renv::repair()` when it moves
+  packages within the active cache, since project libraries that still link to
+  a package's previous cache location are left with broken links. The
+  function's documentation has also been corrected: it no longer claims that
+  links to the old locations are retained.
+
 * When `renv::snapshot()` aborts due to a pre-flight validation failure, the
   error now includes a summary of the problems that were detected (for example,
   the missing packages or unsatisfied dependencies). Previously these details

--- a/R/rehash.R
+++ b/R/rehash.R
@@ -6,9 +6,13 @@
 #' renv. This can be useful if the cache scheme has changed in a new version
 #' of renv, but you'd like to preserve your previously-cached packages.
 #'
-#' Any packages which are re-hashed will retain links to the location of the
-#' newly-hashed package, ensuring that prior installations of renv can still
-#' function as expected.
+#' When re-hashing, packages are relocated to the cache location appropriate
+#' for the active version of renv: they are copied when migrating from a
+#' previous cache version, and moved when re-hashing within the active cache.
+#' Because a package's previous cache location is not retained, project
+#' libraries that still link to that old location will be left with broken
+#' links after a re-hash. Use [repair()] (or, equivalently, [restore()])
+#' within those projects to reinstall and re-link the affected packages.
 #'
 #' @inheritParams renv-params
 #'
@@ -77,6 +81,12 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
   fmt <- "Successfully re-cached %s."
   writef(fmt, nplural("package", n))
   renv_cache_clean_empty()
+
+  # moving a package vacates its previous cache location, so any project
+  # libraries still linking there are now broken; nudge the user toward
+  # repair() to restore them
+  if (identical(label, "moved"))
+    writef("- Use `renv::repair()` within a project to restore any now-broken links to the cache.")
 
   TRUE
 }

--- a/man/rehash.Rd
+++ b/man/rehash.Rd
@@ -20,7 +20,11 @@ renv. This can be useful if the cache scheme has changed in a new version
 of renv, but you'd like to preserve your previously-cached packages.
 }
 \details{
-Any packages which are re-hashed will retain links to the location of the
-newly-hashed package, ensuring that prior installations of renv can still
-function as expected.
+When re-hashing, packages are relocated to the cache location appropriate
+for the active version of renv: they are copied when migrating from a
+previous cache version, and moved when re-hashing within the active cache.
+Because a package's previous cache location is not retained, project
+libraries that still link to that old location will be left with broken
+links after a re-hash. Use \code{\link[=repair]{repair()}} (or, equivalently, \code{\link[=restore]{restore()}})
+within those projects to reinstall and re-link the affected packages.
 }

--- a/tests/testthat/test-rehash.R
+++ b/tests/testthat/test-rehash.R
@@ -18,3 +18,28 @@ test_that("rehash() migrates cached packages as expected", {
   expect_match(cached, "/v5/", fixed = TRUE)
 
 })
+
+test_that("rehash() moves mis-hashed packages and points users at repair()", {
+
+  tempcache <- renv_scope_tempfile("renv-cache-")
+  renv_scope_envvars(RENV_PATHS_CACHE = tempcache)
+  renv_scope_envvars(RENV_CACHE_VERSION = "v5")
+  renv_tests_scope("breakfast")
+  init()
+
+  # relocate one cached package to a bogus hash, mimicking a package that was
+  # cached under a previous (stale) hashing scheme within the active cache
+  entry <- renv_cache_list()[[1L]]
+  hashdir <- dirname(entry)
+  bogus <- file.path(dirname(hashdir), "0000000000000000")
+  renv_file_move(hashdir, bogus)
+
+  # rehash should move it back to its correct location and mention repair()
+  renv_scope_options(renv.verbose = TRUE)
+  output <- capture.output(rehash(prompt = FALSE))
+
+  expect_true(file.exists(entry))
+  expect_false(file.exists(bogus))
+  expect_true(any(grepl("renv::repair()", output, fixed = TRUE)))
+
+})


### PR DESCRIPTION
## Summary

`renv::rehash()` moves packages within the active cache to their re-hashed locations. Because a package's previous cache location is not retained, project libraries that still link to that old location are left with broken symlinks after a re-hash.

This PR:

- Prints a reminder to run `renv::repair()` after `rehash()` moves packages within the active cache (the case that vacates old cache locations). The cross-version *copy* path retains the old location, so no hint is shown there.
- Corrects the `rehash()` documentation, which previously claimed that links to the old locations were retained -- behavior that was removed back in 2019 (the linking step was replaced by copy/move).

## Recovery context

renv already has the tooling to recover affected projects: `renv_library_diagnose()` detects broken cache links, and `renv::repair()` (`renv_repair_links()`) reinstalls and re-links the affected packages. This PR simply surfaces that path to the user; it does not add new repair machinery.

## Testing

- New test in `test-rehash.R` exercises the previously-uncovered move path: it relocates a cached package to a bogus hash, runs `rehash(prompt = FALSE)`, and asserts the package is moved back and the `renv::repair()` hint is printed.
- `devtools::test(filter = "rehash")` -> PASS 7 | FAIL 0.