### PR TITLE
read archived DESCRIPTION when resolving pinned version deps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,12 +14,17 @@
   `lockfile(from = "manifest.json", to = "renv.lock")`. The set of supported
   sources may be expanded in future releases. (#2245)
 
-* When the graph resolver cannot determine the dependencies for a pinned
-  package version (because the version is absent from the configured
-  repositories and crandb is unreachable or has no record of it), it falls back
-  to the latest version's dependencies. renv now warns when this happens, since
-  those dependencies may differ from the pinned version's and could lead to an
-  incorrect install order. (#2315)
+* When resolving the dependencies of a pinned package version that is absent
+  from the configured repositories' `PACKAGES` metadata and cannot be found via
+  crandb (for example, when offline, when using an internal mirror that cannot
+  reach `crandb.r-pkg.org`, or for non-CRAN packages), renv now downloads the
+  archived source tarball for that version and reads its `DESCRIPTION` directly.
+  This is authoritative wherever the package itself is reachable, and the
+  downloaded tarball is reused by the subsequent retrieve step. As a last
+  resort, if the archived tarball also cannot be read, renv falls back to the
+  latest version's dependencies and warns, since those dependencies may differ
+  from the pinned version's and could lead to an incorrect install order.
+  (#2315)
 
 * Fixed a regression introduced in renv 1.2.0 where installing a package from
   the cellar (via `install()` or `use()`) failed to install that package's

--- a/R/graph.R
+++ b/R/graph.R
@@ -154,14 +154,25 @@ renv_graph_resolve <- function(remote, envir, records = NULL, fields = NULL, ove
     if (is.null(desc[[field]]))
       desc[[field]] <- record[[field]]
 
-  # supplement with installed DESCRIPTION for non-standard dependency fields
-  # (e.g. Config/Needs/protein); PACKAGES metadata only has standard fields
-  if (!is.null(fields)) {
-    installed <- catch(renv_description_read(package = package))
-    if (!inherits(installed, "error")) {
-      for (field in fields)
-        if (is.null(desc[[field]]) && !is.null(installed[[field]]))
-          desc[[field]] <- installed[[field]]
+  # supplement with the installed package's DESCRIPTION for non-standard
+  # dependency fields (e.g. Config/Needs/protein); PACKAGES metadata and
+  # archived DESCRIPTIONs only carry the standard fields, and those are
+  # already authoritative from the resolution above -- so only the extra
+  # fields need supplementing, never Depends / Imports / LinkingTo.
+  #
+  # only read a package that is actually installed: renv_description_read()
+  # would otherwise resolve an empty path to the working directory and read
+  # the project's own DESCRIPTION, leaking its fields into this record.
+  extra <- setdiff(fields, c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances"))
+  if (length(extra)) {
+    pkgpath <- renv_package_find(package)
+    if (nzchar(pkgpath)) {
+      installed <- catch(renv_description_read(pkgpath))
+      if (!inherits(installed, "error")) {
+        for (field in extra)
+          if (is.null(desc[[field]]) && !is.null(installed[[field]]))
+            desc[[field]] <- installed[[field]]
+      }
     }
   }
 

--- a/R/graph.R
+++ b/R/graph.R
@@ -264,6 +264,17 @@ renv_graph_description_repository <- function(record) {
       return(as.list(crandb))
   }
 
+  # crandb couldn't help -- e.g. we're offline, using an internal mirror that
+  # can't reach crandb.r-pkg.org, or the package isn't from CRAN. download the
+  # archived source tarball for the requested version and read its DESCRIPTION
+  # directly. this is authoritative and works wherever the package itself is
+  # reachable, and the tarball is reused by the later retrieve step (#2315)
+  if (!is.null(version)) {
+    archive <- catch(renv_graph_description_archive(record))
+    if (!inherits(archive, "error"))
+      return(as.list(archive))
+  }
+
   # last-resort fallback when crandb is unreachable or lacks the version: use
   # the latest entry's full fields with the requested version substituted. this
   # may report stale dependency constraints if they changed between versions,
@@ -321,6 +332,52 @@ renv_graph_description_cellar <- function(record) {
       record[[field]] <- desc[[field]]
 
   record
+
+}
+
+renv_graph_description_archive <- function(record) {
+
+  # resolve the source tarball name for this specific package + version
+  name <- renv_retrieve_repos_archive_name(record, type = "source")
+
+  # determine the repositories to search; prefer a recorded Repository,
+  # mirroring renv_retrieve_repos_archive() so we look where retrieve will
+  repos <- getOption("repos")
+  repository <- record[["Repository"]]
+  strict <- renv_restore_state(key = "strict") %||% FALSE
+  if (is.character(repository)) {
+    names(repository) <- names(repository) %||% repository
+    if (grepl("://", repository, fixed = TRUE)) {
+      repos <- when(strict, repository, c(repository, repos))
+    } else if (!strict && repository %in% names(repos)) {
+      matches <- names(repos) == repository
+      repos <- c(repos[matches], repos[!matches])
+    }
+  }
+
+  # download to the shared sources path so that the later retrieve of this
+  # same record reuses the tarball rather than downloading it a second time
+  destfile <- renv_retrieve_path(record, type = "source")
+  ensure_parent_directory(destfile)
+
+  for (repo in repos) {
+
+    root <- renv_retrieve_repos_archive_root(repo, record)
+    if (is.null(root))
+      next
+
+    url <- file.path(root, name)
+    status <- catch(download(url, destfile = destfile, type = "source", quiet = TRUE))
+    if (inherits(status, "error"))
+      next
+
+    desc <- catch(renv_description_read(destfile))
+    if (!inherits(desc, "error"))
+      return(as.list(desc))
+
+  }
+
+  stopf("could not read archived DESCRIPTION for package '%s'", record$Package)
 
 }
 

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -2,9 +2,6 @@
 
     Code
       install("bread@0.1.0")
-    Condition
-      Warning:
-      could not resolve dependencies for bread 0.1.0; using dependencies from the latest version (1.0.0) instead
     Output
       The following package(s) will be installed:
       - bread [0.1.0]

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -1142,6 +1142,31 @@ test_that("repository graph prefers crandb over latest-with-overridden-version",
 
 })
 
+# https://github.com/rstudio/renv/issues/2315
+test_that("repository graph reads archived DESCRIPTION when crandb fails", {
+
+  renv_tests_scope()
+
+  # force crandb to fail, so resolution must fall through to the archive
+  renv_scope_binding(
+    envir = asNamespace("renv"),
+    symbol = "renv_graph_description_crandb",
+    replacement = function(package, version) {
+      stop("crandb unreachable")
+    }
+  )
+
+  # 'today' is 1.0.0 in the repository with 'Depends: R (>= 99.99.99)', while
+  # the archived 0.1.0 has 'Depends: R (>= 1.0.0)'. requesting 0.1.0 must use
+  # the archived version's dependencies, not those of the latest version.
+  record <- list(Package = "today", Version = "0.1.0", Source = "Repository")
+  desc <- renv_graph_description_repository(record)
+
+  expect_equal(desc$Version, "0.1.0")
+  expect_equal(desc$Depends, "R (>= 1.0.0)")
+
+})
+
 # https://github.com/rstudio/renv/issues/2249
 test_that("gitlab DESCRIPTION path handles empty RemoteSubdir", {
 


### PR DESCRIPTION
## Problem

When installing a pinned older version of a package (e.g. `renv::install("selectr@0.5-1")`), the graph resolver could resolve dependencies from the *latest* version instead of the requested one. If the dependencies changed between versions (selectr dropped its `stringr` dependency in 0.6-0), renv would omit a required dependency and the install would fail to build.

This happens in `renv_graph_description_repository()`. For a pinned version absent from the repository `PACKAGES` metadata, renv tries crandb for the version-specific dependencies, but crandb is a public host (`crandb.r-pkg.org`) that is unreachable in exactly the environments where this matters most: offline, internal-mirror-only, or firewalled setups. It's also CRAN-only. When crandb fails, renv fell back to the latest version's dependencies (with a warning added in #2316).

See #2315.

## Change

Between the crandb lookup and the latest-version fallback, renv now downloads the archived source tarball for the requested version and reads its `DESCRIPTION` directly (via the new `renv_graph_description_archive()`). This is authoritative wherever the package itself is reachable, and mirrors the existing cellar handling in `renv_graph_description_cellar()` (#2313).

- crandb is still tried first, since it's cheaper when available; the tarball download is the reliable fallback.
- The tarball is written to the shared sources path (`renv_retrieve_path()`), so the later retrieve step reuses it rather than downloading twice.
- If the archived tarball also can't be read, renv falls back to the latest version's dependencies and warns, as before.

## Test

`test-graph.R` stubs crandb to fail and requests `today@0.1.0` (present only in the test repo's `Archive/`, with `Depends: R (>= 1.0.0)` versus the latest `1.0.0`'s `Depends: R (>= 99.99.99)`), asserting the archived constraint is returned -- proving the archive path, not the latest-version guess, was used.