### PR TITLE
guard against shared-cache corruption installing the wrong package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # renv (development version)
 
+* renv now guards against corrupted cache entries that contain the wrong
+  package. Before installing a package from the cache, renv verifies that the
+  cache entry's `DESCRIPTION` reports the expected package name; if it does not
+  (for example, due to a concurrent write race on a shared cache), renv ignores
+  the entry and reinstalls the package instead of installing the wrong one.
+  `renv::diagnostics()` also reports any such cache entries. (#2322)
+
 * When `renv::snapshot()` aborts due to a pre-flight validation failure, the
   error now includes a summary of the problems that were detected (for example,
   the missing packages or unsatisfied dependencies). Previously these details

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,9 +13,7 @@
   orphaned, even if its timestamp is stale (for example, when a large package
   copy onto a shared cache takes longer than the lock timeout and the watchdog
   is not refreshing the lock). This reduces the chance of a lock being stolen
-  from a live process, which could otherwise corrupt a shared cache. A lock
-  whose owning process has exited is now reclaimed immediately rather than after
-  the timeout. (#2322)
+  from a live process, which could otherwise corrupt a shared cache. (#2322)
 
 * When `renv::snapshot()` aborts due to a pre-flight validation failure, the
   error now includes a summary of the problems that were detected (for example,

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,15 @@
   the entry and reinstalls the package instead of installing the wrong one.
   `renv::diagnostics()` also reports any such cache entries. (#2322)
 
+* renv's file locks now record the host and process that own them. A lock held
+  by a process that is still alive on the same machine is no longer treated as
+  orphaned, even if its timestamp is stale (for example, when a large package
+  copy onto a shared cache takes longer than the lock timeout and the watchdog
+  is not refreshing the lock). This reduces the chance of a lock being stolen
+  from a live process, which could otherwise corrupt a shared cache. A lock
+  whose owning process has exited is now reclaimed immediately rather than after
+  the timeout. (#2322)
+
 * When `renv::snapshot()` aborts due to a pre-flight validation failure, the
   error now includes a summary of the problems that were detected (for example,
   the missing packages or unsatisfied dependencies). Previously these details

--- a/R/cache.R
+++ b/R/cache.R
@@ -356,6 +356,50 @@ renv_cache_diagnose_missing_descriptions <- function(paths, problems, verbose) {
 
 }
 
+renv_cache_diagnose_wrong_package <- function(paths, problems, verbose) {
+
+  # read the 'Package' field recorded in each cached DESCRIPTION file, and
+  # compare it against the package name implied by the cache entry's path.
+  # a mismatch means the slot has been corrupted and is holding the contents
+  # of a different package (for example, due to a concurrent write race on a
+  # shared cache); such an entry would cause renv to install the wrong package.
+  expected <- renv_path_component(paths, 1L)
+  actual <- map_chr(paths, function(path) {
+    dcf <- catch(renv_description_read(path))
+    if (inherits(dcf, "error"))
+      return(NA_character_)
+    dcf[["Package"]] %||% NA_character_
+  })
+
+  wrong <- !is.na(actual) & actual != expected
+  if (!any(wrong))
+    return(paths)
+
+  # nocov start
+  if (verbose) {
+
+    fmt <- "%s [contains: %s]"
+    entries <- sprintf(fmt, renv_cache_format_path(paths[wrong]), actual[wrong])
+
+    bulletin(
+      "The following packages in the cache contain the wrong package:",
+      entries,
+      "These packages should be purged and reinstalled."
+    )
+
+  }
+  # nocov end
+
+  data <- renv_cache_problems(
+    paths  = paths[wrong],
+    reason = "cache entry contains the wrong package"
+  )
+
+  problems$push(data)
+  paths[!wrong]
+
+}
+
 renv_cache_diagnose_bad_hash <- function(paths, problems, verbose) {
 
   expected <- map_chr(paths, renv_cache_path)
@@ -480,6 +524,7 @@ renv_cache_diagnose <- function(verbose = NULL) {
   paths <- renv_cache_list()
   paths <- renv_cache_diagnose_corrupt_metadata(paths, problems, verbose)
   paths <- renv_cache_diagnose_missing_descriptions(paths, problems, verbose)
+  paths <- renv_cache_diagnose_wrong_package(paths, problems, verbose)
   paths <- renv_cache_diagnose_bad_hash(paths, problems, verbose)
   paths <- renv_cache_diagnose_wrong_built_version(paths, problems, verbose)
 
@@ -543,7 +588,7 @@ renv_cache_clean_empty <- function(cache = NULL) {
 renv_cache_package_validate <- function(path) {
 
   if (renv_project_type(path) == "package")
-    return(TRUE)
+    return(renv_cache_package_validate_name(path))
 
   type <- renv_file_type(path, symlinks = FALSE)
   if (!nzchar(type))
@@ -552,6 +597,29 @@ renv_cache_package_validate <- function(path) {
   name <- if (type == "directory") "directory" else "file"
   fmt <- "%s %s exists but does not appear to be an R package"
   warningf(fmt, name, dQuote(path))
+
+  FALSE
+
+}
+
+# verify that a cache entry actually contains the package its path implies.
+# a mismatch indicates a corrupted cache slot (for example, from a concurrent
+# write race on a shared cache) that would otherwise cause renv to install the
+# wrong package; treat such an entry as unusable so the caller reinstalls.
+renv_cache_package_validate_name <- function(path) {
+
+  expected <- basename(path)
+
+  dcf <- catch(renv_description_read(path))
+  if (inherits(dcf, "error"))
+    return(TRUE)
+
+  actual <- dcf[["Package"]]
+  if (is.null(actual) || identical(actual, expected))
+    return(TRUE)
+
+  fmt <- "cache entry %s contains the wrong package ('%s'); ignoring it"
+  warningf(fmt, dQuote(path), actual)
 
   FALSE
 

--- a/R/lock.R
+++ b/R/lock.R
@@ -48,7 +48,48 @@ renv_lock_acquire_impl <- function(path) {
   }
 
   # attempt to create the lock
-  dir.create(path, mode = "0755", showWarnings = FALSE)
+  created <- dir.create(path, mode = "0755", showWarnings = FALSE)
+
+  # if we created the lock, record its owner so that other processes can
+  # tell whether the lock is still held by a live process on this machine
+  if (created)
+    renv_lock_owner_write(path)
+
+  created
+
+}
+
+# record the host + process that owns a lock, so that renv_lock_orphaned()
+# can check whether the owning process is still alive rather than relying
+# solely on the lock's timestamp being kept fresh by the watchdog
+renv_lock_owner_write <- function(path) {
+
+  contents <- c(
+    sprintf("Host: %s", renv_platform_nodename()),
+    sprintf("Pid: %i", Sys.getpid())
+  )
+
+  owner <- file.path(path, "owner")
+  catchall(writeLines(contents, con = owner))
+
+}
+
+renv_lock_owner_read <- function(path) {
+
+  owner <- file.path(path, "owner")
+  if (!file.exists(owner))
+    return(NULL)
+
+  props <- catch(renv_properties_read(owner))
+  if (inherits(props, "error"))
+    return(NULL)
+
+  host <- props[["Host"]]
+  pid <- suppressWarnings(as.integer(props[["Pid"]]))
+  if (is.null(host) || is.na(pid))
+    return(NULL)
+
+  list(host = host, pid = pid)
 
 }
 
@@ -85,6 +126,26 @@ renv_lock_orphaned <- function(path) {
   if (is.na(info$isdir))
     return(FALSE)
 
+  # if the lock records an owner on this host, check whether that process is
+  # still alive. this lets us keep a live but slow lock holder (for example, a
+  # large package copy onto a shared network cache) from having its lock stolen
+  # when the watchdog isn't refreshing the lock's timestamp -- and lets us
+  # reclaim a dead owner's lock immediately, without waiting for the timeout.
+  #
+  # NOTE: we intentionally trust a live pid here rather than also enforcing the
+  # timeout, since stealing a live holder's lock is what causes cache corruption
+  # in the first place. this could in theory be fooled by pid reuse, but that is
+  # far less likely (and less harmful) than the race it prevents.
+  owner <- renv_lock_owner_read(path)
+  if (!is.null(owner) && identical(owner$host, renv_platform_nodename())) {
+    alive <- catch(renv_process_exists(owner$pid))
+    if (!inherits(alive, "error"))
+      return(!alive)
+  }
+
+  # otherwise (no owner recorded, a lock held on another host, or we couldn't
+  # determine liveness) fall back to treating the lock as orphaned once its
+  # timestamp becomes stale
   diff <- difftime(Sys.time(), info$mtime, units = "secs")
   diff >= timeout
 

--- a/R/lock.R
+++ b/R/lock.R
@@ -126,25 +126,27 @@ renv_lock_orphaned <- function(path) {
   if (is.na(info$isdir))
     return(FALSE)
 
-  # if the lock records an owner on this host, check whether that process is
-  # still alive. this lets us keep a live but slow lock holder (for example, a
-  # large package copy onto a shared network cache) from having its lock stolen
-  # when the watchdog isn't refreshing the lock's timestamp -- and lets us
-  # reclaim a dead owner's lock immediately, without waiting for the timeout.
+  # if the lock records an owner on this host and that process is still alive,
+  # the lock is not orphaned -- even if its timestamp is stale. this keeps a
+  # live but slow lock holder (for example, a large package copy onto a shared
+  # network cache) from having its lock stolen when the watchdog isn't
+  # refreshing the lock's timestamp.
   #
-  # NOTE: we intentionally trust a live pid here rather than also enforcing the
-  # timeout, since stealing a live holder's lock is what causes cache corruption
-  # in the first place. this could in theory be fooled by pid reuse, but that is
-  # far less likely (and less harmful) than the race it prevents.
+  # NOTE: we only trust a *positive* liveness result. renv_process_exists() can
+  # report FALSE for a live process we don't have permission to inspect (for
+  # example, another user's process on a shared machine), and treating that as
+  # orphaned would let us steal a live holder's lock -- the very race that
+  # corrupts a shared cache. so anything other than a definite "alive" falls
+  # through to the timeout below, which is no worse than the previous behavior.
   owner <- renv_lock_owner_read(path)
   if (!is.null(owner) && identical(owner$host, renv_platform_nodename())) {
     alive <- catch(renv_process_exists(owner$pid))
-    if (!inherits(alive, "error"))
-      return(!alive)
+    if (isTRUE(alive))
+      return(FALSE)
   }
 
-  # otherwise (no owner recorded, a lock held on another host, or we couldn't
-  # determine liveness) fall back to treating the lock as orphaned once its
+  # otherwise (no owner recorded, a lock held on another host, an owner we
+  # can't confirm is alive) fall back to treating the lock as orphaned once its
   # timestamp becomes stale
   diff <- difftime(Sys.time(), info$mtime, units = "secs")
   diff >= timeout

--- a/R/platform.R
+++ b/R/platform.R
@@ -49,6 +49,10 @@ renv_platform_solaris <- function() {
   the$sysinfo[["sysname"]] == "SunOS"
 }
 
+renv_platform_nodename <- function() {
+  the$sysinfo[["nodename"]] %||% Sys.info()[["nodename"]]
+}
+
 renv_platform_wsl <- function() {
 
   pv <- "/proc/version"

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -181,6 +181,61 @@ test_that("invalid Built field is detected", {
 
 })
 
+test_that("a cache entry containing the wrong package is detected", {
+
+  skip_on_cran()
+  renv_tests_scope()
+
+  cachepath <- renv_scope_tempfile("renv-cache-")
+  renv_scope_envvars(RENV_PATHS_CACHE = cachepath)
+
+  init()
+  install("bread")
+
+  path <- renv_cache_find(list(Package = "bread", Version = "1.0.0"))
+  expect_true(nzchar(path) && file.exists(path))
+
+  # rewrite the DESCRIPTION so the slot claims to hold a different package,
+  # simulating a corrupted cache entry (e.g. from a concurrent write race)
+  descpath <- file.path(path, "DESCRIPTION")
+  desc <- renv_description_read(descpath)
+  desc$Package <- "toast"
+  renv_dcf_write(desc, file = descpath)
+
+  diagnostics <- renv_cache_diagnose(verbose = FALSE)
+
+  expect_true(is.data.frame(diagnostics))
+  expect_true(nrow(diagnostics) == 1)
+  expect_true(diagnostics$Package == "bread")
+  expect_true(diagnostics$Version == "1.0.0")
+
+})
+
+test_that("a cache entry containing the wrong package is not installed", {
+
+  skip_on_cran()
+  renv_tests_scope()
+
+  cachepath <- renv_scope_tempfile("renv-cache-")
+  renv_scope_envvars(RENV_PATHS_CACHE = cachepath)
+
+  init()
+  install("bread")
+
+  path <- renv_cache_find(list(Package = "bread", Version = "1.0.0"))
+  expect_true(renv_cache_package_validate(path))
+
+  # corrupt the slot so it holds a different package
+  descpath <- file.path(path, "DESCRIPTION")
+  desc <- renv_description_read(descpath)
+  desc$Package <- "toast"
+  renv_dcf_write(desc, file = descpath)
+
+  expect_warning(valid <- renv_cache_package_validate(path))
+  expect_false(valid)
+
+})
+
 test_that("ACLs set on packages in project library are reset", {
 
   skip_on_cran()

--- a/tests/testthat/test-lock.R
+++ b/tests/testthat/test-lock.R
@@ -161,6 +161,76 @@ test_that("old locks are considered 'orphaned'", {
 
 })
 
+test_that("a lock held by a live process is not orphaned, even if stale", {
+
+  skip_on_cran()
+
+  renv_scope_options(renv.config.locking.enabled = TRUE)
+  renv_scope_envvars(RENV_WATCHDOG_ENABLED = "FALSE")
+  renv_scope_options(renv.lock.timeout = 60L)
+
+  path <- renv_lock_path(renv_scope_tempfile())
+  renv_lock_acquire(path)
+
+  # age the lock past the timeout; because it records this (live) process as
+  # its owner, it should still not be considered orphaned
+  Sys.setFileTime(path, Sys.time() - 3600)
+
+  expect_false(renv_lock_orphaned(path))
+
+  renv_lock_release(path)
+
+})
+
+test_that("a lock owned by a dead process is orphaned immediately", {
+
+  skip_on_cran()
+
+  renv_scope_options(renv.lock.timeout = 60L)
+
+  path <- renv_lock_path(renv_scope_tempfile())
+  dir.create(path)
+
+  # find a pid that isn't currently in use
+  deadpid <- 2147483646L
+  while (renv_process_exists(deadpid))
+    deadpid <- deadpid - 1L
+
+  contents <- c(
+    sprintf("Host: %s", renv_platform_nodename()),
+    sprintf("Pid: %i", deadpid)
+  )
+  writeLines(contents, con = file.path(path, "owner"))
+
+  # even with a fresh timestamp, a dead owner means the lock is orphaned
+  expect_true(renv_lock_orphaned(path))
+
+})
+
+test_that("a lock owned by another host falls back to the timeout", {
+
+  skip_on_cran()
+
+  renv_scope_options(renv.lock.timeout = 60L)
+
+  path <- renv_lock_path(renv_scope_tempfile())
+  dir.create(path)
+
+  contents <- c(
+    "Host: some-other-host-that-is-not-us",
+    sprintf("Pid: %i", Sys.getpid())
+  )
+  writeLines(contents, con = file.path(path, "owner"))
+
+  # a fresh lock on another host is not orphaned ...
+  expect_false(renv_lock_orphaned(path))
+
+  # ... but a stale one is
+  Sys.setFileTime(path, Sys.time() - 3600)
+  expect_true(renv_lock_orphaned(path))
+
+})
+
 test_that("multiple renv processes successfully acquire, release locks", {
 
   skip_on_cran()

--- a/tests/testthat/test-lock.R
+++ b/tests/testthat/test-lock.R
@@ -182,7 +182,7 @@ test_that("a lock held by a live process is not orphaned, even if stale", {
 
 })
 
-test_that("a lock owned by a dead process is orphaned immediately", {
+test_that("a lock owned by a dead process falls back to the timeout", {
 
   skip_on_cran()
 
@@ -202,7 +202,11 @@ test_that("a lock owned by a dead process is orphaned immediately", {
   )
   writeLines(contents, con = file.path(path, "owner"))
 
-  # even with a fresh timestamp, a dead owner means the lock is orphaned
+  # a dead owner does not make a fresh lock orphaned (we can't distinguish a
+  # dead pid from one we lack permission to inspect), but a stale one is
+  expect_false(renv_lock_orphaned(path))
+
+  Sys.setFileTime(path, Sys.time() - 3600)
   expect_true(renv_lock_orphaned(path))
 
 })


### PR DESCRIPTION
Addresses reports of a shared renv cache installing the *wrong* package (e.g. `styler` -> `brew`) on multi-user Posit Workbench, per #2322.

styler never depended on `brew`, so the screenshots there reflect a **corrupted cache slot** holding another package's contents -- consistent with a concurrent-write race on the shared cache. This branch adds a defensive guard so the user-visible breakage stops regardless of root cause, plus hardening for the concurrency weak point I found.

### Changes

**1. Guard against cache entries containing the wrong package (`fb96ae1b1`)**
- Before installing a package from the cache, `renv_cache_package_validate()` now verifies the entry's `DESCRIPTION` `Package` field matches the slot's package name. On mismatch renv ignores the entry and reinstalls, rather than installing the wrong package.
- `renv::diagnostics()` reports such entries (new `renv_cache_diagnose_wrong_package()`). This also closes a gap in the existing hash check, which missed a corrupted slot whenever the correct target already existed.

**2. Owner-aware lock orphan detection (`c05049155`, refined in `08dac4600`)**
- File locks now record the owning host + pid. A lock held by a live process on the same host is no longer treated as orphaned even if its timestamp is stale -- closing the window where a slow copy (large package onto a slow/shared FS) outlives the 60s lock timeout while the watchdog isn't refreshing it, and its lock gets stolen by another process.
- Only a *positive* liveness result is trusted: `renv_process_exists()` can return FALSE for a live process owned by another user (common on single-host multi-user Workbench), so anything other than a definite "alive" falls back to the mtime timeout -- never worse than the previous behavior.

### Not changed
The cache slot publish is already atomic (copy into a temp dir under the target parent, then `rename` into place), so no change was needed there.

### Tests
New tests in `test-cache.R` (diagnostic + validate guard) and `test-lock.R` (live owner not orphaned; dead / other-host owners fall back to timeout). All cache and lock tests pass.
