### PR TITLE
avoid network query in ppm transform test

### DIFF
--- a/tests/testthat/test-ppm.R
+++ b/tests/testthat/test-ppm.R
@@ -16,6 +16,11 @@ test_that("repository URLs are properly transformed for different platforms", {
   skip_on_os("windows")
 
   renv_scope_envvars(RENV_RSPM_OS = "__linux__", RENV_RSPM_PLATFORM = "bionic")
+
+  # treat the repository as a known PPM instance, so that the transform is
+  # resolved locally rather than via a (flaky) network query to the server
+  renv_scope_options(renv.ppm.repos = "https://cluster.rstudiopm.com")
+
   repos <- c(RSPM = "https://cluster.rstudiopm.com/cran/latest")
   expected <- c(RSPM = "https://cluster.rstudiopm.com/cran/__linux__/bionic/latest")
   actual <- renv_ppm_transform(repos)


### PR DESCRIPTION
## Summary

The `repository URLs are properly transformed for different platforms` test in `test-ppm.R` used `cluster.rstudiopm.com`, which is not a known PPM host. As a result, `renv_ppm_transform_impl()` fell through to a live query of the server's `/__api__/status` endpoint. That query is wrapped in `catch()`/`tryCatch()`, so any network hiccup is swallowed and the URL is returned untransformed -- producing intermittent CI failures (e.g. the `macos-latest (release)` and `ubuntu-latest (oldrel-3)` failures seen in #2323, which were unrelated to that PR's changes).

This declares the host via the `renv.ppm.repos` option so the transform takes the deterministic "known PPM instance" branch and is resolved locally, without any network access. The test still exercises the real transform logic and still honors the `RENV_RSPM_OS` / `RENV_RSPM_PLATFORM` env vars.

## Testing

- `devtools::test(filter = "ppm")` -> FAIL 0 | PASS 28