### PR TITLE
error when reading DESCRIPTION for a not-installed package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # renv (development version)
 
+* Internal DESCRIPTION reads that request a package by name now error when that
+  package is not installed, rather than silently falling back to the DESCRIPTION
+  in the current working directory. (#2327)
+
 * When `renv::snapshot()` aborts due to a pre-flight validation failure, the
   error now includes a summary of the problems that were detected (for example,
   the missing packages or unsatisfied dependencies). Previously these details

--- a/R/description.R
+++ b/R/description.R
@@ -6,7 +6,11 @@ renv_description_read <- function(path = NULL,
                                   ...)
 {
   # if given a package name, construct path to that package
-  path <- path %||% renv_package_find_impl(package, compat = TRUE)
+  if (is.null(path)) {
+    path <- renv_package_find_impl(package, compat = TRUE)
+    if (!nzchar(path))
+      stopf("package '%s' is not installed", package)
+  }
 
   # normalize non-absolute paths
   if (!renv_path_absolute(path))

--- a/tests/testthat/test-description.R
+++ b/tests/testthat/test-description.R
@@ -41,6 +41,19 @@ test_that("we read DESCRIPTION files correctly", {
 
 })
 
+test_that("reading a not-installed package errors rather than falling back to cwd", {
+
+  # ensure we have a project DESCRIPTION in the working directory, so that
+  # the old fallback behavior would have silently read it
+  renv_tests_scope()
+  writeLines("Package: project", con = "DESCRIPTION")
+
+  # requesting a package that isn't installed should error, not return the
+  # working-directory DESCRIPTION (https://github.com/rstudio/renv/issues/2327)
+  expect_error(renv_description_read(package = "this.package.does.not.exist"))
+
+})
+
 test_that("we can read a DESCRIPTION file with empty lines", {
 
   contents <- heredoc("


### PR DESCRIPTION
Fixes #2327.

## Problem

`renv_description_read(package = X)` did not fail when package `X` could not be found on the library paths. Instead it silently fell back to reading the `DESCRIPTION` in the current working directory (typically the active project's own `DESCRIPTION`).

`renv_package_find_impl()` returns `""` for a package that isn't installed. The empty string is not absolute, so `renv_path_normalize("")` resolves it to the working directory, `dir.exists()` is then `TRUE`, and the code reads `<cwd>/DESCRIPTION`.

This was the root cause behind the CI failures investigated in #2324.

## Fix

When `package` is supplied (and no explicit `path`), error out if `renv_package_find_impl()` returns `""`, rather than falling through to path normalization. The explicit-`path` case retains its existing behavior.

## Caller check

- `graph.R` wraps the call in `catch()`, so the new error is handled gracefully.
- `cache.R` passes a path positionally, so it is unaffected.

## Tests

Added a regression test that writes a working-directory `DESCRIPTION` and confirms requesting a non-installed package errors instead of returning it.