### PR TITLE
don't upgrade transitive dependencies when installing with pak (#2329)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # renv (development version)
 
+* `renv::install()` with pak enabled no longer upgrades already-installed
+  dependencies that are only pulled in transitively -- most visibly recommended
+  packages such as `cluster` or `Matrix`, which previously could be rebuilt when
+  installing an unrelated package. renv now passes `upgrade = FALSE` to pak,
+  matching renv's own installer, while still forcing a (re)install of the
+  packages you explicitly request. (#2329)
+
 * Internal DESCRIPTION reads that request a package by name now error when that
   package is not installed, rather than silently falling back to the DESCRIPTION
   in the current working directory. (#2327)

--- a/R/pak.R
+++ b/R/pak.R
@@ -165,18 +165,23 @@ renv_pak_install <- function(packages,
   pattern <- "(?<!:):([^/#@:]+)"
   packages <- gsub(pattern, "/\\1", packages, perl = TRUE)
   
-  # build parameters
+  # build parameters. explicitly-requested packages always get 'reinstall',
+  # so they are installed even when already current -- matching renv's non-pak
+  # installer, which always (re)installs explicitly-requested packages. with
+  # 'upgrade = FALSE', pak then leaves transitive dependencies (including
+  # recommended packages like 'cluster') at their installed version unless a
+  # dependency constraint requires otherwise. https://github.com/rstudio/renv/issues/2329
   packages <- map_chr(packages, function(package) {
 
     params <- c(
       if (identical(type, "source")) "source",
-      if (identical(rebuild, TRUE) || package %in% rebuild) "reinstall"
+      "reinstall"
     )
 
-    if (length(params))
-      paste(package, paste(params, collapse = "&"), sep = "?")
-    else
-      package
+    # pak (pkgdepends) reads everything after the first '?' as an '&'-separated
+    # query; append with '&' if the spec already carries a query, '?' otherwise
+    sep <- if (grepl("?", package, fixed = TRUE)) "&" else "?"
+    paste(package, paste(params, collapse = "&"), sep = sep)
 
   })
 
@@ -184,7 +189,7 @@ renv_pak_install <- function(packages,
     pkg     = packages,
     lib     = library[[1L]],
     ask     = prompt,
-    upgrade = TRUE
+    upgrade = FALSE
   )
 }
 

--- a/tests/testthat/test-pak.R
+++ b/tests/testthat/test-pak.R
@@ -92,6 +92,81 @@ test_that("install() with an explicit scope filtered to empty is a no-op with pa
 
 })
 
+test_that("install() forces reinstall of explicit requests, not deps (#2329)", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  pak <- renv_namespace_load("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  renv_tests_scope("bread")
+
+  args <- NULL
+  local_mocked_bindings(renv_pak_init = function(...) invisible(NULL))
+  local_mocked_bindings(
+    .package = "pak",
+    pkg_install = function(pkg, upgrade, ...) {
+      args <<- list(pkg = pkg, upgrade = upgrade)
+      invisible(data.frame(package = character()))
+    }
+  )
+
+  quietly(install("bread"))
+
+  # the explicitly-requested package is forced to (re)install, so it is
+  # installed even when already current; upgrade = FALSE leaves pak's
+  # transitively-resolved dependencies (e.g. recommended packages) alone
+  expect_equal(unname(args$pkg), "bread?reinstall")
+  expect_false(args$upgrade)
+
+})
+
+test_that("install() appends reinstall to specs that already carry a query", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  pak <- renv_namespace_load("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  renv_tests_scope("bread")
+
+  args <- NULL
+  local_mocked_bindings(renv_pak_init = function(...) invisible(NULL))
+  local_mocked_bindings(
+    .package = "pak",
+    pkg_install = function(pkg, ...) {
+      args <<- pkg
+      invisible(data.frame(package = character()))
+    }
+  )
+
+  # a spec that already has a '?query' must extend it with '&', not a second
+  # '?', so pkgdepends parses both parameters
+  quietly(install("bread?nocache"))
+  expect_equal(unname(args), "bread?nocache&reinstall")
+
+})
+
+test_that("install() does not upgrade transitively-pulled recommended packages (#2329)", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  pak <- renv_namespace_load("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  project <- renv_tests_scope()
+
+  # 'toast' depends on 'bread'; installing 'toast' must not upgrade an
+  # already-installed, dependency-satisfying 'bread'.
+  quietly(install("bread@0.1.0"))
+  expect_equal(renv_package_version("bread"), "0.1.0")
+
+  quietly(install("toast"))
+  expect_true(renv_package_installed("toast"))
+  expect_equal(renv_package_version("bread"), "0.1.0")
+
+})
+
 test_that("renv::update() works in projects using pak", {
 
   skip_on_cran()


### PR DESCRIPTION
Fixes #2329.

## Problem

`renv::install()` with pak enabled upgrades already-installed dependencies that are only pulled in transitively. Most visibly this affects recommended packages (e.g. `cluster`, `Matrix`) that ship with R: installing an unrelated package like `clue` would drag in `cluster` and, because renv forced `upgrade = TRUE`, pak would upgrade/rebuild it even though `clue` imposed no version constraint. In the reported case that rebuild then failed to compile locally.

The root cause is that `renv_pak_install()` passed `upgrade = TRUE` to `pak::pkg_install()`. pak's default is `upgrade = FALSE`, which does the minimum work to satisfy the request: it installs/upgrades the explicitly-requested packages to the latest version, but leaves already-installed dependencies alone unless a constraint requires a newer one. Forcing `upgrade = TRUE` overrode that and upgraded everything, diverging from renv's own native installer (`renv_graph_needs_update`), which leaves already-satisfied dependencies alone.

## Fix

Pass `upgrade = FALSE` in `renv_pak_install()`, matching pak's default and renv's native installer.

To preserve the one useful property of `upgrade = TRUE` -- that an explicit request is always acted upon -- append the `reinstall` pak parameter to explicitly-requested packages. This mirrors renv's native installer, which always (re)installs explicitly-requested packages (`renv_restore_find` returns `""` for anything in `state$packages`). Verified behaviors against pak 0.10.0:

- explicit request -> installed into the project library and taken to the latest version (and reinstalled even when already current);
- transitive dependency (including recommended packages) -> left at the installed version unless a dependency constraint requires an upgrade.

The query parameter is appended following pkgdepends' own model (everything after the first `?` is an `&`-separated query), so a spec that already carries a query (e.g. `bread?nocache`) is extended with `&` rather than a malformed second `?`.

The no-arg "update everything" path (`renv_pak_update`) is unchanged and still uses `upgrade = TRUE`.

## Tests

Added to `tests/testthat/test-pak.R`:
- explicit requests are sent to pak as `pkg?reinstall` with `upgrade = FALSE`;
- a spec that already has a query gets `&reinstall` appended (not a second `?`);
- a real (skip_if_not_installed) test that installing `toast` does not upgrade an already-installed, dependency-satisfying `bread`.

Full pak suite passes (37 passed, 0 failed, 0 skipped).