### PR TITLE
Suppress failed binary output after source fallback

### DIFF
--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -721,22 +721,19 @@ renv_retrieve_repos <- function(record) {
 
   for (method in methods$data()) {
 
-    status <- catch(
-      withCallingHandlers(
-        method(record),
-        renv.retrieve.error = function(error) {
-          errors$push(error$data)
-        }
-      )
-    )
+    attempt <- renv_retrieve_repos_try(method, record)
+    for (error in attempt$errors)
+      errors$push(error)
 
-    if (inherits(status, "error")) {
-      errors$push(status)
+    status <- attempt$status
+
+    if (inherits(status, "error"))
       next
-    }
 
-    if (identical(status, TRUE))
+    if (identical(status, TRUE)) {
+      writeLines(attempt$output)
       return(TRUE)
+    }
 
     if (!is.logical(status)) {
       fmt <- "internal error: unexpected status code '%s'"
@@ -754,6 +751,32 @@ renv_retrieve_repos <- function(record) {
 
   remote <- renv_record_format_remote(record, compact = TRUE)
   stopf("failed to retrieve package '%s'", remote)
+
+}
+
+renv_retrieve_repos_try <- function(method, record) {
+
+  errors <- stack()
+
+  output <- utils::capture.output({
+    status <- catch(
+      withCallingHandlers(
+        method(record),
+        renv.retrieve.error = function(error) {
+          errors$push(error$data)
+        }
+      )
+    )
+  })
+
+  if (inherits(status, "error") && !length(errors$data()))
+    errors$push(status)
+
+  list(
+    status = status,
+    errors = errors$data(),
+    output = output
+  )
 
 }
 

--- a/tests/testthat/test-retrieve.R
+++ b/tests/testthat/test-retrieve.R
@@ -310,6 +310,55 @@ test_that("we can retrieve packages from R repositories", {
 
 })
 
+test_that("failed binary retrieval is quiet when source fallback succeeds", {
+
+  skip_if(identical(.Platform$pkgType, "source"))
+
+  renv_tests_scope(isolated = TRUE)
+
+  repopath <- renv_scope_tempfile("renv-repository-")
+  srccontrib <- file.path(repopath, "src", "contrib")
+  ensure_directory(srccontrib)
+
+  tarball <- file.path(srccontrib, "bread_1.0.0.tar.gz")
+  local({
+    renv_scope_wd(renv_tests_path("packages"))
+    utils::tar(tarball, "bread", compression = "gzip", tar = "internal")
+  })
+  tools::write_PACKAGES(srccontrib, type = "source")
+
+  # Advertise a binary package without providing its archive.
+  bincontrib <- paste0(repopath, contrib.url("", type = .Platform$pkgType))
+  ensure_directory(bincontrib)
+  file.copy(file.path(srccontrib, "PACKAGES"), bincontrib)
+
+  fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
+  repos <- c(CRAN = sprintf(fmt, repopath))
+  renv_scope_options(pkgType = "both", repos = repos)
+
+  record <- list(
+    Package = "bread",
+    Version = "1.0.0",
+    Source  = "Repository"
+  )
+
+  library <- renv_scope_tempfile("renv-library-")
+  ensure_directory(library)
+  renv_scope_restore(
+    project = getwd(),
+    library = library,
+    records = list(bread = record),
+    packages = "bread",
+    recursive = TRUE
+  )
+
+  output <- utils::capture.output(status <- renv_retrieve_repos(record))
+
+  expect_true(status)
+  expect_false(any(grepl("ERROR", output, fixed = TRUE)))
+
+})
+
 test_that("we can retrieve files using file URIs", {
 
   skip_on_cran()


### PR DESCRIPTION
## Summary

Suppress output from failed repository retrieval candidates when a later candidate succeeds.

## Thanks to maintainers

Thanks for maintaining renv and for documenting the binary-to-source fallback behavior in #1727.

## Issue or motivation

Closes #1727. When a binary archive is unavailable but the source archive can be downloaded, users currently see an `ERROR` line immediately followed by a successful download for the same package.

## Root cause

Each retrieval candidate writes its download result before renv knows whether another candidate will succeed. The same download condition can also be collected once when signaled and again when the candidate stops.

## Change

Capture output separately for each repository retrieval candidate and replay only the output from the candidate that succeeds. If every candidate fails, keep the existing aggregate error reporting. Avoid adding a final thrown error when that candidate already signaled a retrieval error.

## Tests

- `NOT_CRAN=true RENV_EXT_ENABLED=FALSE Rscript -e 'devtools::test(filter = "retrieve", stop_on_failure = TRUE)'` (25 passed, 13 expected skips)
- Local binary-index / missing-archive / source-fallback reproduction
- `RENV_EXT_ENABLED=FALSE R CMD build .`
- `RENV_EXT_ENABLED=FALSE R CMD check --no-manual renv_1.2.3.9000.tar.gz` (`Status: OK`)

## Scope

No changes to repository queries, candidate ordering, package selection, installation behavior, or public APIs.