### PR TITLE
detect rlang::check_installed() and testthat optional dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,15 @@
 
 # renv (development version)
 
+* `renv::dependencies()` now detects packages referenced via
+  `rlang::check_installed()` and `rlang::is_installed()`. (#1936)
+
+* `renv::dependencies()` now infers the optional packages required by certain
+  testthat functions; for example, `skip_if_offline()` implies a dependency on
+  curl, and `snapshot_review()` implies dependencies on shiny and diffviewer.
+  In addition, usage of the Junit reporter is now also detected in calls to
+  `test_check()` and `test_local()`. (#1936)
+
 * `renv::install()` with pak enabled no longer upgrades already-installed
   dependencies that are only pulled in transitively -- most visibly recommended
   packages such as `cluster` or `Matrix`, which previously could be rebuilt when

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -8,7 +8,9 @@
 #' `require(package)`, `requireNamespace("package")`, and `package::method()`.
 #' renv also supports package loading with
 #' [box](https://cran.r-project.org/package=box) (`box::use(...)`) and
-#' [pacman](https://cran.r-project.org/package=pacman) (`pacman::p_load(...)`).
+#' [pacman](https://cran.r-project.org/package=pacman) (`pacman::p_load(...)`),
+#' as well as dependency checks of the form `rlang::check_installed("package")`
+#' and `rlang::is_installed("package")`.
 #'
 #' For \R package projects, `renv` will also detect dependencies expressed
 #' in the `DESCRIPTION` file. For projects using Python, \R dependencies within
@@ -1139,6 +1141,7 @@ renv_dependencies_discover_r <- function(path  = NULL,
     renv_dependencies_discover_r_xfun,
     renv_dependencies_discover_r_library_require,
     renv_dependencies_discover_r_require_namespace,
+    renv_dependencies_discover_r_rlang,
     renv_dependencies_discover_r_colon,
     renv_dependencies_discover_r_citation,
     renv_dependencies_discover_r_system_file,
@@ -1289,6 +1292,38 @@ renv_dependencies_discover_r_require_namespace <- function(node, envir) {
 
   FALSE
 
+
+}
+
+renv_dependencies_discover_r_rlang <- function(node, envir) {
+
+  node <- renv_call_expect(node, "rlang", c("check_installed", "is_installed"))
+  if (is.null(node))
+    return(FALSE)
+
+  matched <- catch(match.call(function(pkg, ...) NULL, node))
+  if (inherits(matched, "error"))
+    return(FALSE)
+
+  # packages might be provided as a vector, e.g. c("a", "b")
+  pkg <- matched$pkg
+  parts <- list(pkg)
+  if (renv_call_matches(pkg, "c"))
+    parts <- as.list(pkg[-1L])
+
+  for (part in parts) {
+
+    if (!is.character(part) || length(part) != 1L)
+      next
+
+    # entries can include version requirements, e.g. "pkg (>= 1.0.0)"
+    package <- sub("\\s*\\(.*", "", part)
+    if (nzchar(package))
+      envir[[package]] <- TRUE
+
+  }
+
+  TRUE
 
 }
 
@@ -1680,8 +1715,31 @@ renv_dependencies_discover_r_testthat <- function(node, envir) {
     return(TRUE)
   }
 
+  # check for usages of testthat functions requiring optional packages
+  implied <- list(
+    expect_known_hash = "digest",
+    expect_s7_class   = "S7",
+    expect_vector     = "vctrs",
+    run_cpp_tests     = "xml2",
+    skip_if_offline   = "curl",
+    snapshot_review   = c("shiny", "diffviewer")
+  )
+
+  call <- renv_call_expect(node, "testthat", names(implied))
+  if (!is.null(call)) {
+    packages <- implied[[as.character(call[[1L]])]]
+    for (package in packages)
+      envir[[package]] <- TRUE
+    return(TRUE)
+  }
+
   # check for calls to various test runners, which accept a reporter
-  node <- renv_call_expect(node, "testthat", c("test_package", "test_dir", "test_file"))
+  node <- renv_call_expect(
+    node,
+    "testthat",
+    c("test_package", "test_dir", "test_file", "test_check", "test_local")
+  )
+
   if (is.null(node))
     return(FALSE)
 

--- a/man/dependencies.Rd
+++ b/man/dependencies.Rd
@@ -66,7 +66,9 @@ parsing the code and looking for calls of the form \code{library(package)},
 \code{require(package)}, \code{requireNamespace("package")}, and \code{package::method()}.
 renv also supports package loading with
 \href{https://cran.r-project.org/package=box}{box} (\code{box::use(...)}) and
-\href{https://cran.r-project.org/package=pacman}{pacman} (\code{pacman::p_load(...)}).
+\href{https://cran.r-project.org/package=pacman}{pacman} (\code{pacman::p_load(...)}),
+as well as dependency checks of the form \code{rlang::check_installed("package")}
+and \code{rlang::is_installed("package")}.
 
 For \R package projects, \code{renv} will also detect dependencies expressed
 in the \code{DESCRIPTION} file. For projects using Python, \R dependencies within
@@ -91,6 +93,13 @@ It also can't generally tell if one of the packages you use, uses one of
 its suggested packages. For example, the \code{tidyr::separate_wider_delim()}
 function requires the \code{stringr} package, but \code{stringr} is only suggested,
 not required, by \code{tidyr}.
+
+For a small number of common cases, renv infers these indirect dependencies
+from the combination of packages in use. For example, a project that uses
+\code{dplyr} together with a database backend (such as \code{DBI} and \code{RSQLite}) is
+assumed to also require \code{dbplyr}, which \code{dplyr} loads at runtime when working
+with databases. These rules are defined by the \code{renv.dependencies.implied}
+\R option; set it to an empty list (\code{options(renv.dependencies.implied = list())}) to disable this inference entirely.
 
 If you find that renv's dependency discovery misses one or more packages
 that you actually use in your project, one escape hatch is to include a file

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -656,6 +656,52 @@ test_that("dependencies() detects usages of Junit test reporters", {
   check("JunitReporter$new()")
   check("testthat::test_dir(reporter = JunitReporter)")
   check("testthat::test_dir(reporter = \"junit\")")
+  check("testthat::test_check(\"example\", reporter = \"junit\")")
+  check("testthat::test_local(reporter = JunitReporter)")
+
+})
+
+test_that("dependencies() detects testthat functions with optional dependencies", {
+
+  check <- function(document, packages) {
+    file <- renv_scope_tempfile("renv-test-", fileext = ".R")
+    writeLines(document, con = file)
+    deps <- dependencies(file, quiet = TRUE)
+    expect_contains(deps$Package, packages)
+  }
+
+  check("expect_known_hash(object, \"hash\")", "digest")
+  check("testthat::expect_s7_class(object, class)", "S7")
+  check("expect_vector(object)", "vctrs")
+  check("testthat::run_cpp_tests(\"example\")", "xml2")
+  check("skip_if_offline()", "curl")
+  check("testthat::snapshot_review()", c("shiny", "diffviewer"))
+
+})
+
+test_that("dependencies() detects rlang::check_installed(), rlang::is_installed()", {
+
+  check <- function(document, packages) {
+    file <- renv_scope_tempfile("renv-test-", fileext = ".R")
+    writeLines(document, con = file)
+    deps <- dependencies(file, quiet = TRUE)
+    expect_contains(deps$Package, packages)
+  }
+
+  check("rlang::check_installed(\"openxlsx\")", "openxlsx")
+  check("check_installed(\"openxlsx\")", "openxlsx")
+  check("rlang::check_installed(\"openxlsx (>= 4.0.0)\")", "openxlsx")
+  check("rlang::check_installed(c(\"shiny\", \"diffviewer\"))", c("shiny", "diffviewer"))
+  check("rlang::check_installed(pkg = \"openxlsx\", reason = \"for exports\")", "openxlsx")
+  check("if (rlang::is_installed(\"openxlsx\")) NULL", "openxlsx")
+  check("is_installed(c(\"shiny\", \"diffviewer\"))", c("shiny", "diffviewer"))
+
+  # symbols and other non-string arguments are ignored
+  file <- renv_scope_tempfile("renv-test-", fileext = ".R")
+  writeLines("rlang::check_installed(package)", con = file)
+  deps <- dependencies(file, quiet = TRUE)
+  expect_contains(deps$Package, "rlang")
+  expect_false("package" %in% deps$Package)
 
 })
 


### PR DESCRIPTION
Addresses parts of #1936.

## What this does

- Adds a new dependency-discovery handler for `rlang::check_installed()` and
  `rlang::is_installed()`, mirroring the existing `requireNamespace()` handler.
  It handles bare and namespaced calls, named or positional `pkg` arguments,
  vectors like `c("shiny", "diffviewer")`, and version-qualified entries like
  `"openxlsx (>= 4.0.0)"` (the version qualifier is stripped).

- Extends the testthat handler to infer optional dependencies implied by
  certain function usages:
  - `expect_known_hash()` -> digest
  - `expect_s7_class()` -> S7
  - `expect_vector()` -> vctrs
  - `run_cpp_tests()` -> xml2
  - `skip_if_offline()` -> curl
  - `snapshot_review()` -> shiny, diffviewer

- Junit reporter detection (xml2) now also matches `test_check()` and
  `test_local()`, in addition to `test_package()` / `test_dir()` /
  `test_file()`. `test_check()` is the usual entry point in
  `tests/testthat.R`, which is likely what the original report was running.

`skip_if_not_installed()` is deliberately not detected, since its purpose is
to declare a package optional.

## What this doesn't do

Static analysis still can't see `check_installed()` calls made inside
third-party package code (e.g. testthat's own `JunitReporter` check, or the
`openxlsx` example in the issue comments); for those cases the
`_dependencies.R` escape hatch or `snapshot(type = "all")` remains the
recommendation.

Note: the regenerated `man/dependencies.Rd` also picks up a paragraph about
`renv.dependencies.implied` that existed in the roxygen source but had not
yet been committed to the Rd.