### PR TITLE
allow package projects to include themselves in the lockfile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # renv (development version)
 
+* Package projects can now request that the package itself be included in the
+  lockfile, by setting `Config/renv/snapshot/include-self: TRUE` in the package
+  `DESCRIPTION` file. This can be useful when deploying a Shiny application
+  that is developed as part of a package. See `?renv::snapshot` for more
+  details. (#2285)
+
 * `renv::dependencies()` now detects packages referenced via
   `rlang::check_installed()` and `rlang::is_installed()`. (#1936)
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -562,13 +562,19 @@ renv_dependencies_discover_renv_lock <- function(path) {
   renv_dependencies_list(path, "renv")
 }
 
-renv_dependencies_discover_description_fields <- function(path, project = NULL) {
+renv_dependencies_project <- function(project = NULL) {
 
   # most callers don't pass in project so we need to get it from global state
-  project <- project %||%
+  project %||%
     renv_dependencies_state(key = "root") %||%
     renv_restore_state(key = "root") %||%
     renv_project_resolve()
+
+}
+
+renv_dependencies_discover_description_fields <- function(path, project = NULL) {
+
+  project <- renv_dependencies_project(project)
 
   # by default, respect fields defined in settings
   fields <- settings$package.dependency.fields(project = project)
@@ -618,6 +624,22 @@ renv_dependencies_discover_description <- function(path,
       packages = c(renv_bioconductor_manager(), "BiocVersion")
     )
     names(data)[[length(data)]] <- "Bioconductor"
+  }
+
+  # if this is the DESCRIPTION for the active project, and the package has
+  # requested that it be included in the lockfile, then treat the package
+  # itself as a dependency of the project as well
+  # https://github.com/rstudio/renv/issues/2285
+  include <- dcf[["Config/renv/snapshot/include-self"]]
+  if (truthy(include, default = FALSE)) {
+    root <- renv_dependencies_project(project)
+    if (renv_path_same(file.path(root, "DESCRIPTION"), path)) {
+      data[[length(data) + 1L]] <- renv_dependencies_list(
+        source   = path,
+        packages = dcf[["Package"]]
+      )
+      names(data)[[length(data)]] <- "Self"
+    }
   }
 
   bind(data, index = "Type")

--- a/R/project.R
+++ b/R/project.R
@@ -221,6 +221,12 @@ renv_project_ignored_packages_self <- function(project) {
   else if (identical(ignore, FALSE))
     return(NULL)
 
+  # respect DESCRIPTION field if set
+  # https://github.com/rstudio/renv/issues/2285
+  include <- desc[["Config/renv/snapshot/include-self"]]
+  if (!is.null(include))
+    return(if (truthy(include)) NULL else package)
+
   # don't ignore self in golem projets
   golem <- file.path(project, "inst/golem-config.yml")
   if (file.exists(golem))

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -68,6 +68,30 @@
 #' requested set of packages, and their recursive dependencies, will be written
 #' to the lockfile.
 #'
+#' # Package projects
+#'
+#' When snapshotting a package project (that is, a project containing a
+#' `DESCRIPTION` file), renv normally records only the package's dependencies
+#' in the lockfile, and excludes the package itself. If you'd like the package
+#' itself to be recorded as well -- for example, because the project is
+#' deployed as a Shiny application, using an `app.R` that runs an application
+#' exported from the package -- you can set:
+#'
+#' ```
+#' Config/renv/snapshot/include-self: TRUE
+#' ```
+#'
+#' in the package's `DESCRIPTION` file. With this set, the package is also
+#' treated as a dependency of the project, and so is expected to be installed
+#' in the project library. Note that for the package to be restorable, it
+#' should be installed from a remote source -- for example, with
+#' `renv::install("<user>/<repo>")` for a package available on GitHub.
+#'
+#' The \R option `renv.snapshot.ignore.self` can also be used to control this
+#' behavior: set it to `FALSE` to include the package in the lockfile, or
+#' `TRUE` to exclude it. When set, this option takes precedence over the
+#' `DESCRIPTION` field.
+#'
 #' @inherit renv-params
 #'
 #' @param library The \R libraries to snapshot. When `NULL`, the active \R

--- a/man/snapshot.Rd
+++ b/man/snapshot.Rd
@@ -161,6 +161,29 @@ requested set of packages, and their recursive dependencies, will be written
 to the lockfile.
 }
 
+\section{Package projects}{
+When snapshotting a package project (that is, a project containing a
+\code{DESCRIPTION} file), renv normally records only the package's dependencies
+in the lockfile, and excludes the package itself. If you'd like the package
+itself to be recorded as well -- for example, because the project is
+deployed as a Shiny application, using an \code{app.R} that runs an application
+exported from the package -- you can set:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{Config/renv/snapshot/include-self: TRUE
+}\if{html}{\out{</div>}}
+
+in the package's \code{DESCRIPTION} file. With this set, the package is also
+treated as a dependency of the project, and so is expected to be installed
+in the project library. Note that for the package to be restorable, it
+should be installed from a remote source -- for example, with
+\code{renv::install("<user>/<repo>")} for a package available on GitHub.
+
+The \R option \code{renv.snapshot.ignore.self} can also be used to control this
+behavior: set it to \code{FALSE} to include the package in the lockfile, or
+\code{TRUE} to exclude it. When set, this option takes precedence over the
+\code{DESCRIPTION} field.
+}
+
 \examples{
 
 \dontrun{

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -157,6 +157,62 @@ test_that("snapshot ignores own package in package development scenarios", {
 
 })
 
+test_that("snapshot includes own package when include-self is set", {
+
+  renv_tests_scope()
+  ensure_directory("bread")
+  renv_scope_wd("bread")
+
+  writeLines(
+    c(
+      "Type: Package",
+      "Package: bread",
+      "Config/renv/snapshot/include-self: TRUE"
+    ),
+    con = "DESCRIPTION"
+  )
+
+  # the package should be discovered as a dependency of itself
+  deps <- dependencies()
+  expect_true("bread" %in% deps$Package)
+
+  # and so included in the lockfile after snapshot
+  install("bread")
+  lockfile <- snapshot(lockfile = NULL)
+  records <- renv_lockfile_records(lockfile)
+  expect_false(is.null(records[["bread"]]))
+
+  # the R option takes precedence over the DESCRIPTION field
+  renv_scope_options(renv.snapshot.ignore.self = TRUE)
+  lockfile <- snapshot(lockfile = NULL)
+  records <- renv_lockfile_records(lockfile)
+  expect_true(is.null(records[["bread"]]))
+
+})
+
+test_that("include-self: FALSE excludes own package in golem projects", {
+
+  renv_tests_scope()
+  ensure_directory("bread")
+  renv_scope_wd("bread")
+
+  writeLines(
+    c(
+      "Type: Package",
+      "Package: bread",
+      "Config/renv/snapshot/include-self: FALSE"
+    ),
+    con = "DESCRIPTION"
+  )
+
+  # golem projects normally include self in the lockfile
+  ensure_directory("inst")
+  writeLines("default: {}", con = "inst/golem-config.yml")
+
+  expect_equal(renv_project_ignored_packages_self(getwd()), "bread")
+
+})
+
 test_that("snapshot warns about unsatisfied dependencies", {
 
   renv_tests_scope("toast")


### PR DESCRIPTION
Closes #2285.

Package projects can now request that the package itself be included in the lockfile, by setting the following in the package `DESCRIPTION` file:

```
Config/renv/snapshot/include-self: TRUE
```

When set:

- The package is no longer excluded from the lockfile during snapshot (same effect as the existing, previously-undocumented `renv.snapshot.ignore.self` option, which still takes precedence when set);
- The package is also treated as a dependency of the project itself, so inclusion doesn't depend on directory structure (e.g. an `app.R` referencing the package). This covers both implicit and explicit snapshot types.

An explicit `Config/renv/snapshot/include-self: FALSE` excludes the package even in golem projects, which are otherwise auto-included.

Also documents the `renv.snapshot.ignore.self` option in `?snapshot`, along with the caveat that the package should be installed from a restorable remote source (e.g. `renv::install("<user>/<repo>")`) for deployment to work.
