### PR TITLE
prompt before removing packages from non-project libraries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
 
 # renv (development version)
 
+* `renv::remove()` gains a `prompt` argument, and now asks for confirmation
+  before removing packages from a library other than the project library --
+  for example, when called without an activated renv project, where the
+  target library would be the user library. (#2331)
+
+* Removing a package record from the lockfile by setting it to `NULL`, e.g.
+  with `renv::record(list(dplyr = NULL))`, is now documented. (#2331)
+
 * `renv::dependencies()` now detects packages referenced via
   `rlang::check_installed()` and `rlang::is_installed()`. (#1936)
 

--- a/R/record.R
+++ b/R/record.R
@@ -14,6 +14,12 @@
 #' or by using an \R list of entries to record within the lockfile. See
 #' `?lockfiles` for more information on the structure of a package record.
 #'
+#' A package's record can be removed from the lockfile by setting its entry
+#' to `NULL`; for example, use `renv::record(list(dplyr = NULL))` to remove
+#' the record for the dplyr package from the lockfile. Note that this only
+#' modifies the lockfile; use [renv::remove()] if you'd also like to remove
+#' the package from the project library.
+#'
 #' @inheritParams renv-params
 #'
 #' @param records A list of named records, mapping package names to a definition

--- a/R/remove.R
+++ b/R/remove.R
@@ -3,12 +3,20 @@
 #'
 #' Remove (uninstall) \R packages.
 #'
+#' Note that `remove()` only removes packages from the requested library;
+#' it does not modify the project lockfile. Use [renv::record()] if you'd
+#' like to remove a package's record from the lockfile.
+#'
 #' @inherit renv-params
 #'
 #' @param packages A character vector of \R packages to remove.
 #' @param library The library from which packages should be removed. When
 #'   `NULL`, the active library (that is, the first entry reported in
 #'   `.libPaths()`) is used instead.
+#'
+#' @param prompt Boolean; prompt the user before removing packages? The prompt
+#'   is only shown when removing packages from a library other than the
+#'   project library.
 #'
 #' @return A vector of package records, describing the packages (if any) which
 #'   were successfully removed.
@@ -19,10 +27,12 @@
 remove <- function(packages,
                    ...,
                    library = NULL,
+                   prompt = interactive(),
                    project = NULL)
 {
   renv_scope_error_handler()
   renv_dots_check(...)
+  renv_scope_verbose_if(prompt)
 
   project <- renv_project_resolve(project)
   renv_project_lock(project = project)
@@ -41,6 +51,7 @@ remove <- function(packages,
   } else {
     fmt <- "- Removing package(s) from library '%s' ..."
     writef(fmt, renv_path_aliased(library))
+    cancel_if(prompt && !proceed())
   }
 
   if (length(packages) == 1) {

--- a/examples/examples-record.R
+++ b/examples/examples-record.R
@@ -17,4 +17,7 @@ digest_record <- list(
 
 renv::record(list(digest = digest_record))
 
+# remove the record for digest from the lockfile
+renv::record(list(digest = NULL))
+
 }

--- a/man/record.Rd
+++ b/man/record.Rd
@@ -43,6 +43,12 @@ suitable alternative.
 Records can be provided either using the \strong{remotes} short-hand syntax,
 or by using an \R list of entries to record within the lockfile. See
 \code{?lockfiles} for more information on the structure of a package record.
+
+A package's record can be removed from the lockfile by setting its entry
+to \code{NULL}; for example, use \code{renv::record(list(dplyr = NULL))} to remove
+the record for the dplyr package from the lockfile. Note that this only
+modifies the lockfile; use \code{\link[=remove]{remove()}} if you'd also like to remove
+the package from the project library.
 }
 
 \examples{
@@ -64,6 +70,9 @@ digest_record <- list(
 )
 
 renv::record(list(digest = digest_record))
+
+# remove the record for digest from the lockfile
+renv::record(list(digest = NULL))
 
 }
 }

--- a/man/remove.Rd
+++ b/man/remove.Rd
@@ -4,7 +4,7 @@
 \alias{remove}
 \title{Remove packages}
 \usage{
-remove(packages, ..., library = NULL, project = NULL)
+remove(packages, ..., library = NULL, prompt = interactive(), project = NULL)
 }
 \arguments{
 \item{packages}{A character vector of \R packages to remove.}
@@ -16,6 +16,10 @@ are matched to \code{...}, renv will signal an error.}
 \code{NULL}, the active library (that is, the first entry reported in
 \code{.libPaths()}) is used instead.}
 
+\item{prompt}{Boolean; prompt the user before removing packages? The prompt
+is only shown when removing packages from a library other than the
+project library.}
+
 \item{project}{The project directory. If \code{NULL}, then the active project will
 be used. If no project is currently active, then the current working
 directory is used instead.}
@@ -26,6 +30,11 @@ were successfully removed.
 }
 \description{
 Remove (uninstall) \R packages.
+}
+\details{
+Note that \code{remove()} only removes packages from the requested library;
+it does not modify the project lockfile. Use \code{\link[=record]{record()}} if you'd
+like to remove a package's record from the lockfile.
 }
 \examples{
 

--- a/tests/testthat/test-remove.R
+++ b/tests/testthat/test-remove.R
@@ -1,0 +1,44 @@
+
+test_that("remove() removes packages from the project library", {
+
+  renv_tests_scope("bread")
+  init()
+
+  expect_true(renv_package_installed("bread"))
+  remove("bread")
+  expect_false(renv_package_installed("bread"))
+
+})
+
+test_that("remove() prompts before removing from a non-project library", {
+
+  renv_tests_scope("bread")
+  init()
+
+  library <- renv_scope_tempfile("renv-library-")
+  ensure_directory(library)
+  install("bread", library = library)
+  expect_true(renv_package_installed("bread", lib.loc = library))
+
+  # declining the prompt leaves the package installed
+  local_mocked_bindings(proceed = function(...) FALSE)
+  expect_error(remove("bread", library = library, prompt = TRUE))
+  expect_true(renv_package_installed("bread", lib.loc = library))
+
+  # accepting the prompt removes the package
+  local_mocked_bindings(proceed = function(...) TRUE)
+  remove("bread", library = library, prompt = TRUE)
+  expect_false(renv_package_installed("bread", lib.loc = library))
+
+})
+
+test_that("remove() does not prompt when removing from the project library", {
+
+  renv_tests_scope("bread")
+  init()
+
+  local_mocked_bindings(proceed = function(...) stop("prompt should not be shown"))
+  remove("bread", prompt = TRUE)
+  expect_false(renv_package_installed("bread"))
+
+})


### PR DESCRIPTION
Closes #2331.

## Changes

- `renv::remove()` gains a `prompt` argument (default `interactive()`), and now asks for confirmation before removing packages from a library other than the project library -- for example, when called without an activated renv project, where the target library would be the user library. No prompt is shown when removing from the project library itself.
- Documents that a package's record can be removed from the lockfile by setting it to `NULL`, e.g. `renv::record(list(dplyr = NULL))`, with cross-references between `remove()` and `record()` clarifying that the former modifies only the library and the latter only the lockfile.

## Tests

- New `test-remove.R` covering removal from the project library, prompt accept/decline behavior for non-project libraries, and that no prompt is shown for the project library.
- `devtools::test(filter = "remove|record")`: 54 passed.