### PR TITLE
Detect knitr and reticulate via Quarto engine binding (#2174)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,12 @@
   In addition, usage of the Junit reporter is now also detected in calls to
   `test_check()` and `test_local()`. (#1936)
 
+* `renv::dependencies()` now infers dependencies on `knitr` and `reticulate`
+  for Quarto (`.qmd`) documents, following Quarto's engine-binding rules. A
+  document that uses the knitr engine now infers `knitr` (rather than
+  `rmarkdown`), and additionally infers `reticulate` when it contains Python
+  chunks. (#2174)
+
 * `renv::install()` with pak enabled no longer upgrades already-installed
   dependencies that are only pulled in transitively -- most visibly recommended
   packages such as `cluster` or `Matrix`, which previously could be rebuilt when

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1018,17 +1018,10 @@ renv_dependencies_discover_chunks <- function(path, mode) {
   # check for dependencies in inline chunks as well
   ideps <- renv_dependencies_discover_chunks_inline(path, contents)
 
-  # if this is a .qmd, infer a dependency on rmarkdown if we have any R chunks
+  # for a .qmd, infer engine-binding dependencies (knitr / reticulate)
   qdeps <- NULL
-  if (mode %in% "qmd") {
-    for (chunk in chunks) {
-      engine <- chunk$params[["engine"]]
-      if (is.character(engine) && tolower(engine) %in% c("r", "rscript")) {
-        qdeps <- renv_dependencies_list(path, "rmarkdown")
-        break
-      }
-    }
-  }
+  if (mode %in% "qmd")
+    qdeps <- renv_dependencies_discover_quarto_engine(path, contents, chunks)
 
   # paste them all together
   deps <- bind(list(cdeps, ideps, qdeps))
@@ -1037,6 +1030,58 @@ renv_dependencies_discover_chunks <- function(path, mode) {
 
   deps$Source <- path
   deps
+
+}
+
+renv_dependencies_discover_quarto_engine <- function(path, contents, chunks) {
+
+  # collect the set of chunk engines present in the document
+  engines <- tolower(map_chr(chunks, function(chunk) {
+    engine <- chunk$params[["engine"]]
+    if (is.character(engine) && length(engine) == 1L) engine else ""
+  }))
+
+  has_r <- any(engines %in% c("r", "rscript"))
+  has_python <- any(engines == "python")
+  has_executable <- any(nzchar(engines))
+
+  # parse the YAML header to check for explicit engine overrides
+  yaml <- NULL
+  yamltext <- renv_dependencies_yaml_header_text(paste(contents, collapse = "\n"))
+  if (!is.null(yamltext) && renv_dependencies_require("yaml")) {
+    parsed <- catch(renv_yaml_load(yamltext))
+    if (is.list(parsed))
+      yaml <- parsed
+  }
+
+  # resolve the engine following Quarto's engine binding rules
+  engine <- local({
+    override <- yaml[["engine"]]
+    if (is.character(override) && length(override) == 1L && nzchar(override))
+      return(tolower(override))
+    if (!is.null(yaml[["jupyter"]]))
+      return("jupyter")
+    if (!is.null(yaml[["knitr"]]))
+      return("knitr")
+    if (has_r)
+      return("knitr")
+    if (has_executable)
+      return("jupyter")
+    ""
+  })
+
+  # map the resolved engine to R package dependencies
+  packages <- character()
+  if (identical(engine, "knitr")) {
+    packages <- "knitr"
+    if (has_python)
+      packages <- c(packages, "reticulate")
+  }
+
+  if (length(packages) == 0L)
+    return(NULL)
+
+  renv_dependencies_list(path, packages)
 
 }
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -777,6 +777,22 @@ renv_dependencies_discover_multimode <- function(path, mode) {
 
 }
 
+renv_dependencies_yaml_header_text <- function(contents) {
+
+  # look for the '---' fences delimiting a YAML header
+  pattern <- "(?:^|\n)\\s*---\\s*(?:$|\n)"
+  matches <- gregexpr(pattern, contents, perl = TRUE)[[1L]]
+
+  # a valid header needs an opening fence at the very start plus a closing fence
+  ok <- length(matches) > 1L && matches[[1L]] == 1L
+  if (!ok)
+    return(NULL)
+
+  # extract the text between the two fences
+  substring(contents, matches[[1L]] + 4L, matches[[2L]] - 1L)
+
+}
+
 renv_dependencies_discover_rmd_yaml_header <- function(path, mode) {
 
   deps <- stack(mode = "character")
@@ -787,12 +803,10 @@ renv_dependencies_discover_rmd_yaml_header <- function(path, mode) {
 
   # try and read the document's YAML header
   contents <- renv_file_read(path)
-  pattern <- "(?:^|\n)\\s*---\\s*(?:$|\n)"
-  matches <- gregexpr(pattern, contents, perl = TRUE)[[1L]]
+  yamltext <- renv_dependencies_yaml_header_text(contents)
 
   # check that we have something that looks like a YAML header
-  ok <- length(matches) > 1L && matches[[1L]] == 1L
-  if (!ok)
+  if (is.null(yamltext))
     return(renv_dependencies_list(path, packages = deps$data()))
 
   # require yaml package for parsing YAML header
@@ -807,8 +821,7 @@ renv_dependencies_discover_rmd_yaml_header <- function(path, mode) {
     return(renv_dependencies_list(path, packages))
   }
 
-  # extract YAML text
-  yamltext <- substring(contents, matches[[1L]] + 4L, matches[[2L]] - 1L)
+  # parse the extracted YAML text
   yaml <- catch(renv_yaml_load(yamltext))
   if (inherits(yaml, "error"))
     return(renv_dependencies_error(path, error = yaml, packages = "rmarkdown"))

--- a/tests/testthat/resources/quarto-jupyter-override.qmd
+++ b/tests/testthat/resources/quarto-jupyter-override.qmd
@@ -1,0 +1,12 @@
+---
+title: Jupyter override
+engine: jupyter
+---
+
+```{r}
+1 + 1
+```
+
+```{python}
+import os
+```

--- a/tests/testthat/resources/quarto-mixedcase-engine.qmd
+++ b/tests/testthat/resources/quarto-mixedcase-engine.qmd
@@ -1,0 +1,8 @@
+---
+title: Mixed case engine
+engine: Knitr
+---
+
+```{python}
+import os
+```

--- a/tests/testthat/resources/quarto-python-chunks.qmd
+++ b/tests/testthat/resources/quarto-python-chunks.qmd
@@ -1,0 +1,7 @@
+---
+title: Python only
+---
+
+```{python}
+import os
+```

--- a/tests/testthat/resources/quarto-python-eval-false.qmd
+++ b/tests/testthat/resources/quarto-python-eval-false.qmd
@@ -1,0 +1,12 @@
+---
+title: Python eval false
+---
+
+```{r}
+1 + 1
+```
+
+```{python}
+#| eval: false
+import os
+```

--- a/tests/testthat/resources/quarto-python-knitr.qmd
+++ b/tests/testthat/resources/quarto-python-knitr.qmd
@@ -1,0 +1,8 @@
+---
+title: Python via knitr
+engine: knitr
+---
+
+```{python}
+import os
+```

--- a/tests/testthat/resources/quarto-r-python-chunks.qmd
+++ b/tests/testthat/resources/quarto-r-python-chunks.qmd
@@ -1,0 +1,11 @@
+---
+title: R and Python
+---
+
+```{r}
+1 + 1
+```
+
+```{python}
+import os
+```

--- a/tests/testthat/resources/quarto-uppercase-chunks.qmd
+++ b/tests/testthat/resources/quarto-uppercase-chunks.qmd
@@ -1,0 +1,11 @@
+---
+title: Uppercase chunk engines
+---
+
+```{R}
+1 + 1
+```
+
+```{Python}
+import os
+```

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -333,9 +333,34 @@ test_that("we don't infer a dependency on rmarkdown for empty .qmd", {
   expect_true(is.null(deps) || !"rmarkdown" %in% deps$Package)
 })
 
-test_that("we do infer dependency on rmarkdown for .qmd with R chunks", {
+test_that("we infer a dependency on knitr for a .qmd with R chunks", {
   deps <- dependencies("resources/quarto-r-chunks.qmd")
-  expect_true("rmarkdown" %in% deps$Package)
+  expect_true("knitr" %in% deps$Package)
+  expect_false("rmarkdown" %in% deps$Package)
+})
+
+test_that("we infer knitr and reticulate for a .qmd with R and Python chunks", {
+  deps <- dependencies("resources/quarto-r-python-chunks.qmd")
+  expect_true(all(c("knitr", "reticulate") %in% deps$Package))
+})
+
+test_that("we do not infer knitr or reticulate for a Python-only .qmd", {
+  deps <- dependencies("resources/quarto-python-chunks.qmd")
+  expect_false("knitr" %in% deps$Package)
+  expect_false("reticulate" %in% deps$Package)
+})
+
+test_that("engine: knitr forces knitr and reticulate for Python chunks", {
+  skip_if_not_installed("yaml")
+  deps <- dependencies("resources/quarto-python-knitr.qmd")
+  expect_true(all(c("knitr", "reticulate") %in% deps$Package))
+})
+
+test_that("engine: jupyter suppresses knitr and reticulate", {
+  skip_if_not_installed("yaml")
+  deps <- dependencies("resources/quarto-jupyter-override.qmd")
+  expect_false("knitr" %in% deps$Package)
+  expect_false("reticulate" %in% deps$Package)
 })
 
 test_that("we parse package references from arbitrary yaml fields", {

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -363,6 +363,22 @@ test_that("engine: jupyter suppresses knitr and reticulate", {
   expect_false("reticulate" %in% deps$Package)
 })
 
+test_that("chunk engine tokens are matched case-insensitively", {
+  deps <- dependencies("resources/quarto-uppercase-chunks.qmd")
+  expect_true(all(c("knitr", "reticulate") %in% deps$Package))
+})
+
+test_that("reticulate is inferred for Python chunks even when eval is false", {
+  deps <- dependencies("resources/quarto-python-eval-false.qmd")
+  expect_true(all(c("knitr", "reticulate") %in% deps$Package))
+})
+
+test_that("engine: value is matched case-insensitively", {
+  skip_if_not_installed("yaml")
+  deps <- dependencies("resources/quarto-mixedcase-engine.qmd")
+  expect_true(all(c("knitr", "reticulate") %in% deps$Package))
+})
+
 test_that("we parse package references from arbitrary yaml fields", {
   deps <- dependencies("resources/rmd-base-format.Rmd")
   expect_true("bookdown" %in% deps$Package)


### PR DESCRIPTION
`renv::dependencies()` now follows Quarto's engine-binding rules for `.qmd` documents: a document using the knitr engine infers `knitr` (rather than `rmarkdown`), and additionally infers `reticulate` when it contains Python chunks. Explicit `engine:`/`jupyter:`/`knitr:` YAML options are honored (so a jupyter-engine document infers neither); closes #2174.