### PR TITLE
use pkgdepends syntax for gitlab remotes with pak

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # renv (development version)
 
+* `renv::install()` and `renv::restore()` with pak enabled can now handle
+  packages hosted on a self-hosted GitLab instance. renv previously handed
+  pak remotes of the form `gitlab@<host>::<group>/<project>`, which pak was
+  unable to parse; renv now translates these into pkgdepends' own syntax,
+  `gitlab::https://<host>/<group>/<project>`. GitLab sub-directories are
+  likewise translated to pkgdepends' `/-/<subdir>` syntax. (#2180)
+
 * `renv::remove()` gains a `prompt` argument, and now asks for confirmation
   before removing packages from a library other than the project library --
   for example, when called without an activated renv project, where the

--- a/R/pak.R
+++ b/R/pak.R
@@ -100,6 +100,35 @@ renv_pak_update <- function(project, library, prompt) {
 
 }
 
+# translate a user-provided remote spec into one which pak understands;
+# specs which are already pak-compatible are returned as-is
+renv_pak_remote <- function(spec) {
+
+  remote <- catch(renv_remotes_parse(spec))
+  if (inherits(remote, "error"))
+    return(spec)
+
+  if (!identical(remote$type, "gitlab"))
+    return(spec)
+
+  # we have no way of expressing a merge request with pkgdepends' syntax;
+  # pass the spec through unchanged, so pak can report the problem itself
+  if (!is.null(remote$pull))
+    return(spec)
+
+  record <- list(
+    Package        = remote$package,
+    RemoteHost     = remote$host,
+    RemoteUsername = remote$user,
+    RemoteRepo     = remote$repo,
+    RemoteSubdir   = remote$subdir,
+    RemoteRef      = remote$ref
+  )
+
+  renv_record_format_remote_pak_gitlab(record, versioned = FALSE)
+
+}
+
 renv_pak_install <- function(packages,
                              library,
                              type,
@@ -159,12 +188,17 @@ renv_pak_install <- function(packages,
     return(renv_pak_update(project, library, prompt))
   }
   
+  # renv's GitLab remote syntax (e.g. 'gitlab@host::group/project') isn't
+  # understood by pak, so translate those specs into pkgdepends' own syntax
+  # https://github.com/rstudio/renv/issues/2180
+  packages <- map_chr(packages, renv_pak_remote)
+
   # pak doesn't support ':' as a sub-directory separator, so try to
   # repair that here
   # https://github.com/rstudio/renv/issues/2011
   pattern <- "(?<!:):([^/#@:]+)"
   packages <- gsub(pattern, "/\\1", packages, perl = TRUE)
-  
+
   # build parameters. explicitly-requested packages always get 'reinstall',
   # so they are installed even when already current -- matching renv's non-pak
   # installer, which always (re)installs explicitly-requested packages. with

--- a/R/records.R
+++ b/R/records.R
@@ -166,6 +166,12 @@ renv_record_format_remote <- function(record,
   subdir <- record[["RemoteSubdir"]]
   subdirsep <- if (pak) "/" else ":"
 
+  # renv's 'gitlab@host::' syntax isn't understood by pak (pkgdepends), and its
+  # sub-directory syntax differs as well, so format those remotes separately
+  # https://github.com/rstudio/renv/issues/2180
+  if (pak && (identical(source, "gitlab") || identical(type, "gitlab")))
+    return(renv_record_format_remote_pak_gitlab(record, versioned = versioned))
+
   # skip type and host if they're defaults
   if (identical(type, "github")) {
     if (is.null(host) || identical(host, "api.github.com")) {
@@ -226,6 +232,46 @@ renv_record_format_remote <- function(record,
 
   remote <- paste(stk$data(), collapse = "")
   return(remote)
+}
+
+# format a GitLab record using pkgdepends' own remote syntax, as used by pak:
+#
+#   [<package>=]gitlab::[<protocol>://<host>/]<group>/<project>[/-/<subdir>][@<ref>]
+#
+renv_record_format_remote_pak_gitlab <- function(record, versioned = TRUE) {
+
+  package <- record[["Package"]]
+  host    <- record[["RemoteHost"]] %||% config$gitlab.host()
+  user    <- record[["RemoteUsername"]]
+  repo    <- record[["RemoteRepo"]]
+  ref     <- record[["RemoteRef"]]
+  sha     <- record[["RemoteSha"]]
+  subdir  <- record[["RemoteSubdir"]]
+
+  stk <- stack(mode = "character")
+
+  # pkgdepends infers the package name from the last path component, which is
+  # wrong whenever a sub-directory is involved, so be explicit when we can
+  if (!is.null(package) && !identical(package, repo))
+    stk$push(package, "=")
+
+  # note that the host has to be spelled as a URL; pkgdepends would otherwise
+  # parse it as the leading component of the project path
+  stk$push("gitlab::", renv_retrieve_origin(host), "/")
+
+  stk$push(user, "/", repo)
+
+  # pkgdepends uses GitLab's own '/-/<path>' syntax for sub-directories
+  if (!is.null(subdir) && nzchar(subdir))
+    stk$push("/-/", subdir)
+
+  if (versioned)
+    stk$push("@", sha %||% ref %||% "HEAD")
+  else if (length(ref))
+    stk$push("@", ref)
+
+  paste(stk$data(), collapse = "")
+
 }
 
 renv_record_format_short <- function(record, versioned = FALSE) {

--- a/tests/testthat/test-pak.R
+++ b/tests/testthat/test-pak.R
@@ -147,6 +147,77 @@ test_that("install() appends reinstall to specs that already carry a query", {
 
 })
 
+test_that("install() translates renv's gitlab remote syntax for pak (#2180)", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  pak <- renv_namespace_load("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  renv_tests_scope()
+
+  args <- NULL
+  local_mocked_bindings(renv_pak_init = function(...) invisible(NULL))
+  local_mocked_bindings(
+    .package = "pak",
+    pkg_install = function(pkg, ...) {
+      args <<- pkg
+      invisible(data.frame(package = character()))
+    }
+  )
+
+  # pak (pkgdepends) doesn't understand 'gitlab@host::', and expects
+  # sub-directories to be separated with '/-/'
+  quietly(install("gitlab@gitlab.example.de::bioinf/rlib/testpackage"))
+  expect_equal(unname(args), "gitlab::https://gitlab.example.de/bioinf/rlib/testpackage?reinstall")
+
+  quietly(install("gitlab::group/repo:subdir@main"))
+  expect_equal(unname(args), "gitlab::https://gitlab.com/group/repo/-/subdir@main?reinstall")
+
+})
+
+test_that("restore() translates gitlab remotes for pak (#2180)", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  pak <- renv_namespace_load("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  renv_tests_scope()
+
+  args <- NULL
+  local_mocked_bindings(
+    .package = "pak",
+    pkg_install = function(pkg, ...) {
+      args <<- pkg
+      invisible(data.frame(package = character()))
+    }
+  )
+
+  lockfile <- list(
+    Packages = list(
+      testpackage = list(
+        Package        = "testpackage",
+        Version        = "0.1.0",
+        Source         = "GitLab",
+        RemoteType     = "gitlab",
+        RemoteHost     = "gitlab.example.de",
+        RemoteUsername = "bioinf",
+        RemoteRepo     = "rlib/testpackage",
+        RemoteSubdir   = "",
+        RemoteRef      = "main",
+        RemoteSha      = "babda05db8146b37a552c77651e2cd084a05ce98"
+      )
+    )
+  )
+
+  renv_pak_restore(lockfile)
+
+  expected <- "testpackage=gitlab::https://gitlab.example.de/bioinf/rlib/testpackage@babda05db8146b37a552c77651e2cd084a05ce98"
+  expect_equal(unname(args), expected)
+
+})
+
 test_that("install() does not upgrade transitively-pulled recommended packages (#2329)", {
 
   skip_on_cran()

--- a/tests/testthat/test-records.R
+++ b/tests/testthat/test-records.R
@@ -210,6 +210,45 @@ test_that("remote hosts are included when formatting", {
 
 })
 
+test_that("gitlab remotes are formatted using pkgdepends syntax for pak (#2180)", {
+
+  record <- list(
+    Package        = "testpackage",
+    Version        = "0.1.0",
+    Source         = "GitLab",
+    RemoteType     = "gitlab",
+    RemoteHost     = "gitlab.example.de",
+    RemoteUsername = "bioinf",
+    RemoteRepo     = "rlib/testpackage",
+    RemoteSubdir   = "",
+    RemoteRef      = "main",
+    RemoteSha      = "babda05db8146b37a552c77651e2cd084a05ce98"
+  )
+
+  # renv's own 'gitlab@host::' syntax is retained for display
+  remote <- renv_record_format_remote(record)
+  expect_equal(remote, "testpackage=gitlab@gitlab.example.de::bioinf/rlib/testpackage@babda05db8146b37a552c77651e2cd084a05ce98")
+
+  # ... but pak requires the host to be spelled as a URL
+  remote <- renv_record_format_remote(record, pak = TRUE)
+  expect_equal(remote, "testpackage=gitlab::https://gitlab.example.de/bioinf/rlib/testpackage@babda05db8146b37a552c77651e2cd084a05ce98")
+
+  # the default host is included as well, so that a sub-directory can never
+  # be mistaken for the project name
+  record$RemoteHost <- NULL
+  record$RemoteUsername <- "group"
+  record$RemoteRepo <- "repo"
+  record$RemoteSubdir <- "testpackage"
+
+  remote <- renv_record_format_remote(record, pak = TRUE)
+  expect_equal(remote, "testpackage=gitlab::https://gitlab.com/group/repo/-/testpackage@babda05db8146b37a552c77651e2cd084a05ce98")
+
+  # unversioned remotes use the ref, if any
+  remote <- renv_record_format_remote(record, pak = TRUE, versioned = FALSE)
+  expect_equal(remote, "testpackage=gitlab::https://gitlab.com/group/repo/-/testpackage@main")
+
+})
+
 test_that("renv_record_source infers 'repository' from Repository field", {
 
   # a record with Source explicitly set uses that


### PR DESCRIPTION
Fixes #2180.

## Problem

`renv_record_format_remote(pak = TRUE)` formats GitLab records using renv's own
remote syntax, which pkgdepends cannot parse:

```
testpackage=gitlab@gitlab.example.de::bioinf/rlib/testpackage@babda05...
```

pkgdepends' GitLab grammar (`pkgdepends:::gitlab_rx()`) is:

```
[<package>=]gitlab::[<protocol>://<host>/]<group>/<project>[/-/<subdir>][@<commitish>]
```

so there are two bugs here, both confirmed by passing renv's output to
`pkgdepends:::parse_pkg_ref()`:

1. **Custom host: hard failure.** `gitlab@host::` is unparseable, which is the
   `Cannot parse package` error reported in #2180. Note the host has to be
   spelled as a URL: `gitlab::gitlab.example.de/group/repo` parses
   "successfully", but treats the hostname as the first path component and so
   looks for the project on gitlab.com.

2. **Sub-directories: silent misparse.** renv emits
   `gitlab::group/repo/subdir@sha`, which pkgdepends reads as project `subdir`
   within group `group/repo` -- installing the wrong thing rather than erroring.

This doesn't reproduce for everyone because packages installed by pak carry a
valid `RemotePkgRef` in their DESCRIPTION, which `renv_record_format_remote()`
returns early and unchanged. The failure only affects lockfile records generated
by renv's own resolver -- which is the lockfile shape reported in #2180.

`renv::install("gitlab@host::...")` was broken the same way on a separate path:
`renv_pak_install()` passes raw user specs to pak untouched, apart from the
`:` -> `/` sub-directory fixup from #2011, which is itself wrong for GitLab.

## Changes

* `renv_record_format_remote_pak_gitlab()` formats GitLab records in
  pkgdepends' syntax. It always includes `https://<host>/` (also for
  gitlab.com, which removes the sub-directory ambiguity), uses `/-/<subdir>`,
  and keeps an explicit `<package>=` prefix, since pkgdepends would otherwise
  infer the package name from the last path component.

* `renv_pak_remote()` translates user-provided GitLab specs on the `install()`
  path. Specs renv can't parse, and merge-request specs (`#42`, which has no
  pkgdepends equivalent), are passed through unchanged so that pak can report
  the problem itself.

## Validation

* Every generated remote now round-trips through
  `pkgdepends:::parse_pkg_ref()` with the expected url / subdir / commitish /
  package.

* End-to-end against gitlab.com with pak enabled: `install()` -> `snapshot()`
  -> `restore()`, plus a `restore()` from a renv-resolved record with no
  `RemotePkgRef` (the shape from the issue). Both install correctly, including
  the subgroup case `renv-group/renv-subgroup/subpackage`. The self-hosted host
  itself can only be validated at the parse layer, which is where the reported
  error is raised (`get_remote_types(refs)`).

## Not addressed

Two adjacent cases fail for the same reason, but need decisions beyond the
scope of this fix:

* **GitHub Enterprise.** `github@host::user/repo` is equally unparseable, and
  `github::` has no host slot in pkgdepends at all; the only route is
  `pkg=git::https://host/user/repo.git@sha`. That needs host translation
  (renv records an API host, e.g. `github.example.com/api/v3`) and `git::`
  supports no sub-directory. `tests/testthat/test-records.R:208` currently
  asserts the broken output.

* **Bitbucket, svn.** pkgdepends has no such sources
  (`Unknown package source: "bitbucket"`), so these could only work via a
  `git::` URL rewrite.
