### PR TITLE
preserve requested remotes when installing with pak (#2341)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # renv (development version)
 
+* `renv::use()` with pak enabled now honours the requested remotes, rather than
+  installing the latest version of each package from the active repositories.
+  Previously, a call like `renv::use("generics@0.1.3")` would install the
+  current CRAN version of generics. `renv::rebuild()` and `renv::repair()` were
+  affected in the same way. (#2341)
+
 * `renv::remove()` gains a `prompt` argument, and now asks for confirmation
   before removing packages from a library other than the project library --
   for example, when called without an activated renv project, where the

--- a/R/pak.R
+++ b/R/pak.R
@@ -123,47 +123,60 @@ renv_pak_install <- function(packages,
   if (identical(name, "renv"))
     renv_scope_envvars("_R_CHECK_PACKAGE_NAME_" = NULL)
 
-  # if we received a named list of remotes, use the names
-  packages <- if (any(nzchar(names(packages))))
-     names(packages)
-  else
-    as.character(packages)
+  # convert the requested packages into pak-compatible remote specifications.
+  # some callers (e.g. renv::use(), rebuild(), repair()) hand us a named list
+  # of already-resolved records; using those names alone would discard the
+  # record's version pin and remote source
+  # https://github.com/rstudio/renv/issues/2341
+  specs <- map_chr(packages, function(package) {
+    if (is.list(package))
+      renv_record_format_remote(package, pak = TRUE)
+    else
+      as.character(package)
+  })
+
+  # associate each spec with its package name where we know it, so include /
+  # exclude filter by package name rather than by remote specification
+  nms <- names(packages) %||% rep.int("", length(specs))
+  names(specs) <- ifelse(nzchar(nms), nms, specs)
 
   # remember whether the caller explicitly scoped this install so we can
   # distinguish "no scope at all" (let pak update the project) from "explicit
   # scope filtered to empty" (no-op, matching the non-pak path)
-  explicit <- length(packages) > 0L || length(include) > 0L || length(exclude) > 0L
+  explicit <- length(specs) > 0L || length(include) > 0L || length(exclude) > 0L
 
   # apply include / exclude consistently with the non-pak install path,
   # so the semantics of these arguments don't depend on the installer.
   # if no packages were specified positionally but include was, treat it
   # as the request set (e.g. install(include = ...))
   # https://github.com/rstudio/renv/issues/2281
-  if (length(packages) == 0L && length(include))
-    packages <- as.character(include)
+  if (length(specs) == 0L && length(include)) {
+    specs <- as.character(include)
+    names(specs) <- specs
+  }
 
   if (length(exclude))
-    packages <- setdiff(packages, exclude)
+    specs <- specs[!names(specs) %in% exclude]
 
   if (length(include))
-    packages <- intersect(packages, include)
+    specs <- specs[names(specs) %in% include]
 
   # if no packages remain, fall through to a project-wide update only when
   # the caller did not provide an explicit scope; otherwise treat this as
   # a no-op so we don't surprise the user with an unintended update
-  if (length(packages) == 0L) {
+  if (length(specs) == 0L) {
     if (explicit) {
       writef("- There are no packages to install.")
       return(invisible(list()))
     }
     return(renv_pak_update(project, library, prompt))
   }
-  
+
   # pak doesn't support ':' as a sub-directory separator, so try to
   # repair that here
   # https://github.com/rstudio/renv/issues/2011
   pattern <- "(?<!:):([^/#@:]+)"
-  packages <- gsub(pattern, "/\\1", packages, perl = TRUE)
+  packages <- gsub(pattern, "/\\1", unname(specs), perl = TRUE)
   
   # build parameters. explicitly-requested packages always get 'reinstall',
   # so they are installed even when already current -- matching renv's non-pak

--- a/tests/testthat/test-pak.R
+++ b/tests/testthat/test-pak.R
@@ -147,6 +147,65 @@ test_that("install() appends reinstall to specs that already carry a query", {
 
 })
 
+test_that("use() preserves the requested remote with pak (#2341)", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  pak <- renv_namespace_load("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  renv_tests_scope()
+
+  args <- NULL
+  local_mocked_bindings(renv_pak_init = function(...) invisible(NULL))
+  local_mocked_bindings(
+    .package = "pak",
+    pkg_install = function(pkg, ...) {
+      args <<- pkg
+      invisible(data.frame(package = character()))
+    }
+  )
+
+  # use() resolves its arguments into records before delegating to install();
+  # the requested version has to survive that round-trip
+  library <- renv_scope_tempfile("renv-library-")
+  quietly(use("bread@0.1.0", library = library, sandbox = FALSE, attach = FALSE))
+
+  expect_equal(unname(args), "bread@0.1.0?reinstall")
+
+})
+
+test_that("install() filters records by package name with pak (#2341)", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if_not_installed("pak")
+  pak <- renv_namespace_load("pak")
+  renv_scope_options(renv.config.pak.enabled = TRUE)
+  renv_tests_scope()
+
+  args <- NULL
+  local_mocked_bindings(renv_pak_init = function(...) invisible(NULL))
+  local_mocked_bindings(
+    .package = "pak",
+    pkg_install = function(pkg, ...) {
+      args <<- pkg
+      invisible(data.frame(package = character()))
+    }
+  )
+
+  # when records are supplied (as rebuild() and repair() do), include / exclude
+  # still match on the package name rather than the generated remote spec
+  records <- list(
+    bread   = list(Package = "bread",   Version = "0.1.0", Source = "Repository"),
+    oatmeal = list(Package = "oatmeal", Version = "1.0.0", Source = "Repository")
+  )
+
+  quietly(install(records, exclude = "oatmeal"))
+  expect_equal(unname(args), "bread@0.1.0?reinstall")
+
+})
+
 test_that("install() does not upgrade transitively-pulled recommended packages (#2329)", {
 
   skip_on_cran()


### PR DESCRIPTION
Fixes #2341.

`renv_pak_install()` collapsed a named list of records down to just the package
names:

```r
# if we received a named list of remotes, use the names
packages <- if (any(nzchar(names(packages))))
   names(packages)
else
  as.character(packages)
```

`renv::use()` resolves its `...` into records before delegating to `install()`,
so the version pin (and any remote source) was discarded before the specs
reached pak -- `renv::use("generics@0.1.3")` asked pak for `generics?reinstall`
and got the latest CRAN version. `renv::install("generics@0.1.3")` was
unaffected because that argument arrives as an unnamed character vector.

`renv::rebuild()` and `renv::repair()` also pass named record lists to
`install()`, so they were affected in the same way. `restore()` and `hydrate()`
were not -- both already format records with `renv_record_format_remote(record,
pak = TRUE)` before calling pak.

This PR formats records the same way, and keeps each spec's package name
alongside it so `include` / `exclude` continue to filter by package name rather
than by remote specification.

### Tests

Two new cases in `tests/testthat/test-pak.R`, using the existing
mocked-`pkg_install` pattern. Both fail on `main` with the reported symptom
(`bread?reinstall`) and pass here:

- `use("bread@0.1.0")` reaches pak as `bread@0.1.0?reinstall`
- `install(records, exclude = "oatmeal")` filters by package name and still
  emits `bread@0.1.0?reinstall`

`devtools::test(filter = "pak|use|install|restore|rebuild|repair|update")`
reports `FAIL 0 | PASS 266`.

### Notes

- The previous `setdiff()` / `intersect()` filtering incidentally de-duplicated
  the package list when `include` / `exclude` was supplied; the name-based
  filtering preserves duplicates. That de-duplication looked incidental rather
  than intended, since it didn't happen without those arguments.
- Pre-existing and still unfixed: for plain character input, `include` /
  `exclude` match against the raw spec, so `install("generics@0.1.3", exclude =
  "generics")` doesn't filter. Fixing that requires resolving each spec to a
  package name, which costs a network round trip for git / GitHub remotes.
