### PR TITLE
report the underlying cause when package downloads fail

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # renv (development version)
 
+* When a package fails to download, renv now reports the reason for the
+  failure, rather than a generic "failed to download" message. For example,
+  when the download destination within the renv root is not writable (as can
+  happen with a misconfigured shared cache), the error now says so directly.
+  (#2340)
+
 * `renv::use()` with pak enabled now honours the requested remotes, rather than
   installing the latest version of each package from the active repositories.
   Previously, a call like `renv::use("generics@0.1.3")` would install the

--- a/R/download.R
+++ b/R/download.R
@@ -132,10 +132,11 @@ renv_download_impl <- function(url, destfile, type = NULL, request = "GET", head
   url      <- chartr("\\", "/", url)
   destfile <- chartr("\\", "/", destfile)
 
-  # check that the destination file is writable
+  # check that the destination file is writable; report the containing
+  # directory, since the destination file itself need not exist yet
   if (!renv_file_writable(destfile)) {
-    fmt <- "destination path '%s' is not writable; cannot proceed"
-    stopf(fmt, renv_path_pretty(destfile))
+    fmt <- "destination directory %s is not writable; cannot proceed"
+    stopf(fmt, renv_path_pretty(dirname(destfile)))
   }
 
   # select the appropriate downloader

--- a/R/graph.R
+++ b/R/graph.R
@@ -1309,7 +1309,10 @@ renv_graph_install <- function(descriptions) {
 
     }
 
-    # sequential fallback for unsupported sources or failed parallel downloads
+    # sequential fallback for unsupported sources or failed parallel downloads;
+    # remember why each retrieval failed, so the reason can be reported
+    # https://github.com/rstudio/renv/issues/2340
+    downloaderrors <- list()
     for (pkg in fallbacks) {
 
       status <- catch({
@@ -1319,6 +1322,7 @@ renv_graph_install <- function(descriptions) {
       })
 
       if (inherits(status, "error")) {
+        downloaderrors[[pkg]] <- conditionMessage(status)
         downloadable[[pkg]] <- NULL
         next
       }
@@ -1347,7 +1351,8 @@ renv_graph_install <- function(descriptions) {
           pkgver <- paste(desc$Package, desc$Version)
           writef("%s %s", boo(), format(pkgver, width = the$install_step_width))
         }
-        errors$push(list(package = package, message = "failed to download"))
+        message <- downloaderrors[[package]] %||% "failed to download"
+        errors$push(list(package = package, message = message))
         failed$push(package)
         next
       }

--- a/tests/testthat/_snaps/init.md
+++ b/tests/testthat/_snaps/init.md
@@ -9,7 +9,7 @@
       # Installing packages ---
       
       The following package(s) were not installed successfully:
-      - [missing]: failed to download
+      - [missing]: package 'missing' is not available
       You may need to manually download and install these packages.
       
       The version of R recorded in the lockfile will be updated:

--- a/tests/testthat/_snaps/install.md
+++ b/tests/testthat/_snaps/install.md
@@ -75,7 +75,7 @@
       # Installing packages ---
       
       The following package(s) were not installed successfully:
-      - [missing]: failed to download
+      - [missing]: package 'missing' is not available
       You may need to manually download and install these packages.
       
     Condition

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -706,6 +706,32 @@ test_that("renv_graph_install_errors is silent with no errors", {
 
 })
 
+test_that("download failures report the underlying cause (#2340)", {
+
+  skip_on_cran()
+  skip_on_windows()
+  skip_if(Sys.info()[["user"]] == "root")
+
+  # use an isolated root, so the package is downloaded rather than
+  # linked from the cache shared by other tests
+  renv_tests_scope("bread", isolated = TRUE)
+  init(bare = TRUE)
+
+  # simulate an unwritable download destination, as might happen
+  # with a shared renv root whose permissions are misconfigured
+  destdir <- renv_paths_source("repository", "bread")
+  ensure_directory(destdir)
+  Sys.chmod(destdir, "0555")
+  defer(Sys.chmod(destdir, "0755"))
+
+  renv_scope_options(renv.verbose = TRUE, renv.caution.verbose = TRUE)
+  output <- capture.output(status <- catch(install("bread")))
+  output <- paste(output, collapse = "\n")
+  expect_true(grepl("is not writable", output))
+  expect_true(grepl(basename(destdir), output, fixed = TRUE))
+
+})
+
 # wave cycle detection ----
 
 test_that("renv_graph_waves warns on dependency cycle", {


### PR DESCRIPTION
Closes #2340.

## Problem

When a package fails to download, the graph installer reports only a generic message:

```
The following package(s) were not installed successfully:
- [terra]: failed to download
```

The sequential download fallback catches the real error -- for example, renv's own "destination directory is not writable" check -- and discards its message, leaving the user with no clue about the cause (see #2340, where the culprit was a shared renv root with misconfigured permissions).

## Approach

- Capture the condition message from failed fallback retrievals, and surface it in the install error summary:

  ```
  The following package(s) were not installed successfully:
  - [bread]: destination directory "/path/to/renv/source/repository/bread" is not writable; cannot proceed
  ```

- Refine the unwritable-destination error in `renv_download_impl()` to name the containing directory rather than the (not-yet-existing) temporary download file, and avoid double-quoting the path.

Existing snapshots for a missing package now report `package 'missing' is not available` instead of the generic message.