### PR TITLE
fix spurious 'loaded before renv activated' warning (#2344)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # renv (development version)
 
+* Fixed an issue where renv would warn that a package "was loaded before renv
+  activated this project" when no such thing had happened. Projects using
+  Bioconductor were affected on every startup, as renv loads `BiocManager`
+  itself when resolving Bioconductor repositories. The check also mistook
+  packages linked into the project library from the renv cache for packages
+  loaded from outside the library paths. (#2344)
+
 
 # renv 1.2.4
 

--- a/R/load.R
+++ b/R/load.R
@@ -3,7 +3,7 @@
 the$load_running <- FALSE
 
 # the namespaces which were already loaded when 'load()' was invoked
-the$load_namespaces <- character()
+the$preloaded_namespaces <- character()
 
 #' Load a project
 #'
@@ -93,7 +93,7 @@ load <- function(project = NULL, quiet = FALSE, profile = NULL, ...) {
   # take note of the namespaces which were loaded before we started, so that
   # renv_load_check_namespaces() can tell them apart from the namespaces renv
   # itself loads while loading the project
-  renv_scope_binding(the, "load_namespaces", loadedNamespaces())
+  renv_scope_binding(the, "preloaded_namespaces", loadedNamespaces())
 
   # if load is being called via the autoloader,
   # then ensure RENV_PROJECT is unset
@@ -783,8 +783,8 @@ renv_load_check_namespaces <- function(project) {
   # most notably BiocManager, when resolving Bioconductor repositories -- and
   # those are not encapsulation breaks.
   # https://github.com/rstudio/renv/issues/2344
-  loaded <- intersect(the$load_namespaces, loadedNamespaces())
-  candidates <- setdiff(loaded, ignored)
+  preloaded <- intersect(the$preloaded_namespaces, loadedNamespaces())
+  candidates <- setdiff(preloaded, ignored)
   if (empty(candidates))
     return(invisible(TRUE))
 

--- a/R/load.R
+++ b/R/load.R
@@ -2,6 +2,9 @@
 # are we currently running 'load()'?
 the$load_running <- FALSE
 
+# the namespaces which were already loaded when 'load()' was invoked
+the$load_namespaces <- character()
+
 #' Load a project
 #'
 #' @description
@@ -86,6 +89,11 @@ load <- function(project = NULL, quiet = FALSE, profile = NULL, ...) {
 
   # indicate that we're now loading the project
   renv_scope_binding(the, "load_running", TRUE)
+
+  # take note of the namespaces which were loaded before we started, so that
+  # renv_load_check_namespaces() can tell them apart from the namespaces renv
+  # itself loads while loading the project
+  renv_scope_binding(the, "load_namespaces", loadedNamespaces())
 
   # if load is being called via the autoloader,
   # then ensure RENV_PROJECT is unset
@@ -769,7 +777,14 @@ renv_load_check_namespaces <- function(project) {
 
   libpaths <- renv_libpaths_all()
   ignored <- c(renv_packages_base(), "renv")
-  candidates <- setdiff(loadedNamespaces(), ignored)
+
+  # only consider namespaces which were already loaded when renv started
+  # loading this project. renv loads some namespaces itself along the way --
+  # most notably BiocManager, when resolving Bioconductor repositories -- and
+  # those are not encapsulation breaks.
+  # https://github.com/rstudio/renv/issues/2344
+  loaded <- intersect(the$load_namespaces, loadedNamespaces())
+  candidates <- setdiff(loaded, ignored)
   if (empty(candidates))
     return(invisible(TRUE))
 
@@ -778,7 +793,7 @@ renv_load_check_namespaces <- function(project) {
     nspath <- catch(renv_namespace_path(pkg))
     if (inherits(nspath, "error") || !nzchar(nspath))
       next
-    if (dirname(nspath) %in% libpaths)
+    if (renv_load_namespace_managed(pkg, nspath, libpaths))
       next
     external[[pkg]] <- renv_path_aliased(nspath)
   }
@@ -803,6 +818,29 @@ renv_load_check_namespaces <- function(project) {
   )
 
   invisible(FALSE)
+
+}
+
+# Is `package`, whose namespace was loaded from `nspath`, provided by one of
+# `libpaths`? R records a namespace's path in fully resolved form, whereas a
+# library entry is commonly a symlink (or, on Windows, a junction) into the
+# renv cache -- so the two must be normalized before they can be compared.
+# https://github.com/rstudio/renv/issues/2344
+renv_load_namespace_managed <- function(package, nspath, libpaths) {
+
+  # fast path for libraries which own their packages outright
+  if (dirname(nspath) %in% libpaths)
+    return(TRUE)
+
+  nspath <- renv_path_normalize(nspath)
+
+  for (libpath in libpaths) {
+    pkgpath <- file.path(libpath, package)
+    if (file.exists(pkgpath) && identical(renv_path_normalize(pkgpath), nspath))
+      return(TRUE)
+  }
+
+  FALSE
 
 }
 

--- a/R/load.R
+++ b/R/load.R
@@ -793,7 +793,7 @@ renv_load_check_namespaces <- function(project) {
     nspath <- catch(renv_namespace_path(pkg))
     if (inherits(nspath, "error") || !nzchar(nspath))
       next
-    if (renv_load_namespace_managed(pkg, nspath, libpaths))
+    if (nzchar(renv_namespace_libpath(pkg, libpaths)))
       next
     external[[pkg]] <- renv_path_aliased(nspath)
   }
@@ -818,29 +818,6 @@ renv_load_check_namespaces <- function(project) {
   )
 
   invisible(FALSE)
-
-}
-
-# Is `package`, whose namespace was loaded from `nspath`, provided by one of
-# `libpaths`? R records a namespace's path in fully resolved form, whereas a
-# library entry is commonly a symlink (or, on Windows, a junction) into the
-# renv cache -- so the two must be normalized before they can be compared.
-# https://github.com/rstudio/renv/issues/2344
-renv_load_namespace_managed <- function(package, nspath, libpaths) {
-
-  # fast path for libraries which own their packages outright
-  if (dirname(nspath) %in% libpaths)
-    return(TRUE)
-
-  nspath <- renv_path_normalize(nspath)
-
-  for (libpath in libpaths) {
-    pkgpath <- file.path(libpath, package)
-    if (file.exists(pkgpath) && identical(renv_path_normalize(pkgpath), nspath))
-      return(TRUE)
-  }
-
-  FALSE
 
 }
 

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -14,6 +14,32 @@ renv_namespace_path <- function(package) {
   .getNamespaceInfo(namespace, "path")
 }
 
+# The library path providing `package`'s loaded namespace, or "" if the
+# namespace was loaded from somewhere else. R records a namespace's path in
+# fully resolved form, whereas a library entry is commonly a symlink (or, on
+# Windows, a junction) into the renv cache -- so the two must be normalized
+# before they can be compared.
+# https://github.com/rstudio/renv/issues/2344
+renv_namespace_libpath <- function(package, libpaths = renv_libpaths_all()) {
+
+  nspath <- renv_namespace_path(package)
+
+  # fast path for libraries which own their packages outright
+  if (dirname(nspath) %in% libpaths)
+    return(dirname(nspath))
+
+  nspath <- renv_path_normalize(nspath)
+
+  for (libpath in libpaths) {
+    pkgpath <- file.path(libpath, package)
+    if (file.exists(pkgpath) && identical(renv_path_normalize(pkgpath), nspath))
+      return(libpath)
+  }
+
+  ""
+
+}
+
 renv_namespace_load <- function(package) {
   suppressPackageStartupMessages(getNamespace(package))
 }

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -108,6 +108,10 @@ test_that("renv_load_check_namespaces flags packages loaded from outside libpath
   ensure_directory(projlib)
   renv_scope_libpaths(c(projlib, .Library))
 
+  # the check only considers namespaces which were loaded before renv began
+  # loading the project; load() normally records these for us
+  renv_scope_binding(the, "load_namespaces", loadedNamespaces())
+
   # we test the helper directly; renv_load_check() only wires it up
   # during autoloader-driven startup, which doesn't fire in tests
   expect_output(
@@ -128,8 +132,90 @@ test_that("renv_load_check_namespaces is silent when all loaded packages are on 
   loaded <- setdiff(loadedNamespaces(), c(renv_packages_base(), "renv"))
   paths <- vapply(loaded, function(p) dirname(renv_namespace_path(p)), character(1))
   renv_scope_libpaths(unique(c(paths, .libPaths())))
+  renv_scope_binding(the, "load_namespaces", loadedNamespaces())
 
   expect_silent(result <- renv_load_check_namespaces(getwd()))
   expect_true(result)
+
+})
+
+test_that("renv_load_check_namespaces tolerates packages linked from the cache", {
+
+  # https://github.com/rstudio/renv/issues/2344 -- R records a namespace's
+  # path in resolved form, so a package linked into the library from the
+  # renv cache must not be mistaken for one loaded from outside .libPaths()
+
+  skip_on_os("windows")
+
+  renv_tests_scope()
+  renv_scope_options(renv.caution.verbose = TRUE)
+
+  # install bread, then stage it as the cache does: the real package lives
+  # outside the library, which merely holds a symlink pointing at it
+  cache <- renv_scope_tempfile("renv-cache-")
+  ensure_directory(cache)
+  install("bread", library = cache)
+
+  projlib <- renv_scope_tempfile("renv-projlib-")
+  ensure_directory(projlib)
+
+  pkg <- "bread"
+  file.symlink(file.path(cache, pkg), file.path(projlib, pkg))
+
+  renv_scope_libpaths(c(projlib, .Library))
+  loadNamespace(pkg, lib.loc = projlib)
+  defer(unloadNamespace(pkg))
+
+  # consider only bread, so that the check's verdict is unambiguous
+  renv_scope_binding(the, "load_namespaces", pkg)
+
+  # the namespace path points into the cache, not the library ...
+  expect_false(dirname(renv_namespace_path(pkg)) %in% renv_libpaths_all())
+
+  # ... but the package is reachable via the library, so it's managed
+  expect_silent(result <- renv_load_check_namespaces(getwd()))
+  expect_true(result)
+
+})
+
+test_that("renv_load_check_namespaces ignores namespaces renv loaded itself", {
+
+  # https://github.com/rstudio/renv/issues/2344 -- renv loads BiocManager
+  # while resolving Bioconductor repositories, well after project load has
+  # begun; such packages must not be reported as loaded before renv started
+
+  renv_tests_scope()
+  renv_scope_options(renv.caution.verbose = TRUE)
+
+  # oatmeal lives in the project library; bread does not
+  projlib <- renv_scope_tempfile("renv-projlib-")
+  ensure_directory(projlib)
+  install("oatmeal", library = projlib)
+
+  userlib <- renv_scope_tempfile("renv-userlib-")
+  ensure_directory(userlib)
+  install("bread", library = userlib)
+
+  managed <- "oatmeal"
+  external <- "bread"
+
+  renv_scope_libpaths(c(projlib, userlib, .Library))
+  loadNamespace(managed)
+  defer(unloadNamespace(managed))
+  loadNamespace(external)
+  defer(unloadNamespace(external))
+
+  # drop bread's library, leaving it loaded from outside .libPaths()
+  renv_scope_libpaths(c(projlib, .Library))
+
+  # renv loaded bread only after project load began, so it isn't reported
+  renv_scope_binding(the, "load_namespaces", managed)
+  expect_silent(result <- renv_load_check_namespaces(getwd()))
+  expect_true(result)
+
+  # whereas had it been loaded beforehand, it would be
+  renv_scope_binding(the, "load_namespaces", c(managed, external))
+  expect_output(result <- renv_load_check_namespaces(getwd()), external)
+  expect_false(result)
 
 })

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -110,7 +110,7 @@ test_that("renv_load_check_namespaces flags packages loaded from outside libpath
 
   # the check only considers namespaces which were loaded before renv began
   # loading the project; load() normally records these for us
-  renv_scope_binding(the, "load_namespaces", loadedNamespaces())
+  renv_scope_binding(the, "preloaded_namespaces", loadedNamespaces())
 
   # we test the helper directly; renv_load_check() only wires it up
   # during autoloader-driven startup, which doesn't fire in tests
@@ -132,7 +132,7 @@ test_that("renv_load_check_namespaces is silent when all loaded packages are on 
   loaded <- setdiff(loadedNamespaces(), c(renv_packages_base(), "renv"))
   paths <- vapply(loaded, function(p) dirname(renv_namespace_path(p)), character(1))
   renv_scope_libpaths(unique(c(paths, .libPaths())))
-  renv_scope_binding(the, "load_namespaces", loadedNamespaces())
+  renv_scope_binding(the, "preloaded_namespaces", loadedNamespaces())
 
   expect_silent(result <- renv_load_check_namespaces(getwd()))
   expect_true(result)
@@ -167,7 +167,7 @@ test_that("renv_load_check_namespaces tolerates packages linked from the cache",
   defer(unloadNamespace(pkg))
 
   # consider only bread, so that the check's verdict is unambiguous
-  renv_scope_binding(the, "load_namespaces", pkg)
+  renv_scope_binding(the, "preloaded_namespaces", pkg)
 
   # the namespace path points into the cache, not the library ...
   expect_false(dirname(renv_namespace_path(pkg)) %in% renv_libpaths_all())
@@ -209,12 +209,12 @@ test_that("renv_load_check_namespaces ignores namespaces renv loaded itself", {
   renv_scope_libpaths(c(projlib, .Library))
 
   # renv loaded bread only after project load began, so it isn't reported
-  renv_scope_binding(the, "load_namespaces", managed)
+  renv_scope_binding(the, "preloaded_namespaces", managed)
   expect_silent(result <- renv_load_check_namespaces(getwd()))
   expect_true(result)
 
   # whereas had it been loaded beforehand, it would be
-  renv_scope_binding(the, "load_namespaces", c(managed, external))
+  renv_scope_binding(the, "preloaded_namespaces", c(managed, external))
   expect_output(result <- renv_load_check_namespaces(getwd()), external)
   expect_false(result)
 

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -1,0 +1,72 @@
+
+test_that("renv_namespace_libpath finds the library providing a namespace", {
+
+  renv_tests_scope()
+
+  projlib <- renv_scope_tempfile("renv-projlib-")
+  ensure_directory(projlib)
+  install("bread", library = projlib)
+
+  # indirect the package name through a variable so R CMD check doesn't
+  # flag bread as an undeclared dependency
+  pkg <- "bread"
+  renv_scope_libpaths(c(projlib, .Library))
+  loadNamespace(pkg, lib.loc = projlib)
+  defer(unloadNamespace(pkg))
+
+  expect_equal(renv_namespace_libpath(pkg, projlib), projlib)
+
+  # libpaths defaults to the active library paths
+  expect_equal(renv_namespace_libpath(pkg), projlib)
+
+})
+
+test_that("renv_namespace_libpath resolves packages linked from the cache", {
+
+  # https://github.com/rstudio/renv/issues/2344 -- R records a namespace's
+  # path in resolved form, so the library entry and the namespace path have
+  # to be normalized before they can be compared
+
+  skip_on_os("windows")
+
+  renv_tests_scope()
+
+  # the real package lives outside the library, which holds only a symlink
+  cache <- renv_scope_tempfile("renv-cache-")
+  ensure_directory(cache)
+  install("bread", library = cache)
+
+  projlib <- renv_scope_tempfile("renv-projlib-")
+  ensure_directory(projlib)
+
+  pkg <- "bread"
+  file.symlink(file.path(cache, pkg), file.path(projlib, pkg))
+
+  renv_scope_libpaths(c(projlib, .Library))
+  loadNamespace(pkg, lib.loc = projlib)
+  defer(unloadNamespace(pkg))
+
+  expect_equal(renv_namespace_libpath(pkg, projlib), projlib)
+
+})
+
+test_that("renv_namespace_libpath returns '' for namespaces outside the libpaths", {
+
+  renv_tests_scope()
+
+  userlib <- renv_scope_tempfile("renv-userlib-")
+  ensure_directory(userlib)
+  install("bread", library = userlib)
+
+  pkg <- "bread"
+  renv_scope_libpaths(c(userlib, .Library))
+  loadNamespace(pkg, lib.loc = userlib)
+  defer(unloadNamespace(pkg))
+
+  # a library which doesn't provide bread at all
+  projlib <- renv_scope_tempfile("renv-projlib-")
+  ensure_directory(projlib)
+
+  expect_equal(renv_namespace_libpath(pkg, projlib), "")
+
+})


### PR DESCRIPTION
Fixes #2344.

## The report

`renv::init(bioconductor = TRUE)` leaves every subsequent startup printing:

```
The following package(s) were loaded before renv activated this project:
- BiocManager [~/.cache/R/renv/cache/v5/.../BiocManager/1.30.27/.../BiocManager]
```

Nothing the reporter tried helped -- restarting R, or removing BiocManager from
either the path shown or the project library, all produced the same message on
the next load.

## Two causes, both introduced with the check in #2301

**The path comparison doesn't account for the cache.** `renv_load_check_namespaces()`
decided a package was external via `dirname(nspath) %in% libpaths`. But `nspath`
comes from `.getNamespaceInfo(ns, "path")`, which R records in fully resolved
form, and with `use.cache = TRUE` every project library entry is a symlink into
the renv cache. So `dirname(nspath)` is the cache directory and never a library
path. This also explains the reporter's confusion: the path printed is the cache
path, which isn't a library location, so `remove.packages()` on it does nothing.

**renv loads BiocManager itself, then warns about it.** In `renv_load()`,
`renv_load_bioconductor()` reaches `renv_bioconductor_repos()` ->
`renv_scope_biocmanager()` -> `renv_namespace_load("BiocManager")`. Only
afterwards does `renv_load_finish()` run `renv_load_check_namespaces()`. So renv
loads BiocManager out of the project library and then reports that it "was
loaded before renv activated this project". Deleting it doesn't help, because
`renv_bioconductor_init()` reinstalls and relinks it on the next load.

Both are required to produce the report: the ordering puts BiocManager inside the
window, and the cache symlink makes the check misjudge it.

## The fix

New `renv_load_namespace_managed()` helper replaces the `dirname()` test. It
keeps that comparison as a fast path for libraries that own their packages
outright, and otherwise checks whether the package is reachable through any
library path by comparing `renv_path_normalize()` on both sides -- which resolves
symlinks and Windows junctions.

Note that `renv_path_same()` is *not* usable here: it deliberately normalizes
only the parent directory and leaves the final component's symlink unresolved
(`R/path.R:124`), so it returns `FALSE` in exactly this scenario.

`load()` now also records `loadedNamespaces()` into `the$load_namespaces` via a
scoped binding, and the check intersects against that snapshot. This makes the
message's claim literally true, and keeps the check correct if renv starts
loading other namespaces during load in future.

## Test plan

- New test staging a package the way the cache does (real package outside the
  library, symlink inside it); asserts the namespace path really does point
  outside `.libPaths()`, then asserts the check stays silent.
- New test confirming a package loaded *after* project load began is skipped,
  while the same package is still reported when loaded beforehand -- so the fix
  doesn't blind the check to the #2300 case it was written for.
- The two existing tests updated to set up the new `load_namespaces` state. The
  pre-existing "silent" test could not have caught this: it built `.libPaths()`
  out of `dirname(renv_namespace_path(p))`, hard-coding the very identity the
  cache breaks, and neither existing test used the cache.
- `devtools::test(filter = "load|bioconductor|install|snapshot|package|config|restore|status")`
  on main: 427 pass / 0 fail. On this branch: 434 pass / 0 fail, with identical
  warning and skip counts.

## Deliberately out of scope

`renv_package_libpath_version()` (`R/package.R:74`) makes the same symlink
assumption in its fast path, but degrades safely -- it falls through to the
libpath scan, which handles symlinks. The cost is a `DESCRIPTION` read for cached
packages, a missed optimization rather than a defect. Changing it would alter how
`install()` decides what to skip, which doesn't belong in a fix for a load-time
warning.

The issue's title also points at something real and separate: `init(bioconductor
= TRUE)` installs BiocManager into the project library (`R/init.R:115`), but
under implicit snapshot BiocManager only becomes a dependency when some
DESCRIPTION carries `biocViews` (`R/dependencies.R:621`) or install sees a
Bioconductor-sourced remote (`R/install.R:220`). A project with no Bioconductor
packages yet leaves it orphaned: in the library, absent from the lockfile, and
invisible to `status()`. That predates #2301 and is a design question worth
deciding on its own.
