### PR TITLE
don't fall back to source install for untagged crandb records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # renv (development version)
 
+* `renv::install()` and `renv::restore()` no longer build a package from source
+  when a binary of the requested version is available, in cases where the active
+  repositories are pinned to a dated snapshot (for example, a Posit Package
+  Manager URL like `https://p3m.dev/cran/2025-03-28`) and the `crandb.enabled`
+  option is set. renv consulted crandb to find the newest version of the package,
+  but because crandb is not restricted to the configured repositories, it could
+  report a version those repositories don't provide -- and renv then fell back to
+  installing from source. (#2345)
+
 
 # renv 1.2.4
 

--- a/R/graph.R
+++ b/R/graph.R
@@ -925,19 +925,35 @@ renv_graph_url_repository <- function(desc) {
   if (is.null(version) || identical(record$Version, version))
     return(renv_graph_url_repository_record(desc, record))
 
-  # the latest version doesn't match; try a version-filtered lookup
-  # using the same type that was selected for the latest
-  type <- attr(record, "type", exact = TRUE) %||% "source"
-  entry <- catch(renv_available_packages_entry(
-    package = package,
-    type    = type,
-    filter  = version,
-    prefer  = desc[["Repository"]]
-  ))
+  # the latest version doesn't match; try a version-filtered lookup.
+  #
+  # normally we reuse the type selected for the latest record, but records
+  # from crandb carry no type tag -- and because crandb isn't restricted to
+  # the configured repositories, it can report a version those repositories
+  # don't have (e.g. when they're pinned to a dated snapshot), so it's these
+  # untagged records that tend to land here. assuming source for them would
+  # build from source even when a binary of the requested version is
+  # available, so honor the requested package type instead (#2345)
+  tagtype <- attr(record, "type", exact = TRUE)
+  types <- if (is.null(tagtype))
+    renv_graph_url_repository_types()
+  else
+    tagtype
 
-  if (!inherits(entry, "error")) {
-    tagged <- renv_available_packages_record(entry, type)
-    return(renv_graph_url_repository_record(desc, tagged))
+  for (type in types) {
+
+    entry <- catch(renv_available_packages_entry(
+      package = package,
+      type    = type,
+      filter  = version,
+      prefer  = desc[["Repository"]]
+    ))
+
+    if (!inherits(entry, "error")) {
+      tagged <- renv_available_packages_record(entry, type)
+      return(renv_graph_url_repository_record(desc, tagged))
+    }
+
   }
 
   # the requested version is not in current available packages;
@@ -963,6 +979,27 @@ renv_graph_url_repository <- function(desc) {
 
   # couldn't resolve; fall back to sequential retrieval
   NULL
+
+}
+
+# the package types to search, in preference order, when the record we're
+# resolving carries no type tag of its own
+renv_graph_url_repository_types <- function() {
+
+  type <- the$install_pkg_type %||% getOption("pkgType", default = "source")
+
+  # on platforms where only source packages are supported, "both" collapses
+  # to source; see renv_available_packages_latest_repos() (#2275)
+  if (identical(.Platform$pkgType, "source") && identical(type, "both"))
+    type <- "source"
+
+  if (identical(type, "source"))
+    return("source")
+
+  if (grepl("\\bbinary\\b", type))
+    return("binary")
+
+  c("binary", "source")
 
 }
 

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -302,6 +302,51 @@ test_that("renv_graph_url_repository resolves from test repo", {
 
 })
 
+test_that("renv_graph_url_repository prefers a binary for untagged records", {
+
+  skip_if(identical(.Platform$pkgType, "source"),
+          "binary packages not supported on this platform")
+
+  renv_tests_scope()
+  renv_scope_options(pkgType = .Platform$pkgType)
+
+  # records from crandb carry no url or type attribute, and crandb isn't
+  # restricted to the configured repositories -- so it can report a version
+  # those repositories don't have. renv used to fall back to source in that
+  # case, ignoring an available binary of the requested version (#2345)
+  local_mocked_bindings(
+    renv_available_packages_latest = function(package, ...) {
+      list(Package = package, Version = "9.9.9", Source = "Repository")
+    }
+  )
+
+  desc <- list(Package = "bread", Version = "1.0.0", Source = "Repository")
+  info <- renv_graph_url_repository(desc)
+
+  expect_equal(info$pkgtype, "binary")
+  expect_true(endsWith(info$url, renv_package_ext("binary")))
+
+})
+
+test_that("renv_graph_url_repository honors a source request for untagged records", {
+
+  renv_tests_scope()
+  renv_scope_options(pkgType = "source")
+
+  local_mocked_bindings(
+    renv_available_packages_latest = function(package, ...) {
+      list(Package = package, Version = "9.9.9", Source = "Repository")
+    }
+  )
+
+  desc <- list(Package = "bread", Version = "1.0.0", Source = "Repository")
+  info <- renv_graph_url_repository(desc)
+
+  expect_equal(info$pkgtype, "source")
+  expect_true(endsWith(info$url, ".tar.gz"))
+
+})
+
 # adjacency graph ----
 
 test_that("renv_graph_adjacency computes correct structure for chain", {


### PR DESCRIPTION
Fixes #2345.

`renv::install()` built a package from source even though a binary of the requested version was available, when the active repositories were pinned to a dated snapshot (e.g. `https://p3m.dev/cran/2025-03-28`) and `crandb.enabled` was set.

The reporter's project, `jabenninghoff/rdev`, sets `renv.config.crandb.enabled = TRUE` in its `.Rprofile`, which is how they hit this.

## Cause

`renv_graph_url_repository()` resolves the download URL. When the "latest available" version doesn't match the version being installed, it falls back to a version-filtered lookup, reusing the type selected for the latest record:

```r
type <- attr(record, "type", exact = TRUE) %||% "source"
```

With crandb enabled, `renv_available_packages_latest()` can return a crandb record. crandb isn't restricted to the configured repositories, so for a pinned snapshot it reports the current CRAN version (stringi 1.8.9) rather than the snapshot's (1.8.7). Two things follow: the versions no longer match, so we enter the fallback; and crandb records carry no `url` or `type` attribute, so the `%||%` silently yields `"source"`.

Without crandb, the repository record (1.8.7, tagged `binary`) matches and is used directly.

## Fix

When the record carries no type tag, honor the requested package type instead of assuming source. Tagged records are unaffected, so the default configuration behaves exactly as before.

## Scope

This only bites where the repository actually has a binary for the requested version but `renv_available_packages_latest()` names a different one — dated snapshots and other multi-version repositories. Against an ordinary latest-only mirror, an older version resolves to source with or without crandb, which is correct: only the source archive carries it.

## Verification

Two regression tests mock `renv_available_packages_latest()` to return an untagged record with a mismatched version (the crandb shape), asserting a binary is preferred when available and that an explicit source request is still honored. Against the unfixed code they fail with `actual: "source", expected: "binary"`.

End to end with the reporter's configuration, stringi 1.8.7 now installs as the PPM-built binary (`Built: R 4.6.0; aarch64-apple-darwin20; 2026-07-28`) rather than compiling locally.

Full suite: FAIL 0, PASS 1717.

## Note

`type = "binary"` is **not** a workaround for users hitting this — the crandb record still wins on version and the fallback still ignores the requested type. Until this ships, `crandb.enabled = FALSE` is the only option.

#### Related

`bugfix/prefer-repos-over-crandb` addresses the underlying resolver behavior that sets this off. The two are independent; this one is worth keeping either way as defense-in-depth.
