### PR TITLE
prefer repository records over crandb

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # renv (development version)
 
+* When the `crandb.enabled` option is set, renv now prefers the record from the
+  active repositories whenever those repositories can supply the package, rather
+  than taking whichever of the two reports the newer version. crandb is not
+  restricted to the active repositories, so it could name a version they don't
+  carry -- for example, when they're pinned to a dated snapshot such as
+  `https://p3m.dev/cran/2025-03-28`. renv now consults crandb only when the
+  active repositories have no candidate at all, which is the case it was added
+  to handle: finding a version compatible with an older version of R. (#2345)
+
 
 # renv 1.2.4
 

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -430,35 +430,19 @@ renv_available_packages_latest <- function(package,
     return(entries[[2L]])
   }
 
-  # extract both entries
-  lhs <- entries[[1L]]
-  rhs <- entries[[2L]]
-
-  # extract versions
-  lhsv <- package_version(lhs$Version %||% "0.0")
-  rhsv <- package_version(rhs$Version %||% "0.0")
-
-  # if the versions don't match, take the newest one
-  if (lhsv > rhsv)
-    return(lhs)
-  else if (rhsv > lhsv)
-    return(rhs)
-
-  # otherwise, if we have a binary from the active package repositories,
-  # use those; otherwise, use the mran binary
-  if (identical(lhsv, rhsv)) {
-    if (identical(attr(lhs, "type", exact = TRUE), "binary"))
-      return(lhs)
-    # when rhs is from crandb it has no URL; prefer lhs to avoid archive
-    # fallback which fails for packages still live on CRAN (#1735)
-    # renv_record_tagged is true if the record has a url and type. Crandb does not have URL.
-    if (!renv_record_tagged(rhs))
-      return(lhs)
-    return(rhs)
-  }
-
-  # otherwise, return the regular repository entry
-  lhs
+  # both the configured repositories and crandb have a candidate; use the
+  # repository record.
+  #
+  # the configured repositories determine what can actually be installed, and
+  # available_packages() already drops versions whose R requirement the current
+  # session can't satisfy -- so crandb's role is to name a compatible version
+  # when the repositories have none, which is the branch above. crandb is not
+  # restricted to the configured repositories, so when it does name a newer
+  # version here, that version generally isn't installable from them: acting on
+  # it yields a failed download, an archive fallback that fails for packages
+  # still live on CRAN (#1735), or a source build where the repositories had a
+  # binary all along (#2345)
+  entries[[1L]]
 
 }
 

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -279,6 +279,58 @@ test_that("when crandb is enabled, repos entry is preferred when versions match 
   expect_true(nzchar(record$Version))
 })
 
+test_that("a repository record is preferred over a newer crandb version", {
+
+  renv_tests_scope()
+  renv_scope_options(renv.config.crandb.enabled = TRUE)
+
+  # crandb isn't restricted to the configured repositories, so it can name a
+  # version those repositories can't supply -- as happens when they're pinned
+  # to a dated snapshot. the repository record has to win, or renv resolves to
+  # a version it can't install from the repositories it was given (#2345)
+  local_mocked_bindings(
+    renv_available_packages_latest_crandb = function(package, ...) {
+      list(
+        Package    = package,
+        Version    = "9.9.9",
+        Source     = "Repository",
+        Repository = "CRAN"
+      )
+    }
+  )
+
+  record <- renv_available_packages_latest("bread")
+
+  expect_equal(record$Version, "1.0.0")
+  expect_true(renv_record_tagged(record))
+
+})
+
+test_that("crandb is still used when the repositories have no candidate", {
+
+  renv_tests_scope()
+  renv_scope_options(renv.config.crandb.enabled = TRUE)
+
+  # this is what crandb is for: naming a version renv can go find when the
+  # configured repositories can't supply the package at all
+  local_mocked_bindings(
+    renv_available_packages_latest_crandb = function(package, ...) {
+      list(
+        Package    = package,
+        Version    = "9.9.9",
+        Source     = "Repository",
+        Repository = "CRAN"
+      )
+    }
+  )
+
+  record <- renv_available_packages_latest("nonexistent.package")
+
+  expect_equal(record$Version, "9.9.9")
+  expect_false(renv_record_tagged(record))
+
+})
+
 test_that("version requirement parsing works correctly", {
 
   # Test various requirement formats


### PR DESCRIPTION
Follow-up to #2345, addressing the resolver behavior that set it off. Independent of the fix on `bugfix/crandb-binary-type`.

## Problem

`renv_available_packages_latest()` queried the configured repositories and crandb, then took whichever reported the newer version:

```r
if (lhsv > rhsv)
  return(lhs)
else if (rhsv > lhsv)
  return(rhs)
```

crandb isn't restricted to the configured repositories. When they're pinned to a dated snapshot — or are a lagging mirror, or an internal subset — crandb reports a version they don't carry, and wins. renv then resolves to a version it can't install from the repositories it was given.

In #2345 that surfaced as a source build where the snapshot had a binary all along. It can also produce a failed download, or an archive fallback that fails for packages still live on CRAN (#1735).

## Change

Consult crandb only when the configured repositories have no candidate.

That is what crandb was added for (#2215): naming a version compatible with an older R. `available_packages()` already runs `renv_available_packages_filter_version()`, which drops rows whose `Depends: R` the session can't satisfy — so when the repositories carry only a too-new version, they return nothing and crandb fills the gap. That branch is untouched.

When the repositories *do* return a record, they are the authority on what is installable, so it wins.

Worth noting the deleted comparison had already converged on this: the equal-version branch returned the repository record whenever the crandb record was untagged, and crandb records are never tagged. Only the `rhsv > lhsv` branch let crandb override, and that is the pathological one.

## Verification

Two tests mock the crandb method to report a newer version: one asserts the repository record wins when the repositories can supply the package, the other asserts crandb is still used when they can't. The first fails against the unfixed code with `actual: "9.9.9", expected: "1.0.0"`.

The existing crandb tests pass unchanged, including "repos entry is preferred when versions match (tagged record)" (#1735), which this strengthens.

Full suite: FAIL 0, PASS 1717.

## Follow-up not included here

crandb is still queried eagerly even when the repository lookup succeeds, so its result is now usually computed and discarded — one HTTP request per package for crandb users. Making it lazy is a natural next step, but it runs into a related oddity worth handling separately: `methods` has four entries (repos, crandb, archive, p3m), yet only `entries[[1]]` and `entries[[2]]` are ever read. If repos and crandb both return NULL while archive or p3m returns a record, the function returns `entries[[1L]]`, which is NULL. I have not exercised that path, and both are gated (`renv.install.allowArchivedPackages`, `renv_p3m_enabled()`), so I left it alone rather than widen this change.
