### PR TITLE
crandb review nits: news option name, simplify entry selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,14 @@
 # renv (development version)
 
-* When the `crandb.enabled` option is set, renv now prefers the record from the
-  active repositories whenever those repositories can supply the package, rather
-  than taking whichever of the two reports the newer version. crandb is not
-  restricted to the active repositories, so it could name a version they don't
-  carry -- for example, when they're pinned to a dated snapshot such as
-  `https://p3m.dev/cran/2025-03-28`. renv now consults crandb only when the
-  active repositories have no candidate at all, which is the case it was added
-  to handle: finding a version compatible with an older version of R. (#2345)
+* When the `renv.config.crandb.enabled` option is set, renv now prefers the
+  record from the active repositories whenever those repositories can supply
+  the package, rather than taking whichever of the two reports the newer
+  version. crandb is not restricted to the active repositories, so it could
+  name a version they don't carry -- for example, when they're pinned to a
+  dated snapshot such as `https://p3m.dev/cran/2025-03-28`. renv now consults
+  crandb only when the active repositories have no candidate at all, which is
+  the case it was added to handle: finding a version compatible with an older
+  version of R. (#2345)
 
 * Fixed an issue where renv would warn that a package "was loaded before renv
   activated this project" when no such thing had happened. Projects using

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,13 +18,13 @@
   loaded from outside the library paths. (#2344)
 
 * `renv::install()` and `renv::restore()` no longer build a package from source
-  when a binary of the requested version is available, in cases where the active
-  repositories are pinned to a dated snapshot (for example, a Posit Package
-  Manager URL like `https://p3m.dev/cran/2025-03-28`) and the `crandb.enabled`
-  option is set. renv consulted crandb to find the newest version of the package,
-  but because crandb is not restricted to the configured repositories, it could
-  report a version those repositories don't provide -- and renv then fell back to
-  installing from source. (#2345)
+  when a binary of the requested version is available, in cases where the
+  active repositories are pinned to a dated snapshot (for example, a Posit
+  Package Manager URL like `https://p3m.dev/cran/2025-03-28`) and the
+  `renv.config.crandb.enabled` option is set. renv consulted crandb to find the
+  newest version of the package, but because crandb is not restricted to the
+  configured repositories, it could report a version those repositories don't
+  provide -- and renv then fell back to installing from source. (#2345)
 
 
 # renv 1.2.4

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -424,25 +424,21 @@ renv_available_packages_latest <- function(package,
     if (!is.null(entry))
       stopf("package '%s' is not available\n- %s", package, entry$reason)
     stopf("package '%s' is not available", package)
-  } else if (is.null(entries[[2L]])) {
-    return(entries[[1L]])
-  } else if (is.null(entries[[1L]])) {
-    return(entries[[2L]])
   }
 
-  # both the configured repositories and crandb have a candidate; use the
-  # repository record.
+  # prefer the record from the configured repositories, consulting crandb only
+  # when they have no candidate.
   #
   # the configured repositories determine what can actually be installed, and
   # available_packages() already drops versions whose R requirement the current
   # session can't satisfy -- so crandb's role is to name a compatible version
-  # when the repositories have none, which is the branch above. crandb is not
-  # restricted to the configured repositories, so when it does name a newer
-  # version here, that version generally isn't installable from them: acting on
-  # it yields a failed download, an archive fallback that fails for packages
-  # still live on CRAN (#1735), or a source build where the repositories had a
-  # binary all along (#2345)
-  entries[[1L]]
+  # when the repositories have none. crandb is not restricted to the configured
+  # repositories, so when it names a newer version than they carry, that
+  # version generally isn't installable from them: acting on it yields a failed
+  # download, an archive fallback that fails for packages still live on CRAN
+  # (#1735), or a source build where the repositories had a binary all along
+  # (#2345)
+  entries[[1L]] %||% entries[[2L]]
 
 }
 


### PR DESCRIPTION
Post-merge review nits for #2348, which was merged before they landed on its branch.

- NEWS: refer to the config option by the name users actually set,
  `renv.config.crandb.enabled`, in both the #2348 entry and the #2347 entry,
  matching how other NEWS entries reference config options.
- `renv_available_packages_latest()`: collapse the two `else if` null-check
  branches and the final `entries[[1L]]` into `entries[[1L]] %||% entries[[2L]]`.
  No behavior change, including the gated path where both entries are NULL but
  archive/p3m returned a record (still returns NULL, as before).

Tests: `test-available-packages.R` passes (FAIL 0, PASS 50, 1 unrelated platform skip).
