### PR TITLE
don't cache partial available packages results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,10 @@
   an hour -- renv would behave as though the failed repositories held no
   packages at all, without reporting why. Partial results are no longer
   cached, so failed repositories are re-queried (and failures re-reported)
-  on subsequent calls. (#2350)
+  on subsequent calls. Similarly, failed archive queries (used when the
+  `renv.install.allowArchivedPackages` option is enabled) are no longer
+  cached, as the failure may be transient; such queries are still only
+  attempted once per operation. (#2350)
 
 * When the `renv.config.crandb.enabled` option is set, renv now prefers the
   record from the active repositories whenever those repositories can supply

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # renv (development version)
 
+* Fixed an issue where, if one or more repositories could not be queried for
+  available packages, the partial result would be cached and served for up to
+  an hour -- renv would behave as though the failed repositories held no
+  packages at all, without reporting why. Partial results are no longer
+  cached, so failed repositories are re-queried (and failures re-reported)
+  on subsequent calls. (#2350)
+
 * When the `renv.config.crandb.enabled` option is set, renv now prefers the
   record from the active repositories whenever those repositories can supply
   the package, rather than taking whichever of the two reports the newer

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -97,6 +97,11 @@ renv_available_packages_query <- function(type, repos, quiet = FALSE) {
   })
 
   bulletin(header, msgs)
+
+  # signal that this is a partial result, so it isn't cached in the index --
+  # failed repositories should be re-queried on the next call (#2350)
+  renv_condition_signal("renv.index.skip")
+
   filter(dbs, Negate(is.null))
 
 }

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -513,12 +513,27 @@ renv_available_packages_latest_p3m <- function(package,
 
 renv_available_packages_latest_archive_query <- function(repo) {
 
+  # use a dynamic layer over the index, so that failed queries -- which are
+  # not written to the index -- are still only attempted once per operation
+  dynamic(
+    key = list(repo = repo),
+    value = renv_available_packages_latest_archive_query_index(repo)
+  )
+
+}
+
+renv_available_packages_latest_archive_query_index <- function(repo) {
+
   index(
     scope = "available-packages-archive",
     key   = repo,
     value = tryCatch(
       renv_available_packages_latest_archive_query_impl(repo),
-      error = function(e) list()
+      error = function(e) {
+        # the failure may be transient, so avoid caching it (#2350)
+        renv_condition_signal("renv.index.skip")
+        list()
+      }
     )
   )
 

--- a/R/index.R
+++ b/R/index.R
@@ -44,6 +44,17 @@ index <- function(scope, key = NULL, value = NULL, limit = 3600L) {
   if (!is.null(item))
     return(item)
 
+  # otherwise, compute the value; computations can signal 'renv.index.skip'
+  # to indicate a partial result which shouldn't be cached (#2350)
+  skip <- FALSE
+  withCallingHandlers(
+    force(value),
+    renv.index.skip = function(cnd) skip <<- TRUE
+  )
+
+  if (skip)
+    return(value)
+
   # otherwise, update the index
   renv_index_set(root, scope, index, key, value, now, limit)
 

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -213,6 +213,38 @@ test_that("available_packages() tolerates missing repositories", {
   expect_true(is.null(dbs[["NARC"]]))
 })
 
+test_that("a failed repository query is not cached in the index (#2350)", {
+
+  renv_tests_scope()
+
+  # add a local repository which doesn't exist yet
+  repopath <- renv_scope_tempfile("renv-repos-")
+  fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
+
+  repos <- getOption("repos")
+  repos[["LOCAL"]] <- sprintf(fmt, repopath)
+  renv_scope_options(repos = repos)
+
+  dbs <- available_packages(type = "source")
+  expect_false(is.null(dbs[["CRAN"]]))
+  expect_true(is.null(dbs[["LOCAL"]]))
+
+  # now, create the repository
+  contrib <- file.path(repopath, "src/contrib")
+  ensure_directory(contrib)
+  file.create(file.path(contrib, "PACKAGES"))
+
+  # clear the in-memory memoization, so we hit the on-disk index
+  renv_dynamic_reset()
+
+  # the repository should now be visible; a partial result
+  # from the previous query should not have been cached
+  dbs <- available_packages(type = "source")
+  expect_false(is.null(dbs[["CRAN"]]))
+  expect_false(is.null(dbs[["LOCAL"]]))
+
+})
+
 test_that("crandb query returns R-compatible versions", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -245,6 +245,54 @@ test_that("a failed repository query is not cached in the index (#2350)", {
 
 })
 
+test_that("failed archive queries are not cached in the index (#2350)", {
+
+  renv_tests_scope()
+
+  # a local repository which doesn't exist yet
+  repopath <- renv_scope_tempfile("renv-repos-")
+  fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
+  repo <- sprintf(fmt, repopath)
+
+  count <- 0L
+  renv_scope_trace(
+    what   = renv:::renv_available_packages_latest_archive_query_impl,
+    tracer = function() count <<- count + 1L
+  )
+
+  # repeated lookups within a single operation only query once
+  repos <- c(CRAN = repo, EXTRA = repo)
+  entry <- renv_available_packages_latest_archive("bread", repos = repos)
+  expect_null(entry)
+  expect_identical(count, 1L)
+
+  # however, the failure is not cached in the on-disk index,
+  # so a new operation re-queries the repository
+  renv_dynamic_reset()
+  entry <- renv_available_packages_latest_archive("bread", repos = repos)
+  expect_null(entry)
+  expect_identical(count, 2L)
+
+  # create the archive metadata, and check the query now succeeds
+  meta <- file.path(repopath, "src/contrib/Meta")
+  ensure_directory(meta)
+  database <- list(bread = data.frame(size = 1024L, row.names = "bread/bread_0.5.0.tar.gz"))
+  saveRDS(database, file = file.path(meta, "archive.rds"))
+
+  renv_dynamic_reset()
+  entry <- renv_available_packages_latest_archive("bread", repos = repos)
+  expect_identical(entry$Package, "bread")
+  expect_identical(entry$Version, "0.5.0")
+  expect_identical(count, 3L)
+
+  # successful queries are cached in the index, as before
+  renv_dynamic_reset()
+  entry <- renv_available_packages_latest_archive("bread", repos = repos)
+  expect_identical(entry$Package, "bread")
+  expect_identical(count, 3L)
+
+})
+
 test_that("crandb query returns R-compatible versions", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test-index.R
+++ b/tests/testthat/test-index.R
@@ -146,3 +146,33 @@ test_that("the available packages index is updated and cleaned", {
   expect_length(files, 2L)
 
 })
+
+test_that("values signaling 'renv.index.skip' are not indexed", {
+
+  counter$reset()
+  key <- renv_id_generate()
+
+  value <- index(
+    scope = scope,
+    key   = key,
+    value = {
+      counter$increment()
+      renv_condition_signal("renv.index.skip")
+      "partial"
+    }
+  )
+
+  # the value is still returned as-is
+  expect_equal(value, "partial")
+  expect_equal(counter$get(), 1L)
+
+  # but it wasn't cached, so the next call re-computes
+  index(
+    scope = scope,
+    key   = key,
+    value = counter$increment()
+  )
+
+  expect_equal(counter$get(), 2L)
+
+})


### PR DESCRIPTION
Fixes #2350.

When one or more repositories failed to respond during an available-packages query, the partial result -- containing only the repositories that did answer -- was written to the on-disk index and served for up to an hour. During that window, renv behaved as though the failed repositories held no packages at all, and since no query ran, the failure was never re-reported. As described in #2350, this could send `restore()` down the archive fallback path with only a generic "failed to download" error.

This PR makes two changes:

- `renv_available_packages_query()` now signals a new `renv.index.skip` condition when any repository fails; `index()` listens for it while forcing the value, and skips writing such partial results to the index. Failed repositories are therefore re-queried (and failures re-reported) on subsequent calls. Complete results are cached exactly as before, and the in-call `dynamic()` memoization still prevents repeated queries within a single operation.

- The archive query used with `renv.install.allowArchivedPackages` had the same class of issue: any error was converted to an empty list and cached for an hour, so a transient network failure would make renv conclude no archived versions exist. Failed archive queries now also bypass the index, with a `dynamic()` layer added so a failing repository is still only queried once per operation, rather than once per package lookup.

Both regression tests fail without their respective fixes: the available-packages test reproduces the issue's scenario (repository fails once, then comes online, and must be visible on the next query), and the archive test additionally verifies the once-per-operation memoization and that successful results still cache.