### PR TITLE
report all matching sysreqs rules, not just the first

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # renv (development version)
 
+* Fixed an issue where `renv::sysreqs()` (and the system requirement checks
+  performed during install and restore) would only report the first system
+  package required by an R package. When a package's `SystemRequirements`
+  field declared multiple system libraries -- for example, `ragg` declares
+  freetype2, libpng, libtiff, libjpeg, and libwebp -- only the first matching
+  system dependency was reported. All matching dependencies are now reported.
+  (#2352)
+
 * Fixed an issue where, if one or more repositories could not be queried for
   available packages, the partial result would be cached and served for up to
   an hour -- renv would behave as though the failed repositories held no

--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -193,8 +193,22 @@ renv_sysreqs_crandb_impl_one <- function(package) {
 }
 
 renv_sysreqs_resolve <- function(sysreqs, rules = renv_sysreqs_rules()) {
+
   matches <- map(sysreqs, renv_sysreqs_match, rules)
-  unlist(matches, recursive = FALSE)
+  matches <- unlist(matches, recursive = FALSE)
+  if (empty(matches))
+    return(NULL)
+
+  # a single SystemRequirements field can match multiple rules,
+  # so merge the fields from each matching rule
+  merged <- list()
+  for (field in c("packages", "pre_install", "post_install")) {
+    values <- unlist(map(matches, `[[`, field), recursive = FALSE, use.names = FALSE)
+    merged[[field]] <- unique(values)
+  }
+
+  merged
+
 }
 
 renv_sysreqs_rules <- function() {
@@ -207,17 +221,11 @@ renv_sysreqs_rules_impl <- function() {
 }
 
 renv_sysreqs_match <- function(sysreq, rules = renv_sysreqs_rules()) {
-
-  for (rule in rules) {
-    match <- renv_sysreqs_match_impl(sysreq, rule)
-    if (!is.null(match)) {
-      return(match)
-    }
-  }
-
+  matches <- map(rules, renv_sysreqs_match_impl, sysreq)
+  reject(matches, is.null)
 }
 
-renv_sysreqs_match_impl <- function(sysreq, rule) {
+renv_sysreqs_match_impl <- function(rule, sysreq) {
 
   # check for a match in the declared system requirements
   pattern <- paste(rule$patterns, collapse = "|")

--- a/tests/testthat/test-sysreqs.R
+++ b/tests/testthat/test-sysreqs.R
@@ -21,6 +21,25 @@ test_that("system requirements are reported", {
 
 })
 
+test_that("all matching rules are reported for multi-library requirements", {
+
+  skip_on_cran()
+
+  renv_scope_binding(the, "os", "linux")
+  renv_scope_binding(the, "distro", "ubuntu")
+  renv_scope_binding(the, "platform", list(VERSION_ID = "24.04"))
+
+  # e.g. from the 'ragg' package -- https://github.com/rstudio/renv/issues/2352
+  sysreq <- "freetype2, libpng, libtiff, libjpeg, libwebp,\nlibwebpmux"
+  sysdep <- renv_sysreqs_resolve(sysreq)
+
+  expect_equal(
+    sysdep$packages,
+    list("libfreetype6-dev", "libjpeg-dev", "libpng-dev", "libtiff-dev", "libwebp-dev")
+  )
+
+})
+
 test_that("version constraints are respected", {
 
   skip_on_cran()


### PR DESCRIPTION
Addresses part of #2352.

`renv_sysreqs_match()` returned as soon as any rule in the system requirements database matched, so a `SystemRequirements` field declaring multiple system libraries only ever produced a single system package. For example, `ragg` declares:

```
SystemRequirements: freetype2, libpng, libtiff, libjpeg, libwebp, libwebpmux
```

but `renv::sysreqs(packages = "ragg", distro = "ubuntu:24.04", report = TRUE, collapse = TRUE)` reported only:

```
sudo apt install -y libfreetype6-dev
```

With this change, all matching rules are collected and their fields (`packages`, `pre_install`, `post_install`) are merged per package, so the same call now reports:

```
sudo apt install -y libfreetype6-dev libjpeg-dev libpng-dev libtiff-dev libwebp-dev
```

This also strengthens the preflight system requirement checks performed during `install()`, `restore()`, and `diagnostics()`, which go through the same matcher.

Notes:

- `renv_sysreqs_resolve()` still returns `NULL` when nothing matches, so downstream consumers see the same shape as before; the `constraints` field is no longer included in the result, as it is matcher-internal and nothing consumed it.
- The remaining delta vs. `pak::pkg_sysreqs()` in #2352 is transitive R package dependency expansion, which is not addressed here.
