### PR TITLE
map centos stream and el 10 to the right ppm platform

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # renv (development version)
 
+* Fixed an issue where renv computed the wrong Posit Package Manager binary
+  URL on some Enterprise Linux distributions. CentOS Stream 9 and 10 were
+  mapped to the non-existent `centos9` and `centos1` platforms rather than
+  `rhel9` and `rhel10`, and Rocky Linux 10 and AlmaLinux 10 were mapped to
+  `rhel1` rather than `rhel10`, causing package downloads to fail with 404
+  errors. (#2354)
+
 * Fixed an issue where, if one or more repositories could not be queried for
   available packages, the partial result would be cached and served for up to
   an hour -- renv would behave as though the failed repositories held no

--- a/R/ppm.R
+++ b/R/ppm.R
@@ -184,6 +184,8 @@ renv_ppm_platform <- function(file = "/etc/os-release") {
     return("macos")
 
   platform <- renv_ppm_platform_impl(file)
+  if (is.null(platform))
+    return(NULL)
 
   # https://github.com/rstudio/renv/issues/2227
   if (startsWith(platform, "opensuse15"))
@@ -213,10 +215,10 @@ renv_ppm_platform_impl <- function(file = "/etc/os-release") {
 
     case(
       identical(id, "ubuntu")    ~ renv_ppm_platform_ubuntu(properties),
-      identical(id, "centos")    ~ renv_ppm_platform_centos(properties),
-      identical(id, "rhel")      ~ renv_ppm_platform_rhel(properties),
-      identical(id, "rocky")     ~ renv_ppm_platform_rocky(properties),
-      identical(id, "almalinux") ~ renv_ppm_platform_alma(properties),
+      identical(id, "centos")    ~ renv_ppm_platform_el(properties),
+      identical(id, "rhel")      ~ renv_ppm_platform_el(properties),
+      identical(id, "rocky")     ~ renv_ppm_platform_el(properties),
+      identical(id, "almalinux") ~ renv_ppm_platform_el(properties),
       grepl("suse\\b", id)       ~ renv_ppm_platform_suse(properties),
       identical(id, "sles")      ~ renv_ppm_platform_sles(properties),
       identical(id, "debian")    ~ renv_ppm_platform_debian(properties),
@@ -237,47 +239,23 @@ renv_ppm_platform_ubuntu <- function(properties) {
 
 }
 
-renv_ppm_platform_centos <- function(properties) {
+# Enterprise Linux distributions all share the same PPM binaries, published
+# under a 'centos' prefix for releases before 9 and 'rhel' from 9 onwards.
+renv_ppm_platform_el <- function(properties) {
 
   id <- properties$VERSION_ID
   if (is.null(id))
     return(NULL)
 
-  paste0("centos", substring(id, 1L, 1L))
-
-}
-
-renv_ppm_platform_rhel <- function(properties) {
-
-  id <- properties$VERSION_ID
-  if (is.null(id))
-    return(NULL)
-
-  name <- ifelse(numeric_version(id) < "9", "centos", "rhel")
+  # take just the major version; VERSION_ID may include a minor part (e.g. 9.2)
   version <- strsplit(id, ".", fixed = TRUE)[[1L]][[1L]]
+
+  major <- suppressWarnings(as.integer(version))
+  if (is.na(major))
+    return(NULL)
+
+  name <- if (major < 9L) "centos" else "rhel"
   paste0(name, version)
-
-}
-
-renv_ppm_platform_rocky <- function(properties) {
-
-  id <- properties$VERSION_ID
-  if (is.null(id))
-    return(NULL)
-
-  version <- ifelse(numeric_version(id) < "9", "centos", "rhel")
-  paste0(version, substring(id, 1L, 1L))
-
-}
-
-renv_ppm_platform_alma <- function(properties) {
-
-  id <- properties$VERSION_ID
-  if (is.null(id))
-    return(NULL)
-
-  version <- ifelse(numeric_version(id) < "9", "centos", "rhel")
-  paste0(version, substring(id, 1L, 1L))
 
 }
 

--- a/tests/testthat/test-ppm.R
+++ b/tests/testthat/test-ppm.R
@@ -112,6 +112,88 @@ test_that("renv correctly detects RHEL9 for PPM", {
 
 })
 
+test_that("renv correctly detects CentOS Linux 7 for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    NAME="CentOS Linux"
+    VERSION="7 (Core)"
+    ID="centos"
+    ID_LIKE="rhel fedora"
+    VERSION_ID="7"
+    PRETTY_NAME="CentOS Linux 7 (Core)"
+    ANSI_COLOR="0;31"
+    CPE_NAME="cpe:/o:centos:centos:7"
+    HOME_URL="https://www.centos.org/"
+    BUG_REPORT_URL="https://bugs.centos.org/"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "centos7")
+
+})
+
+test_that("renv correctly detects CentOS Stream 9 as rhel9 for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  # https://github.com/rstudio/renv/issues/2354
+  release <- heredoc('
+    NAME="CentOS Stream"
+    VERSION="9"
+    ID="centos"
+    ID_LIKE="rhel fedora"
+    VERSION_ID="9"
+    PLATFORM_ID="platform:el9"
+    PRETTY_NAME="CentOS Stream 9"
+    ANSI_COLOR="0;31"
+    LOGO="fedora-logo-icon"
+    CPE_NAME="cpe:/o:centos:centos:9"
+    HOME_URL="https://centos.org/"
+    BUG_REPORT_URL="https://issues.redhat.com/"
+    REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 9"
+    REDHAT_SUPPORT_PRODUCT_VERSION="CentOS Stream"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "rhel9")
+
+})
+
+test_that("renv correctly detects CentOS Stream 10 as rhel10 for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    NAME="CentOS Stream"
+    VERSION="10 (Coughlan)"
+    ID="centos"
+    ID_LIKE="rhel fedora"
+    VERSION_ID="10"
+    PLATFORM_ID="platform:el10"
+    PRETTY_NAME="CentOS Stream 10 (Coughlan)"
+    ANSI_COLOR="0;31"
+    LOGO="fedora-logo-icon"
+    CPE_NAME="cpe:/o:centos:centos:10"
+    HOME_URL="https://centos.org/"
+    BUG_REPORT_URL="https://issues.redhat.com/"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "rhel10")
+
+})
+
 test_that("renv correctly detects Rocky Linux 8 as centos8 for PPM", {
   skip_on_cran()
   skip_on_os("windows")
@@ -173,6 +255,39 @@ test_that("renv correctly detects Rocky Linux 9 as rhel9 for PPM", {
 
   platform <- renv_ppm_platform_impl(file = file)
   expect_equal(platform, "rhel9")
+
+})
+
+test_that("renv correctly detects Rocky Linux 10 as rhel10 for PPM", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  release <- heredoc('
+    NAME="Rocky Linux"
+    VERSION="10.0 (Red Quartz)"
+    ID="rocky"
+    ID_LIKE="rhel centos fedora"
+    VERSION_ID="10.0"
+    PLATFORM_ID="platform:el10"
+    PRETTY_NAME="Rocky Linux 10.0 (Red Quartz)"
+    ANSI_COLOR="0;32"
+    LOGO="fedora-logo-icon"
+    CPE_NAME="cpe:/o:rocky:rocky:10::baseos"
+    HOME_URL="https://rockylinux.org/"
+    VENDOR_NAME="Rocky Linux"
+    BUG_REPORT_URL="https://bugs.rockylinux.org/"
+    SUPPORT_END="2035-05-31"
+    ROCKY_SUPPORT_PRODUCT="Rocky-Linux-10"
+    ROCKY_SUPPORT_PRODUCT_VERSION="10.0"
+    REDHAT_SUPPORT_PRODUCT="Rocky Linux"
+    REDHAT_SUPPORT_PRODUCT_VERSION="10.0"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  platform <- renv_ppm_platform_impl(file = file)
+  expect_equal(platform, "rhel10")
 
 })
 
@@ -361,6 +476,28 @@ test_that("renv detects no supported PPM platform for Amazon Linux 2023", {
 
   platform <- renv_ppm_platform_impl(file = file)
   expect_null(platform)
+
+})
+
+test_that("renv_ppm_platform() returns NULL for unrecognized distributions", {
+  skip_on_cran()
+  skip_on_os(c("windows", "mac"))
+
+  renv_scope_envvars(RENV_PPM_PLATFORM = NULL, RENV_RSPM_PLATFORM = NULL)
+
+  release <- heredoc('
+    NAME="Alpine Linux"
+    ID=alpine
+    VERSION_ID=3.20.0
+    PRETTY_NAME="Alpine Linux v3.20"
+    HOME_URL="https://alpinelinux.org/"
+    BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
+  ')
+
+  file <- renv_scope_tempfile()
+  writeLines(release, con = file)
+
+  expect_null(renv_ppm_platform(file = file))
 
 })
 


### PR DESCRIPTION
Fixes #2354.

renv builds PPM binary URLs from `/etc/os-release`. On CentOS Stream 9 it produced `.../cran/__linux__/centos9/<snapshot>`, which 404s -- PPM publishes that platform as `rhel9`.

The `centos` handler always used a `centos` prefix and only kept the first character of `VERSION_ID`, so it was wrong twice over: CentOS Stream 9 became `centos9`, and CentOS Stream 10 became `centos1`. The `rocky` and `almalinux` handlers shared the truncation bug, mapping their 10.x releases to `rhel1`. Only the `rhel` handler was correct.

Verified against PPM:

| platform | HTTP |
| --- | --- |
| `centos9` | 404 |
| `centos1` | 404 |
| `rhel9` | 200 |
| `rhel10` | 200 |

All four Enterprise Linux handlers implemented the same rule -- a `centos` prefix before release 9, `rhel` from 9 onwards -- so this folds them into a single `renv_ppm_platform_el()` that takes the full major version rather than the first character.

Also guards `renv_ppm_platform()` against a `NULL` platform: `startsWith(NULL, ...)` errors rather than short-circuiting, so an unrecognized distro (Alpine, Fedora, Amazon Linux 2023) threw out of `renv_ppm_platform()`. `renv_ppm_transform()` catches it and returns the URL unchanged, so the outcome matched the intended `is.null(platform)` early return -- but only by accident.

Tests cover CentOS Linux 7, CentOS Stream 9 and 10, Rocky Linux 10, and the `NULL` platform guard.