### PR TITLE
Fix available package fallback ordering

### DIFF
--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -422,28 +422,18 @@ renv_available_packages_latest <- function(package,
 
   })
 
-  # if both entries are null, error
-  if (all(map_lgl(entries, is.null))) {
-    map(errors$data(), warning)
-    entry <- the$rejected_packages[[package]]
-    if (!is.null(entry))
-      stopf("package '%s' is not available\n- %s", package, entry$reason)
-    stopf("package '%s' is not available", package)
-  }
+  # prefer configured repositories, using crandb, archives, and P3M as
+  # fallbacks when earlier methods have no candidate.
+  idx <- which(!map_lgl(entries, is.null))
+  if (length(idx))
+    return(entries[[idx[[1L]]]])
 
-  # prefer the record from the configured repositories, consulting crandb only
-  # when they have no candidate.
-  #
-  # the configured repositories determine what can actually be installed, and
-  # available_packages() already drops versions whose R requirement the current
-  # session can't satisfy -- so crandb's role is to name a compatible version
-  # when the repositories have none. crandb is not restricted to the configured
-  # repositories, so when it names a newer version than they carry, that
-  # version generally isn't installable from them: acting on it yields a failed
-  # download, an archive fallback that fails for packages still live on CRAN
-  # (#1735), or a source build where the repositories had a binary all along
-  # (#2345)
-  entries[[1L]] %||% entries[[2L]]
+  # if all entries are null, error
+  map(errors$data(), warning)
+  entry <- the$rejected_packages[[package]]
+  if (!is.null(entry))
+    stopf("package '%s' is not available\n- %s", package, entry$reason)
+  stopf("package '%s' is not available", package)
 
 }
 

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -411,6 +411,74 @@ test_that("crandb is still used when the repositories have no candidate", {
 
 })
 
+test_that("P3M remains a fallback when repositories have no candidate", {
+
+  renv_tests_scope()
+  renv_scope_options(
+    pkgType = "binary",
+    renv.config.ppm.enabled = TRUE,
+    renv.config.crandb.enabled = FALSE,
+    renv.install.allowArchivedPackages = FALSE
+  )
+
+  # P3M is a fallback for packages unavailable from the configured
+  # repositories. This path regressed when crandb was inserted ahead of P3M
+  # in the candidate list (#2348).
+  local_mocked_bindings(
+    renv_available_packages_latest_repos = function(...) NULL,
+    renv_available_packages_latest_p3m = function(package, ...) {
+      list(
+        Package    = package,
+        Version    = "9.9.9",
+        Source     = "Repository",
+        Repository = "P3M"
+      )
+    }
+  )
+
+  record <- renv_available_packages_latest("nonexistent.package")
+
+  expect_equal(record$Version, "9.9.9")
+  expect_equal(record$Repository, "P3M")
+
+})
+
+test_that("configured repositories are preferred over P3M fallback", {
+
+  renv_tests_scope()
+  renv_scope_options(
+    pkgType = "binary",
+    renv.config.ppm.enabled = TRUE,
+    renv.config.crandb.enabled = FALSE,
+    renv.install.allowArchivedPackages = FALSE
+  )
+
+  local_mocked_bindings(
+    renv_available_packages_latest_repos = function(package, ...) {
+      list(
+        Package    = package,
+        Version    = "1.0.0",
+        Source     = "Repository",
+        Repository = "CRAN"
+      )
+    },
+    renv_available_packages_latest_p3m = function(package, ...) {
+      list(
+        Package    = package,
+        Version    = "9.9.9",
+        Source     = "Repository",
+        Repository = "P3M"
+      )
+    }
+  )
+
+  record <- renv_available_packages_latest("breakfast")
+
+  expect_equal(record$Version, "1.0.0")
+  expect_equal(record$Repository, "CRAN")
+
+})
+
 test_that("version requirement parsing works correctly", {
 
   # Test various requirement formats


### PR DESCRIPTION
## Summary

Restore P3M as a fallback when configured repositories have no candidate, while keeping configured repository records preferred.

## Thanks to maintainers

Thanks for the recent available-package resolver work in #2348 and for the diagnosis documented in #1901.

## Issue or motivation

When a package is unavailable from the configured repositories, the available-package lookup should continue to later fallback sources. This is relevant to the repository/snapshot behavior described in #1901.

## Root cause

The resolver builds an ordered list of repository, crandb, archive, and P3M candidates, but the final return expression only considered the first two entries after crandb was added in #2348. A P3M candidate could therefore be found and then discarded.

## Change

Return the first non-null candidate in the existing method order and add regression tests for both P3M fallback and configured-repository precedence.

## Tests

- Focused mocked regression tests: 2 tests, 2 successes
- `R CMD build .`: passed
- `R CMD check --as-cran renv_1.2.4.9000.tar.gz`: passed with 3 existing NOTES (development version, groundhogr.com HTTP 406, and local HTML Tidy version)

## Scope

This changes candidate selection only. It does not change repository querying, P3M database contents, version compatibility rules, or package installation behavior.