### PR TITLE
use archived packages when repositories and crandb have none

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,9 @@
   package. Records resolved this way also carry the URL of the repository's
   archive, so they can be downloaded in the same parallel batch as everything
   else, and they retain their repository even when `getOption("repos")` is
-  unnamed. (#2356)
+  unnamed. Their archived `DESCRIPTION` is read before dependency resolution,
+  so strong dependencies are not omitted, and binary-only requests continue
+  to reject these source-only candidates. (#2356)
 
 * The available-package lookup now stops at the first source that can supply
   the package, rather than querying every source and discarding the extra
@@ -2640,4 +2642,3 @@
 # renv 0.8.0
 
 * Initial CRAN release.
-

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # renv (development version)
 
+* Fixed an issue where, with the `renv.install.allowArchivedPackages` option
+  enabled, a package available only from a repository's archive would resolve
+  to nothing at all. The archive was queried, but the result was then
+  discarded: the lookup only ever returned the repository or crandb candidate.
+  Archived candidates are now used when neither of those can supply the
+  package. Records resolved this way also carry the URL of the repository's
+  archive, so they can be downloaded in the same parallel batch as everything
+  else, and they retain their repository even when `getOption("repos")` is
+  unnamed. (#2356)
+
+* The available-package lookup now stops at the first source that can supply
+  the package, rather than querying every source and discarding the extra
+  answers. Repositories still take precedence over crandb and the archive, so
+  which record is chosen is unchanged; renv simply no longer makes crandb and
+  P3M requests whose results it cannot use.
+
 * Fixed an issue where `renv::sysreqs()` (and the system requirement checks
   performed during install and restore) would only report the first system
   package required by an R package. When a package's `SystemRequirements`

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -396,57 +396,67 @@ renv_available_packages_latest <- function(package,
                                            type = NULL,
                                            repos = NULL)
 {
+  # the sources consulted for this lookup, in strict precedence order: the
+  # first one to name a version wins, and the configured repositories always
+  # get the first word.
+  #
+  # the repositories determine what can actually be installed, and
+  # available_packages() already drops versions whose R requirement the current
+  # session can't satisfy -- so the later sources exist to name a compatible
+  # version when the repositories have none. those sources are not restricted
+  # to the configured repositories, so when one names a newer version than the
+  # repositories carry, that version generally isn't installable from them:
+  # acting on it yields a failed download, an archive fallback that fails for
+  # packages still live on CRAN (#1735), or a source build where the
+  # repositories had a binary all along (#2345)
+  #
+  # P3M is deliberately not in this list. it stopped being consulted here in
+  # #1771, when the archive method was inserted ahead of it -- but that is also
+  # what stopped renv preferring a newer P3M binary over the pinned repository
+  # snapshot a user actually configured (#1901), and
+  # renv_available_packages_latest_p3m() still ignores `repos` entirely.
+  # bringing it back is a separate decision, not a side effect of repairing
+  # this ordering
   methods <- list(
     renv_available_packages_latest_repos,
     renv_available_packages_latest_crandb,
     if (getOption("renv.install.allowArchivedPackages", default = FALSE))
-      renv_available_packages_latest_archive,
-    if (renv_p3m_enabled())
-      renv_available_packages_latest_p3m
+      renv_available_packages_latest_archive
   )
 
   errors <- stack()
 
-  entries <- lapply(methods, function(method) {
+  for (method in methods) {
 
     if (is.null(method))
-      return(NULL)
+      next
 
     entry <- catch(method(package, type, repos))
     if (inherits(entry, "error")) {
       errors$push(entry)
-      return(NULL)
+      next
     }
 
-    entry
-
-  })
-
-  # if both entries are null, error
-  if (all(map_lgl(entries, is.null))) {
-    map(errors$data(), warning)
-    entry <- the$rejected_packages[[package]]
     if (!is.null(entry))
-      stopf("package '%s' is not available\n- %s", package, entry$reason)
-    stopf("package '%s' is not available", package)
+      return(entry)
+
   }
 
-  # prefer the record from the configured repositories, consulting crandb only
-  # when they have no candidate.
-  #
-  # the configured repositories determine what can actually be installed, and
-  # available_packages() already drops versions whose R requirement the current
-  # session can't satisfy -- so crandb's role is to name a compatible version
-  # when the repositories have none. crandb is not restricted to the configured
-  # repositories, so when it names a newer version than they carry, that
-  # version generally isn't installable from them: acting on it yields a failed
-  # download, an archive fallback that fails for packages still live on CRAN
-  # (#1735), or a source build where the repositories had a binary all along
-  # (#2345)
-  entries[[1L]] %||% entries[[2L]]
+  # nothing named a version; report whatever went wrong along the way
+  map(errors$data(), warning)
+
+  entry <- the$rejected_packages[[package]]
+  if (!is.null(entry))
+    stopf("package '%s' is not available\n- %s", package, entry$reason)
+
+  stopf("package '%s' is not available", package)
 
 }
 
+# NOTE: currently unreferenced -- see renv_available_packages_latest() for why
+# P3M is not consulted when picking a latest version. kept here because reviving
+# it is a live option, but it would need to honor `repos` and a database that
+# covers current R releases first
 renv_available_packages_latest_p3m <- function(package,
                                                type = NULL,
                                                repos = NULL)
@@ -549,14 +559,22 @@ renv_available_packages_latest_archive <- function(package,
                                                    type = NULL,
                                                    repos = NULL)
 {
-  type <- type %||% getOption("pkgType")
+  # note that `type` is ignored: a CRAN-style archive only ever holds source
+  # tarballs. the record is tagged "source" below so consumers build it as one;
+  # refusing a binary request outright would just turn the last remaining
+  # candidate into no candidate at all
   repos <- repos %||% getOption("repos")
 
   for (i in seq_along(repos)) {
 
-    # extract pieces of interest
-    name <- names(repos)[[i]]
+    # extract pieces of interest. repositories may be unnamed or only partly
+    # named, in which case the URL doubles as the name -- assigning NULL would
+    # instead delete the Repository field that renv_retrieve_repos_archive()
+    # uses to find this package again
     repo <- repos[[i]]
+    name <- names(repos)[[i]] %||% ""
+    if (!nzchar(name))
+      name <- repo
 
     # check for potential packages in archive
     archive <- renv_available_packages_latest_archive_query(repo)
@@ -570,12 +588,12 @@ renv_available_packages_latest_archive <- function(package,
     # grab files that look like packages
     extpat <- "(?:\\.tar\\.gz|\\.tgz|\\.zip)$"
     parts <- strsplit(rns, "_", fixed = TRUE)
-    package <- map_chr(parts, `[[`, 1L)
+    packages <- map_chr(parts, `[[`, 1L)
     rest <- map_chr(parts, `[[`, 2L)
     version <- sub(extpat, "", rest)
 
     # put it into a data.frame
-    data <- data.frame(Package = package, Version = version)
+    data <- data.frame(Package = packages, Version = version)
 
     # take the newest version
     ord <- order(numeric_version(version), decreasing = TRUE)
@@ -583,7 +601,14 @@ renv_available_packages_latest_archive <- function(package,
     entry$Source <- "Repository"
     entry$Repository <- name
 
-    return(entry)
+    # resolve where this repository keeps its archived tarballs, so the record
+    # carries a URL the download machinery can actually use. a repository whose
+    # archive layout we can't determine is no use to us, so move on
+    root <- catch(renv_retrieve_repos_archive_root(repo, entry))
+    if (inherits(root, "error") || is.null(root))
+      next
+
+    return(renv_record_tag(entry, type = "source", url = root, name = name))
 
   }
 

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -461,7 +461,7 @@ renv_available_packages_latest_p3m <- function(package,
                                                type = NULL,
                                                repos = NULL)
 {
-  type <- type %||% getOption("pkgType")
+  type <- type %||% getOption("pkgType", default = "source")
   if (identical(type, "source"))
     stop("binary packages are not available")
 
@@ -559,10 +559,13 @@ renv_available_packages_latest_archive <- function(package,
                                                    type = NULL,
                                                    repos = NULL)
 {
-  # note that `type` is ignored: a CRAN-style archive only ever holds source
-  # tarballs. the record is tagged "source" below so consumers build it as one;
-  # refusing a binary request outright would just turn the last remaining
-  # candidate into no candidate at all
+  # a CRAN-style archive only ever holds source tarballs. honor binary-only
+  # requests rather than silently building from source; "both" still permits
+  # this source fallback
+  type <- type %||% getOption("pkgType", default = "source")
+  if (grepl("\\bbinary\\b", type))
+    return(NULL)
+
   repos <- repos %||% getOption("repos")
 
   for (i in seq_along(repos)) {
@@ -608,7 +611,7 @@ renv_available_packages_latest_archive <- function(package,
     if (inherits(root, "error") || is.null(root))
       next
 
-    return(renv_record_tag(entry, type = "source", url = root, name = name))
+    return(renv_record_tag_archive(entry, type = "source", url = root, name = name))
 
   }
 

--- a/R/graph.R
+++ b/R/graph.R
@@ -253,16 +253,18 @@ renv_graph_description_repository <- function(record) {
   if (!inherits(entry, "error"))
     return(as.list(entry))
 
-  # try cellar via renv_available_packages_latest (includes cellar = TRUE);
-  # cellar packages won't be found by renv_available_packages_entry.
+  # try cellar and archive fallback via renv_available_packages_latest;
+  # neither is found by renv_available_packages_entry.
   # NOTE: renv_available_packages_latest only returns limited fields
-  # (Package, Version, etc.) -- no Depends/Imports/LinkingTo, so cellar
-  # records are supplemented from the archive DESCRIPTION below (#2313)
+  # (Package, Version, etc.) -- no Depends/Imports/LinkingTo, so these
+  # records are supplemented from their package DESCRIPTION below
   latest <- catch(renv_available_packages_latest(package, type = type))
   if (!inherits(latest, "error")) {
     if (is.null(version) || identical(latest$Version, version)) {
       if (identical(renv_record_source(latest, normalize = TRUE), "cellar"))
         latest <- renv_graph_description_cellar(latest)
+      else if (renv_record_archived(latest))
+        latest <- renv_graph_description_archive_enrich(latest)
       return(as.list(latest))
     }
   }
@@ -343,6 +345,26 @@ renv_graph_description_cellar <- function(record) {
   for (field in names(desc))
     if (is.null(record[[field]]))
       record[[field]] <- desc[[field]]
+
+  record
+
+}
+
+renv_graph_description_archive_enrich <- function(record) {
+
+  # archive indexes only name package versions; read the package DESCRIPTION
+  # before graph traversal so strong dependencies are not silently omitted.
+  # Keep the resolved record's repository fields and archive tag so download
+  # and provenance handling continue to use the archive path.
+  # Deliberately let retrieval / DESCRIPTION errors propagate. Returning the
+  # minimal archive-index record would allow installation to continue without
+  # the package's strong dependencies, which is the bug this enrichment fixes.
+  desc <- renv_graph_description_archive(record)
+  for (field in names(desc))
+    if (is.null(record[[field]]))
+      record[[field]] <- desc[[field]]
+
+  attr(record, "archive.downloaded") <- TRUE
 
   record
 
@@ -1016,10 +1038,17 @@ renv_graph_url_repository_record <- function(desc, record) {
   if (is.null(repo))
     return(NULL)
 
-  name <- renv_retrieve_repos_archive_name(record, type)
-
-  url <- file.path(repo, name)
   destfile <- renv_retrieve_path(as.list(desc), type = type)
+
+  # archive enrichment already downloaded and validated this tarball while
+  # reading its DESCRIPTION. route it through sequential retrieval, whose
+  # normal existing-file check reuses it, instead of downloading it again in
+  # the parallel batch
+  if (renv_record_archive_downloaded(desc) && file.exists(destfile))
+    return(NULL)
+
+  name <- renv_retrieve_repos_archive_name(record, type)
+  url <- file.path(repo, name)
 
   # carry repository metadata so install can tag the record
   # for renv_package_augment (RemoteRepos, RemoteReposName)

--- a/R/graph.R
+++ b/R/graph.R
@@ -364,8 +364,6 @@ renv_graph_description_archive_enrich <- function(record) {
     if (is.null(record[[field]]))
       record[[field]] <- desc[[field]]
 
-  attr(record, "archive.downloaded") <- TRUE
-
   record
 
 }
@@ -1044,7 +1042,7 @@ renv_graph_url_repository_record <- function(desc, record) {
   # reading its DESCRIPTION. route it through sequential retrieval, whose
   # normal existing-file check reuses it, instead of downloading it again in
   # the parallel batch
-  if (renv_record_archive_downloaded(desc) && file.exists(destfile))
+  if (renv_record_archived(desc) && file.exists(destfile))
     return(NULL)
 
   name <- renv_retrieve_repos_archive_name(record, type)

--- a/R/graph.R
+++ b/R/graph.R
@@ -1008,6 +1008,14 @@ renv_graph_url_repository_record <- function(desc, record) {
   type <- attr(record, "type", exact = TRUE) %||% "source"
   repo <- attr(record, "url", exact = TRUE)
   reponame <- attr(record, "name", exact = TRUE)
+
+  # an untagged record carries no repository URL. file.path(NULL, name) would
+  # quietly yield character(0), and a zero-length url aborts the whole parallel
+  # download batch when it's unpacked with vapply(). returning NULL instead
+  # routes just this package to the sequential retrieve path
+  if (is.null(repo))
+    return(NULL)
+
   name <- renv_retrieve_repos_archive_name(record, type)
 
   url <- file.path(repo, name)

--- a/R/record.R
+++ b/R/record.R
@@ -142,9 +142,23 @@ renv_record_tag <- function(record, type, url, name) {
 
 }
 
+renv_record_tag_archive <- function(record, type, url, name) {
+  record <- renv_record_tag(record, type, url, name)
+  attr(record, "archive") <- TRUE
+  record
+}
+
 renv_record_tagged <- function(record) {
   attrs <- attributes(record)
   all(c("url", "type") %in% names(attrs))
+}
+
+renv_record_archived <- function(record) {
+  identical(attr(record, "archive", exact = TRUE), TRUE)
+}
+
+renv_record_archive_downloaded <- function(record) {
+  identical(attr(record, "archive.downloaded", exact = TRUE), TRUE)
 }
 
 # abstracted out in case we want to use a different sigil in the future,

--- a/R/record.R
+++ b/R/record.R
@@ -157,10 +157,6 @@ renv_record_archived <- function(record) {
   identical(attr(record, "archive", exact = TRUE), TRUE)
 }
 
-renv_record_archive_downloaded <- function(record) {
-  identical(attr(record, "archive.downloaded", exact = TRUE), TRUE)
-}
-
 # abstracted out in case we want to use a different sigil in the future,
 # like `_`, `<NA>`, or something else
 renv_record_placeholder <- function() {

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -663,9 +663,13 @@ renv_retrieve_explicit <- function(record) {
 
 renv_retrieve_repos <- function(record) {
 
-  # if this record is tagged with a type + url, we can
-  # use that directly for retrieval
-  if (renv_record_tagged(record))
+  tagged <- renv_record_tagged(record)
+  archived <- renv_record_archived(record)
+
+  # non-archive records can use their resolved URL directly. archive records
+  # also try that URL first below, but retain the remaining retrieval methods
+  # for repository failover
+  if (tagged && !archived)
     return(renv_retrieve_repos_impl(record))
 
   # figure out what package sources are okay to use here
@@ -681,6 +685,12 @@ renv_retrieve_repos <- function(record) {
 
   # collect list of 'methods' for retrieval
   methods <- stack(mode = "list")
+
+  # preserve an explicitly-resolved archive URL even when it did not come from
+  # the current repos option. source policy still applies, and a failed direct
+  # attempt falls through to the other repositories below
+  if (archived && srcok)
+    methods$push(renv_retrieve_repos_impl)
 
   # add binary package methods
   if (binok) {

--- a/tests/testthat/helper-setup.R
+++ b/tests/testthat/helper-setup.R
@@ -312,3 +312,35 @@ renv_tests_setup_repos <- function(scope = parent.frame()) {
 
 }
 
+renv_tests_archive_repo <- function(package = "gravy",
+                                    version = "0.5.0",
+                                    tarball = NULL,
+                                    scope = parent.frame())
+{
+  repopath <- renv_scope_tempfile("renv-repos-", scope = scope)
+  meta <- file.path(repopath, "src/contrib/Meta")
+  root <- file.path(repopath, "src/contrib/Archive", package)
+  ensure_directory(meta)
+  ensure_directory(root)
+
+  filename <- sprintf("%s_%s.tar.gz", package, version)
+  relpath <- file.path(package, filename)
+  size <- 1024L
+  if (!is.null(tarball)) {
+    target <- file.path(root, filename)
+    if (!file.copy(tarball, target))
+      stopf("failed to copy test archive '%s'", tarball)
+    size <- file.info(target)$size
+  }
+
+  entries <- data.frame(size = size, row.names = relpath)
+  database <- named(list(entries), package)
+  saveRDS(database, file = file.path(meta, "archive.rds"))
+
+  fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
+  list(
+    path = repopath,
+    root = root,
+    url = sprintf(fmt, repopath)
+  )
+}

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -420,14 +420,8 @@ test_that("the archive is consulted when the repositories have no candidate", {
   )
 
   # a repository which serves nothing from PACKAGES, but does archive 'gravy'
-  repopath <- renv_scope_tempfile("renv-repos-")
-  meta <- file.path(repopath, "src/contrib/Meta")
-  ensure_directory(meta)
-  database <- list(gravy = data.frame(size = 1024L, row.names = "gravy/gravy_0.5.0.tar.gz"))
-  saveRDS(database, file = file.path(meta, "archive.rds"))
-
-  fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
-  renv_scope_options(repos = c(ARCHIVED = sprintf(fmt, repopath)))
+  archive <- renv_tests_archive_repo()
+  renv_scope_options(repos = c(ARCHIVED = archive$url))
 
   # the archive method was added in #1771 and lost its slot in #2215, when
   # crandb was inserted ahead of it and the picker kept reading only the first
@@ -447,14 +441,8 @@ test_that("an archived record carries a usable download URL", {
     renv.install.allowArchivedPackages = TRUE
   )
 
-  repopath <- renv_scope_tempfile("renv-repos-")
-  meta <- file.path(repopath, "src/contrib/Meta")
-  ensure_directory(meta)
-  database <- list(gravy = data.frame(size = 1024L, row.names = "gravy/gravy_0.5.0.tar.gz"))
-  saveRDS(database, file = file.path(meta, "archive.rds"))
-
-  fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
-  renv_scope_options(repos = c(ARCHIVED = sprintf(fmt, repopath)))
+  archive <- renv_tests_archive_repo()
+  renv_scope_options(repos = c(ARCHIVED = archive$url))
 
   record <- renv_available_packages_latest("gravy")
 
@@ -475,20 +463,49 @@ test_that("an archived record keeps its Repository with unnamed repositories", {
 
   renv_tests_scope()
 
-  repopath <- renv_scope_tempfile("renv-repos-")
-  meta <- file.path(repopath, "src/contrib/Meta")
-  ensure_directory(meta)
-  database <- list(gravy = data.frame(size = 1024L, row.names = "gravy/gravy_0.5.0.tar.gz"))
-  saveRDS(database, file = file.path(meta, "archive.rds"))
-
-  fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
-  repo <- sprintf(fmt, repopath)
+  archive <- renv_tests_archive_repo()
+  repo <- archive$url
 
   # renv supports unnamed repositories; names(repos)[[i]] is NULL for these,
   # and assigning that to entry$Repository used to delete the field outright
   entry <- renv_available_packages_latest_archive("gravy", repos = repo)
 
   expect_equal(entry$Repository, repo)
+
+})
+
+test_that("an archive does not satisfy a binary-only request", {
+
+  renv_tests_scope()
+  archive <- renv_tests_archive_repo()
+  renv_scope_options(
+    repos = c(ARCHIVED = archive$url),
+    renv.config.crandb.enabled = FALSE,
+    renv.install.allowArchivedPackages = TRUE
+  )
+
+  entry <- renv_available_packages_latest_archive(
+    package = "gravy",
+    type = "binary"
+  )
+
+  expect_null(entry)
+  expect_equal(
+    renv_available_packages_latest_archive("gravy", type = "both")$Version,
+    "0.5.0"
+  )
+  expect_null(renv_available_packages_latest_archive("gravy", type = "mac.binary"))
+
+  renv_scope_options(pkgType = NULL)
+  expect_equal(
+    renv_available_packages_latest_archive("gravy")$Version,
+    "0.5.0"
+  )
+
+  expect_error(
+    suppressWarnings(renv_available_packages_latest("gravy", type = "binary")),
+    "package 'gravy' is not available"
+  )
 
 })
 
@@ -525,11 +542,15 @@ test_that("P3M is not consulted when picking a latest version (#1901)", {
   # snapshot the user actually asked for
   # force the conditions under which P3M would be eligible, so this actually
   # asserts something on platforms where the test scope leaves it disabled
-  called <- FALSE
+  enabled_called <- FALSE
+  latest_called <- FALSE
   local_mocked_bindings(
-    renv_p3m_enabled = function() TRUE,
+    renv_p3m_enabled = function() {
+      enabled_called <<- TRUE
+      TRUE
+    },
     renv_available_packages_latest_p3m = function(package, ...) {
-      called <<- TRUE
+      latest_called <<- TRUE
       list(
         Package    = package,
         Version    = "9.9.9",
@@ -541,7 +562,8 @@ test_that("P3M is not consulted when picking a latest version (#1901)", {
 
   record <- renv_available_packages_latest("bread")
 
-  expect_false(called)
+  expect_false(enabled_called)
+  expect_false(latest_called)
   expect_equal(record$Version, "1.0.0")
 
 })

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -411,6 +411,141 @@ test_that("crandb is still used when the repositories have no candidate", {
 
 })
 
+test_that("the archive is consulted when the repositories have no candidate", {
+
+  renv_tests_scope()
+  renv_scope_options(
+    renv.config.crandb.enabled = FALSE,
+    renv.install.allowArchivedPackages = TRUE
+  )
+
+  # a repository which serves nothing from PACKAGES, but does archive 'gravy'
+  repopath <- renv_scope_tempfile("renv-repos-")
+  meta <- file.path(repopath, "src/contrib/Meta")
+  ensure_directory(meta)
+  database <- list(gravy = data.frame(size = 1024L, row.names = "gravy/gravy_0.5.0.tar.gz"))
+  saveRDS(database, file = file.path(meta, "archive.rds"))
+
+  fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
+  renv_scope_options(repos = c(ARCHIVED = sprintf(fmt, repopath)))
+
+  # the archive method was added in #1771 and lost its slot in #2215, when
+  # crandb was inserted ahead of it and the picker kept reading only the first
+  # two entries -- so an archived-only package resolved to nothing at all
+  record <- renv_available_packages_latest("gravy")
+
+  expect_equal(record$Version, "0.5.0")
+  expect_equal(record$Repository, "ARCHIVED")
+
+})
+
+test_that("an archived record carries a usable download URL", {
+
+  renv_tests_scope()
+  renv_scope_options(
+    renv.config.crandb.enabled = FALSE,
+    renv.install.allowArchivedPackages = TRUE
+  )
+
+  repopath <- renv_scope_tempfile("renv-repos-")
+  meta <- file.path(repopath, "src/contrib/Meta")
+  ensure_directory(meta)
+  database <- list(gravy = data.frame(size = 1024L, row.names = "gravy/gravy_0.5.0.tar.gz"))
+  saveRDS(database, file = file.path(meta, "archive.rds"))
+
+  fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
+  renv_scope_options(repos = c(ARCHIVED = sprintf(fmt, repopath)))
+
+  record <- renv_available_packages_latest("gravy")
+
+  # archives only ever hold source tarballs
+  expect_true(renv_record_tagged(record))
+  expect_equal(attr(record, "type", exact = TRUE), "source")
+
+  # the record has to survive URL construction: an untagged record yields a
+  # zero-length url, which aborts the entire parallel download batch rather
+  # than just this package
+  info <- renv_graph_url_repository_record(record, record)
+  expect_equal(basename(info$url), "gravy_0.5.0.tar.gz")
+  expect_equal(basename(dirname(info$url)), "gravy")
+
+})
+
+test_that("an archived record keeps its Repository with unnamed repositories", {
+
+  renv_tests_scope()
+
+  repopath <- renv_scope_tempfile("renv-repos-")
+  meta <- file.path(repopath, "src/contrib/Meta")
+  ensure_directory(meta)
+  database <- list(gravy = data.frame(size = 1024L, row.names = "gravy/gravy_0.5.0.tar.gz"))
+  saveRDS(database, file = file.path(meta, "archive.rds"))
+
+  fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
+  repo <- sprintf(fmt, repopath)
+
+  # renv supports unnamed repositories; names(repos)[[i]] is NULL for these,
+  # and assigning that to entry$Repository used to delete the field outright
+  entry <- renv_available_packages_latest_archive("gravy", repos = repo)
+
+  expect_equal(entry$Repository, repo)
+
+})
+
+test_that("the repositories short-circuit the later lookup methods", {
+
+  renv_tests_scope()
+  renv_scope_options(
+    renv.config.crandb.enabled = FALSE,
+    renv.install.allowArchivedPackages = TRUE
+  )
+
+  # 'bread' is live in the test repository, so nothing after it should be
+  # consulted at all -- these methods reach the network
+  count <- 0L
+  renv_scope_trace(
+    what   = renv:::renv_available_packages_latest_archive,
+    tracer = function() count <<- count + 1L
+  )
+
+  record <- renv_available_packages_latest("bread")
+
+  expect_equal(record$Version, "1.0.0")
+  expect_identical(count, 0L)
+
+})
+
+test_that("P3M is not consulted when picking a latest version (#1901)", {
+
+  renv_tests_scope()
+  renv_scope_options(renv.config.crandb.enabled = FALSE)
+
+  # P3M ignores the configured repositories entirely, so letting it name a
+  # version means renv can prefer a P3M binary over the pinned repository
+  # snapshot the user actually asked for
+  # force the conditions under which P3M would be eligible, so this actually
+  # asserts something on platforms where the test scope leaves it disabled
+  called <- FALSE
+  local_mocked_bindings(
+    renv_p3m_enabled = function() TRUE,
+    renv_available_packages_latest_p3m = function(package, ...) {
+      called <<- TRUE
+      list(
+        Package    = package,
+        Version    = "9.9.9",
+        Source     = "Repository",
+        Repository = "P3M"
+      )
+    }
+  )
+
+  record <- renv_available_packages_latest("bread")
+
+  expect_false(called)
+  expect_equal(record$Version, "1.0.0")
+
+})
+
 test_that("version requirement parsing works correctly", {
 
   # Test various requirement formats

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -302,6 +302,18 @@ test_that("renv_graph_url_repository resolves from test repo", {
 
 })
 
+test_that("renv_graph_url_repository_record rejects an untagged record", {
+
+  record <- list(
+    Package = "bread",
+    Version = "1.0.0",
+    Source = "Repository"
+  )
+
+  expect_null(renv_graph_url_repository_record(record, record))
+
+})
+
 test_that("renv_graph_url_repository prefers a binary for untagged records", {
 
   skip_if(identical(.Platform$pkgType, "source"),
@@ -1235,6 +1247,76 @@ test_that("repository graph reads archived DESCRIPTION when crandb fails", {
 
   expect_equal(desc$Version, "0.1.0")
   expect_equal(desc$Depends, "R (>= 1.0.0)")
+
+})
+
+test_that("repository graph enriches a versionless archive record", {
+
+  renv_tests_scope()
+
+  tarball <- file.path(
+    renv_tests_repopath(),
+    "src/contrib/Archive/today/today_0.1.0.tar.gz"
+  )
+  archive <- renv_tests_archive_repo(
+    package = "today",
+    version = "0.1.0",
+    tarball = tarball
+  )
+
+  renv_scope_options(
+    repos = c(ARCHIVED = archive$url),
+    renv.config.crandb.enabled = FALSE,
+    renv.install.allowArchivedPackages = TRUE
+  )
+
+  latest <- renv_available_packages_latest_archive(
+    package = "today",
+    type = "source",
+    repos = c(ARCHIVED = archive$url)
+  )
+  local_mocked_bindings(
+    renv_available_packages_entry = function(...) {
+      stop("package is not live in the repository")
+    },
+    renv_available_packages_latest = function(...) latest
+  )
+
+  # the repository index contains no live candidate, so the latest-version
+  # lookup supplies the archive record. graph resolution must read the archived
+  # DESCRIPTION before returning it or the package's dependencies disappear.
+  record <- list(Package = "today", Source = "Repository")
+  desc <- renv_graph_description_repository(record)
+
+  expect_equal(desc$Version, "0.1.0")
+  expect_equal(desc$Depends, "R (>= 1.0.0)")
+  expect_true(renv_record_archived(desc))
+
+  # DESCRIPTION enrichment downloaded the tarball already; do not send it
+  # through the parallel downloader a second time
+  expect_null(renv_graph_url_repository_record(desc, latest))
+
+})
+
+test_that("archive enrichment rejects an unreadable DESCRIPTION", {
+
+  renv_tests_scope()
+  archive <- renv_tests_archive_repo(package = "gravy", version = "0.5.0")
+  renv_scope_options(repos = c(ARCHIVED = archive$url))
+
+  record <- renv_available_packages_latest_archive(
+    package = "gravy",
+    type = "source",
+    repos = c(ARCHIVED = archive$url)
+  )
+
+  # Returning this minimal record would silently omit the package's strong
+  # dependencies. Fail during graph construction when the advertised tarball
+  # cannot supply an authoritative DESCRIPTION.
+  expect_error(
+    renv_graph_description_archive_enrich(record),
+    "could not read archived DESCRIPTION"
+  )
 
 })
 

--- a/tests/testthat/test-retrieve.R
+++ b/tests/testthat/test-retrieve.R
@@ -367,6 +367,80 @@ test_that("failed binary downloads are quiet when a source fallback succeeds", {
 
 })
 
+test_that("tagged archive records try their resolved URL first", {
+
+  renv_tests_scope()
+  renv_scope_options(pkgType = "source")
+
+  record <- renv_record_tag_archive(
+    record = list(
+      Package = "bread",
+      Version = "1.0.0",
+      Source = "Repository"
+    ),
+    type = "source",
+    url = "https://example.com/archive/bread",
+    name = "EXPLICIT"
+  )
+
+  called <- FALSE
+  local_mocked_bindings(
+    renv_retrieve_repos_impl = function(record, ...) {
+      called <<- TRUE
+      TRUE
+    }
+  )
+
+  expect_true(renv_retrieve_repos(record))
+  expect_true(called)
+
+})
+
+test_that("tagged archive records fall back to later repositories", {
+
+  renv_tests_scope(isolated = TRUE)
+
+  tarball <- file.path(renv_tests_repopath(), "src/contrib/bread_1.0.0.tar.gz")
+  first <- renv_tests_archive_repo(package = "bread", version = "1.0.0")
+  second <- renv_tests_archive_repo(
+    package = "bread",
+    version = "1.0.0",
+    tarball = tarball
+  )
+
+  repos <- c(FIRST = first$url, SECOND = second$url)
+  renv_scope_options(
+    pkgType = "source",
+    repos = repos,
+    renv.config.crandb.enabled = FALSE,
+    renv.install.allowArchivedPackages = TRUE
+  )
+
+  # the first archive index advertises the package but its tarball is absent;
+  # the tagged URL is useful to the parallel downloader, but sequential
+  # retrieval must still continue to the second repository
+  record <- renv_available_packages_latest_archive(
+    package = "bread",
+    type = "source",
+    repos = repos
+  )
+  expect_equal(record$Repository, "FIRST")
+  expect_true(renv_record_archived(record))
+
+  library <- renv_scope_tempfile("renv-library-")
+  ensure_directory(library)
+  renv_scope_restore(
+    project = getwd(),
+    library = library,
+    records = list(bread = record),
+    packages = "bread",
+    recursive = TRUE
+  )
+
+  expect_true(renv_retrieve_repos(record))
+
+})
+
 test_that("download errors are reported when all retrieval candidates fail", {
 
   skip_on_cran()


### PR DESCRIPTION
## Summary

`renv_available_packages_latest()` assembles an ordered list of candidate
sources, but only ever returned the first two entries. A package available
only from a repository's archive therefore resolved to nothing at all.

This restores the archive as a fallback, fixes the archive record so it is
safe to use now that it can escape the lookup, and leaves P3M out
deliberately.

Alternative to #2356, which repairs the same return expression but also
re-enables P3M.

## History

The attribution matters, because the two dead slots have different causes:

* The archive method was added at slot 2 in #1771 (903418874), where it
  participated in the version comparison. It lost its reachable slot in #2215
  (c6ebc42f8), when crandb was inserted ahead of it and the tail kept reading
  `entries[[1]]` / `entries[[2]]`. This is an unintended regression.
* P3M was pushed from slot 2 to slot 3 by that same #1771 commit, which is
  when it stopped being consulted. Before #1771 the tail was a two-way
  "take the newest" race between the repositories and P3M -- exactly the
  mechanism behind #1901, where a P3M binary of dplyr 1.1.4 won over the
  1.1.0 in a pinned `2023-03-01` snapshot. Its removal was accidental, but
  it is what fixed that class of bug.

Neither slot was lost in #2348, which only rewrote the tail to `%||%`.

## Changes

**Return the first source that can supply the package**, and stop there.
Repositories still take precedence over crandb and the archive, so which
record is chosen for an already-working lookup is unchanged. Short-circuiting
also means renv no longer issues crandb and P3M queries on every lookup whose
results it then discards. Error draining is unaffected: errors were only ever
surfaced when every source came back empty, and in that case every source
still runs.

**Tag the archive record.** `renv_available_packages_latest_archive()`
returned an untagged record. `renv_graph_url_repository_record()` builds its
URL from `attr(record, "url")`, so an untagged record produced
`file.path(NULL, name)` -> `character(0)`, and a zero-length url aborts the
*entire* parallel download batch in
`vapply(downloadable, "[[", character(1L), "url")`. The record now carries the
repository's resolved archive root and `type = "source"`.

**Keep `Repository` for unnamed repositories.** `names(repos)[[i]]` is `NULL`
when `getOption("repos")` is unnamed and `""` when it is partly named;
`entry$Repository <- NULL` *deletes* the field that
`renv_retrieve_repos_archive()` uses to find the package again. The URL now
doubles as the name, matching what `renv_retrieve_repos_archive()` does.

**Guard `renv_graph_url_repository_record()`** against any untagged record, so
it returns `NULL` (routing that one package to sequential retrieval) instead
of `character(0)`. This also covers crandb records, which have the same shape
and hit the same path today.

**Leave P3M out of the candidate list**, for the reasons in the History
section, plus: `renv_available_packages_latest_p3m()` ignores its `repos`
argument entirely, and the bundled database covers only
`/bin/{macosx,macosx/big-sur-arm64,windows}/contrib/{4.1..4.4}` with data
ending 2025-07-31 -- so it cannot answer on R >= 4.5 or on Linux regardless.
Reviving it should be a deliberate change.

## Tests

Five tests, all of which fail against the current implementation (9 failing
assertions) and pass here:

* an archived-only package now resolves
* the resolved record is tagged and survives URL construction
* `Repository` survives an unnamed repository
* the repositories short-circuit the later methods
* P3M is not consulted

`devtools::test()`: 1760 passing, 0 failures. Baseline on `main` is 1749
passing, 0 failures, with the same 7 pre-existing warnings.

## Follow-ups, not addressed here

* `renv_available_packages_latest()` now returns a record or throws; it can no
  longer return `NULL`. That makes the `is.null()` guards at
  `retrieve.R:1458`, `retrieve.R:216` and the "unable to find a compatible
  version" block at `retrieve.R:1461-1475` unreachable. The R-version case
  that block reports is already covered by the `the$rejected_packages` message
  in the lookup itself, so it probably wants deleting -- but that removes
  user-facing text and belongs in its own change.
* `renv_available_packages_latest_p3m()` is now unreferenced. It can be
  removed, or revived properly (honor `repos`, sync the database past R 4.4);
  leaving it as-is is the one thing worth avoiding.
* Archived records carry no `Depends`/`Imports`/`LinkingTo`, so
  `renv_graph_description()`'s no-version path returns a record with no
  dependency fields. Adjacent to #2315 and the work on
  `bugfix/graph-archive-description`.
* `renv::update()` has no `NULL` branch in `renv_update_find_repos_impl()`;
  `empty(latest$Version)` silently absorbed the old `NULL`. Now that the
  archive can answer, an archived version can be proposed as an update.
