### PR TITLE
back off between lock acquisition attempts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # renv (development version)
 
+* Fixed an issue where renv would busy-wait, consuming an entire CPU core,
+  while waiting to acquire a lock. The retry loop's backoff had become
+  unreachable, so renv retried as fast as it could rather than at the intended
+  0.2s interval. In addition, when the lock path was not writable at all (for
+  example, under an OS sandbox denying writes outside the project), the loop
+  had no terminating condition and renv would hang indefinitely -- silently,
+  and uninterruptibly when reached via `renv/activate.R` during startup. renv
+  now backs off between attempts, and reports an error (including the reason
+  reported by the operating system) when the lock path cannot be written.
+  (#2358)
+
 * Fixed an issue where `renv::sysreqs()` (and the system requirement checks
   performed during install and restore) would only report the first system
   package required by an R package. When a package's `SystemRequirements`

--- a/R/lock.R
+++ b/R/lock.R
@@ -21,10 +21,34 @@ renv_lock_acquire <- function(path) {
   renv_scope_options(warn = -1L)
 
   # loop until we acquire the lock
-  repeat tryCatch(
-    renv_lock_acquire_impl(path) && break,
-    error = function(cnd) Sys.sleep(0.2)
-  )
+  #
+  # note that contention is reported by the return value rather than by a
+  # signalled condition, so the retry has to be driven by that return value.
+  # wrapping this in tryCatch() would also swallow the error signalled by
+  # setTimeLimit(), leaving callers with no way to bound the wait.
+  # https://github.com/rstudio/renv/issues/2358
+  failures <- 0L
+  repeat {
+
+    status <- renv_lock_acquire_impl(path)
+    if (status$acquired)
+      break
+
+    # ordinary contention and a lock path we simply cannot write to are
+    # reported identically -- dir.create() just returns FALSE -- but only the
+    # former is worth waiting on. a missing lock after a failed create hints at
+    # the latter, so use it to gate an occasional probe of the parent directory,
+    # which then tells us for certain whether retrying could ever succeed.
+    failures <- if (file.exists(path)) 0L else failures + 1L
+    if (failures >= 3L) {
+      if (!renv_lock_writable(path))
+        renv_lock_acquire_abort(path, status$reason)
+      failures <- 0L
+    }
+
+    Sys.sleep(0.2)
+
+  }
 
   # mark this path as locked by us
   the$lock_registry[[path]] <- 1L
@@ -38,6 +62,36 @@ renv_lock_acquire <- function(path) {
 
 }
 
+# check whether we could create a lock at 'path' at all. used to tell ordinary
+# contention -- someone else holds the lock, so waiting is the right thing --
+# apart from a lock path we have no hope of writing to, where waiting is a hang.
+renv_lock_writable <- function(path) {
+
+  # the probe name is unique to this process, so (unlike the lock itself) a
+  # failure to create it can never be blamed on another process
+  probe <- sprintf("%s.probe-%i", path, Sys.getpid())
+
+  unlink(probe, recursive = TRUE, force = TRUE)
+  created <- dir.create(probe, mode = "0755", showWarnings = FALSE)
+  unlink(probe, recursive = TRUE, force = TRUE)
+
+  created
+
+}
+
+renv_lock_acquire_abort <- function(path, reason) {
+
+  message <- sprintf("renv failed to acquire the lock at %s", renv_path_pretty(path))
+
+  body <- c(
+    if (length(reason)) paste("-", reason),
+    "- renv requires write access to this path to synchronize concurrent sessions."
+  )
+
+  abort(message, body = body, class = "renv_error_lock_unwritable")
+
+}
+
 # https://rcrowley.org/2010/01/06/things-unix-can-do-atomically.html
 renv_lock_acquire_impl <- function(path) {
 
@@ -47,15 +101,24 @@ renv_lock_acquire_impl <- function(path) {
     unlink(path, recursive = TRUE, force = TRUE)
   }
 
-  # attempt to create the lock
-  created <- dir.create(path, mode = "0755", showWarnings = FALSE)
+  # attempt to create the lock, retaining the warning describing why we
+  # couldn't -- it's normally the only thing that explains a failure which
+  # isn't just ordinary contention
+  reason <- NULL
+  created <- withCallingHandlers(
+    dir.create(path, mode = "0755"),
+    warning = function(cnd) {
+      reason <<- conditionMessage(cnd)
+      invokeRestart("muffleWarning")
+    }
+  )
 
   # if we created the lock, record its owner so that other processes can
   # tell whether the lock is still held by a live process on this machine
   if (created)
     renv_lock_owner_write(path)
 
-  created
+  list(acquired = created, reason = reason)
 
 }
 

--- a/R/lock.R
+++ b/R/lock.R
@@ -28,6 +28,9 @@ renv_lock_acquire <- function(path) {
   # setTimeLimit(), leaving callers with no way to bound the wait.
   # https://github.com/rstudio/renv/issues/2358
   failures <- 0L
+  blocked <- 0L
+  probefailures <- 0L
+  probeafter <- 3L
   repeat {
 
     status <- renv_lock_acquire_impl(path)
@@ -35,14 +38,22 @@ renv_lock_acquire <- function(path) {
       break
 
     # ordinary contention and a lock path we simply cannot write to are
-    # reported identically -- dir.create() just returns FALSE -- but only the
-    # former is worth waiting on. a missing lock after a failed create hints at
-    # the latter, so use it to gate an occasional probe of the parent directory,
-    # which then tells us for certain whether retrying could ever succeed.
-    failures <- if (file.exists(path)) 0L else failures + 1L
-    if (failures >= 3L) {
-      if (!renv_lock_writable(path))
-        renv_lock_acquire_abort(path, status$reason)
+    # reported identically -- dir.create() just returns FALSE -- so occasionally
+    # probe the parent directory to determine whether retrying could succeed.
+    failures <- failures + 1L
+    blocked <- if (status$blocked) blocked + 1L else 0L
+    if (failures >= probeafter) {
+      if (renv_lock_writable(path)) {
+        if (blocked >= 3L)
+          renv_lock_acquire_abort(path, status$reason)
+        probefailures <- 0L
+        probeafter <- if (renv_file_exists(path)) 25L else 3L
+      } else {
+        probefailures <- probefailures + 1L
+        if (probefailures >= 3L)
+          renv_lock_acquire_abort(path, status$reason)
+        probeafter <- probeafter * 2L
+      }
       failures <- 0L
     }
 
@@ -96,7 +107,8 @@ renv_lock_acquire_abort <- function(path, reason) {
 renv_lock_acquire_impl <- function(path) {
 
   # check for orphaned locks
-  if (renv_lock_orphaned(path)) {
+  orphaned <- renv_lock_orphaned(path)
+  if (orphaned) {
     dlog("lock", "%s: removing orphaned lock", path)
     unlink(path, recursive = TRUE, force = TRUE)
   }
@@ -118,7 +130,14 @@ renv_lock_acquire_impl <- function(path) {
   if (created)
     renv_lock_owner_write(path)
 
-  list(acquired = created, reason = reason)
+  # a stale lock we could not remove, or a non-directory entry at the lock
+  # path, cannot be resolved by retrying even when the parent is writable
+  info <- renv_file_info(path)
+  blocked <- !created &&
+    renv_file_exists(path) &&
+    (orphaned || !identical(info$isdir, TRUE))
+
+  list(acquired = created, reason = reason, blocked = blocked)
 
 }
 

--- a/tests/testthat/test-lock.R
+++ b/tests/testthat/test-lock.R
@@ -87,21 +87,44 @@ test_that("lock acquisition backs off, and remains interruptible", {
 
   skip_on_cran()
 
-  renv_scope_options(renv.config.locking.enabled = TRUE)
-  renv_scope_options(renv.lock.timeout = 1e6)
+  skip_if(
+    is.null(formals(system2)[["timeout"]]),
+    "system2() lacks the timeout argument"
+  )
 
   # simulate a lock held by another process, which we'll never manage to acquire
   path <- renv_lock_path(renv_scope_tempfile())
   dir.create(path)
 
+  result <- renv_scope_tempfile(fileext = ".rds")
   limit <- 2
-  timing <- system.time(
-    tryCatch({
-      setTimeLimit(elapsed = limit, transient = TRUE)
-      renv_lock_acquire(path)
-    }, error = function(cnd) NULL)
+  script <- renv_test_code(
+    {
+      options(renv.config.locking.enabled = TRUE)
+      options(renv.lock.timeout = 1e6)
+      timing <- system.time(
+        tryCatch({
+          setTimeLimit(elapsed = limit, transient = TRUE)
+          renv:::renv_lock_acquire(path)
+        }, error = function(cnd) NULL)
+      )
+      setTimeLimit()
+      saveRDS(timing, result)
+    },
+    list(path = path, limit = limit, result = result)
   )
-  setTimeLimit()
+
+  args <- c("--vanilla", "-s", "-f", shQuote(script))
+  status <- suppressWarnings(
+    system2(R(), args, stdout = FALSE, stderr = FALSE, timeout = 10L)
+  )
+
+  expect_equal(status, 0L)
+  expect_true(file.exists(result))
+  if (!file.exists(result))
+    return()
+
+  timing <- readRDS(result)
 
   # the loop has to sleep between attempts, so it should use almost no CPU, and
   # it has to let setTimeLimit()'s condition through rather than treating it as
@@ -112,10 +135,15 @@ test_that("lock acquisition backs off, and remains interruptible", {
 
 })
 
-test_that("acquiring a lock in an unwritable directory fails rather than hanging", {
+test_that("an unremovable lock fails rather than hanging", {
 
   skip_on_cran()
   skip_on_os("windows")
+
+  skip_if(
+    is.null(formals(system2)[["timeout"]]),
+    "system2() lacks the timeout argument"
+  )
 
   # root ignores the directory permissions we rely on here
   skip_if(
@@ -128,17 +156,68 @@ test_that("acquiring a lock in an unwritable directory fails rather than hanging
   parent <- renv_scope_tempfile("renv-lock-parent-")
   ensure_directory(parent)
 
-  # make the parent read-only, so the lock can never be created
+  # leave a stale lock in a read-only parent, so it cannot be removed
+  path <- file.path(parent, "lock")
+  dir.create(path)
   Sys.chmod(parent, mode = "0555")
   defer(Sys.chmod(parent, mode = "0755"))
 
-  # bound the wait, so that a regression here fails rather than hangs
-  setTimeLimit(elapsed = 30, transient = TRUE)
-  defer(setTimeLimit())
+  result <- renv_scope_tempfile(fileext = ".rds")
+  script <- renv_test_code(
+    {
+      options(renv.config.locking.enabled = TRUE)
+      options(renv.lock.timeout = -1L)
+      cnd <- tryCatch(
+        renv:::renv_lock_acquire(path),
+        renv_error_lock_unwritable = function(cnd) cnd
+      )
+      saveRDS(cnd, result)
+    },
+    list(path = path, result = result)
+  )
 
-  path <- file.path(parent, "lock")
-  expect_error(renv_lock_acquire(path), class = "renv_error_lock_unwritable")
-  expect_false(file.exists(path))
+  args <- c("--vanilla", "-s", "-f", shQuote(script))
+  status <- suppressWarnings(
+    system2(R(), args, stdout = FALSE, stderr = FALSE, timeout = 15L)
+  )
+
+  expect_equal(status, 0L)
+  expect_true(file.exists(result))
+  if (!file.exists(result))
+    return()
+
+  cnd <- readRDS(result)
+  expect_s3_class(cnd, "renv_error_lock_unwritable")
+  expect_length(cnd$meta$body, 2L)
+  expect_true(file.exists(path))
+
+})
+
+test_that("transient writability failures are retried", {
+
+  skip_on_cran()
+
+  path <- renv_lock_path(renv_scope_tempfile())
+  attempts <- 0L
+  probes <- 0L
+
+  local_mocked_bindings(
+    renv_lock_acquire_impl = function(path) {
+      attempts <<- attempts + 1L
+      if (attempts <= 9L)
+        return(list(acquired = FALSE, reason = "transient", blocked = FALSE))
+      dir.create(path)
+      list(acquired = TRUE, reason = NULL, blocked = FALSE)
+    },
+    renv_lock_writable = function(path) {
+      probes <<- probes + 1L
+      probes > 1L
+    }
+  )
+
+  expect_true(renv_lock_acquire(path))
+  expect_equal(probes, 2L)
+  renv_lock_release(path)
 
 })
 

--- a/tests/testthat/test-lock.R
+++ b/tests/testthat/test-lock.R
@@ -83,6 +83,65 @@ test_that("other processes cannot lock our owned locks", {
 
 })
 
+test_that("lock acquisition backs off, and remains interruptible", {
+
+  skip_on_cran()
+
+  renv_scope_options(renv.config.locking.enabled = TRUE)
+  renv_scope_options(renv.lock.timeout = 1e6)
+
+  # simulate a lock held by another process, which we'll never manage to acquire
+  path <- renv_lock_path(renv_scope_tempfile())
+  dir.create(path)
+
+  limit <- 2
+  timing <- system.time(
+    tryCatch({
+      setTimeLimit(elapsed = limit, transient = TRUE)
+      renv_lock_acquire(path)
+    }, error = function(cnd) NULL)
+  )
+  setTimeLimit()
+
+  # the loop has to sleep between attempts, so it should use almost no CPU, and
+  # it has to let setTimeLimit()'s condition through rather than treating it as
+  # one more reason to retry. previously it did neither. (#2358)
+  cpu <- timing[["user.self"]] + timing[["sys.self"]]
+  expect_lt(cpu, limit / 4)
+  expect_lt(timing[["elapsed"]], limit * 5)
+
+})
+
+test_that("acquiring a lock in an unwritable directory fails rather than hanging", {
+
+  skip_on_cran()
+  skip_on_os("windows")
+
+  # root ignores the directory permissions we rely on here
+  skip_if(
+    identical(Sys.info()[["effective_user"]], "root"),
+    "running as root"
+  )
+
+  renv_scope_options(renv.config.locking.enabled = TRUE)
+
+  parent <- renv_scope_tempfile("renv-lock-parent-")
+  ensure_directory(parent)
+
+  # make the parent read-only, so the lock can never be created
+  Sys.chmod(parent, mode = "0555")
+  defer(Sys.chmod(parent, mode = "0755"))
+
+  # bound the wait, so that a regression here fails rather than hangs
+  setTimeLimit(elapsed = 30, transient = TRUE)
+  defer(setTimeLimit())
+
+  path <- file.path(parent, "lock")
+  expect_error(renv_lock_acquire(path), class = "renv_error_lock_unwritable")
+  expect_false(file.exists(path))
+
+})
+
 test_that("locks are released on process exit", {
 
   skip_on_cran()


### PR DESCRIPTION
Fixes #2358.

## The bug

`renv_lock_acquire_impl()` reports contention by returning `FALSE`, so
`renv_lock_acquire_impl(path) && break` short-circuits, the `error =` handler
never runs, and `Sys.sleep(0.2)` is never reached. renv retries as fast as it
can, consuming a full core for as long as the lock is held.

The loop was correct when written in #1446, which paired it with:

```r
renv_scope_options(warn = 2L)     # "make sure warnings are errors here"
dir.create(path, mode = "0755")   # no showWarnings = FALSE
```

`dir.create()` warns on failure, `warn = 2L` promoted that warning to an error,
and the handler caught it -- the impl never *returned* `FALSE` on contention.
e56566dc3 ("avoid using warn = 2") replaced both halves of that mechanism and
left the loop untouched, making the handler unreachable. First released in renv
1.0.4.

There's a second, worse consequence. When the lock path isn't writable at all,
`dir.create()` fails identically to ordinary contention, so the loop has no
terminating condition. It can't be bounded by `setTimeLimit()` either, since
that signals an error the handler treats as one more reason to retry. Reached
via `renv/activate.R`, it presents as a silent hang that also ignores SIGINT --
R suspends interrupts while evaluating the startup profile. The reporter had
eight processes stuck for ~22 hours.

## The fix

- Drive the retry off the return value. Dropping the `tryCatch` also lets
  `setTimeLimit()` through, so callers can bound the wait at all.
- Retain the warning `dir.create()` emits instead of discarding it via
  `showWarnings = FALSE`. Under the caller's `warn = -1L` it was already
  invisible; now it's captured and muffled, so nothing new prints but the cause
  survives to be reported.
- Distinguish contention from an unwritable path so the loop can terminate.
  A missing lock after a failed create gates an occasional probe -- creating a
  pid-unique sibling directory -- which answers the question for certain. This
  matters because aborting on the missing-lock heuristic alone could misfire
  during a contention burst, and a spurious failure at R startup would be a
  worse bug than the one being fixed.

Users now get:

```
Error: renv failed to acquire the lock at ".../cache/sandbox.lock"
- cannot create dir '.../cache/sandbox.lock', reason 'Permission denied'
- renv requires write access to this path to synchronize concurrent sessions.
```

Via `renv_sandbox_activate()` this is caught and `warnify`'d, so the reported
startup scenario warns and continues rather than hanging.

## Verification

|                          | before          | after            |
| ------------------------ | --------------- | ---------------- |
| held lock, 5s wait       | 4.6s CPU        | 0.02s CPU        |
| unwritable lock path     | hangs forever   | errors in 0.41s  |
| `setTimeLimit()`         | swallowed       | propagates       |

Full suite passes (0 failures, 1677 passing).

## Note

The abort carries a `renv_error_lock_unwritable` class, so the new test can
assert on it precisely under a `setTimeLimit()` bound -- otherwise a regression
would hang the suite rather than fail it. renv doesn't use custom condition
classes anywhere else, so happy to drop it if you'd rather not start.
