### PR TITLE
prefer P3M as an available-package fallback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,12 @@
   which record is chosen is unchanged; renv simply no longer makes crandb and
   P3M requests whose results it cannot use.
 
+* On Windows and macOS, the available-package lookup once again consults the
+  P3M historical-binary database as a final fallback. Configured repositories,
+  crandb, and enabled repository archives retain precedence, and source-only
+  requests do not consult P3M. Missing records for newer R or platform versions
+  are treated as an ordinary miss while the database catches up.
+
 * Fixed an issue where `renv::sysreqs()` (and the system requirement checks
   performed during install and restore) would only report the first system
   package required by an R package. When a package's `SystemRequirements`

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,15 +14,15 @@
 
 * The available-package lookup now stops at the first source that can supply
   the package, rather than querying every source and discarding the extra
-  answers. Repositories still take precedence over crandb and the archive, so
-  which record is chosen is unchanged; renv simply no longer makes crandb and
-  P3M requests whose results it cannot use.
+  answers. Repositories still take precedence over P3M, crandb, and the archive,
+  so renv no longer makes fallback requests whose results it cannot use.
 
 * On Windows and macOS, the available-package lookup once again consults the
-  P3M historical-binary database as a final fallback. Configured repositories,
-  crandb, and enabled repository archives retain precedence, and source-only
-  requests do not consult P3M. Missing records for newer R or platform versions
-  are treated as an ordinary miss while the database catches up.
+  P3M historical-binary database when configured repositories have no
+  candidate. P3M binaries are preferred over crandb version hints and enabled
+  repository archives, while source-only requests do not consult P3M. Missing
+  records for newer R or platform versions are treated as an ordinary miss
+  while the database catches up.
 
 * Fixed an issue where `renv::sysreqs()` (and the system requirement checks
   performed during install and restore) would only report the first system

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -410,18 +410,16 @@ renv_available_packages_latest <- function(package,
   # packages still live on CRAN (#1735), or a source build where the
   # repositories had a binary all along (#2345)
   #
-  # P3M is deliberately not in this list. it stopped being consulted here in
-  # #1771, when the archive method was inserted ahead of it -- but that is also
-  # what stopped renv preferring a newer P3M binary over the pinned repository
-  # snapshot a user actually configured (#1901), and
-  # renv_available_packages_latest_p3m() still ignores `repos` entirely.
-  # bringing it back is a separate decision, not a side effect of repairing
-  # this ordering
+  # P3M comes last: it can provide a historical binary when none of the
+  # configured repositories or other fallbacks names a candidate, but it must
+  # not override the version selected by a configured repository (#1901)
   methods <- list(
     renv_available_packages_latest_repos,
     renv_available_packages_latest_crandb,
     if (getOption("renv.install.allowArchivedPackages", default = FALSE))
-      renv_available_packages_latest_archive
+      renv_available_packages_latest_archive,
+    if (renv_p3m_enabled(type))
+      renv_available_packages_latest_p3m
   )
 
   errors <- stack()
@@ -453,17 +451,13 @@ renv_available_packages_latest <- function(package,
 
 }
 
-# NOTE: currently unreferenced -- see renv_available_packages_latest() for why
-# P3M is not consulted when picking a latest version. kept here because reviving
-# it is a live option, but it would need to honor `repos` and a database that
-# covers current R releases first
 renv_available_packages_latest_p3m <- function(package,
                                                type = NULL,
                                                repos = NULL)
 {
   type <- type %||% getOption("pkgType", default = "source")
   if (identical(type, "source"))
-    stop("binary packages are not available")
+    return(NULL)
 
   # ensure local p3m database is up-to-date
   renv_p3m_database_refresh(explicit = FALSE)
@@ -477,14 +471,14 @@ renv_available_packages_latest_p3m <- function(package,
   suffix <- contrib.url("", type = "binary")
   entry <- database[[suffix]]
   if (is.null(entry))
-    stopf("no records available from repository URL '%s'", suffix)
+    return(NULL)
 
   # find all available packages
   keys <- attr(entry, "keys")
   pattern <- paste0("^", package, " ")
   matching <- grep(pattern, keys, perl = TRUE, value = TRUE)
   if (empty(matching))
-    stopf("package '%s' is not available", package)
+    return(NULL)
 
   # take the latest-available package
   entries <- unlist(mget(matching, envir = entry))

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -410,16 +410,17 @@ renv_available_packages_latest <- function(package,
   # packages still live on CRAN (#1735), or a source build where the
   # repositories had a binary all along (#2345)
   #
-  # P3M comes last: it can provide a historical binary when none of the
-  # configured repositories or other fallbacks names a candidate, but it must
-  # not override the version selected by a configured repository (#1901)
+  # P3M comes next: when the repositories have no candidate, prefer a concrete
+  # historical binary over the version hint from crandb or a source archive.
+  # the repositories still get the first word, so P3M cannot override a version
+  # selected by a configured repository (#1901)
   methods <- list(
     renv_available_packages_latest_repos,
+    if (renv_p3m_enabled(type))
+      renv_available_packages_latest_p3m,
     renv_available_packages_latest_crandb,
     if (getOption("renv.install.allowArchivedPackages", default = FALSE))
-      renv_available_packages_latest_archive,
-    if (renv_p3m_enabled(type))
-      renv_available_packages_latest_p3m
+      renv_available_packages_latest_archive
   )
 
   errors <- stack()

--- a/R/p3m.R
+++ b/R/p3m.R
@@ -1,6 +1,7 @@
 
-renv_p3m_enabled <- function() {
-  !identical(getOption("pkgType"), "source") && config$ppm.enabled()
+renv_p3m_enabled <- function(type = NULL) {
+  type <- type %||% getOption("pkgType", default = "source")
+  !identical(type, "source") && config$ppm.enabled()
 }
 
 renv_p3m_database_path <- function() {

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -563,15 +563,17 @@ test_that("configured repositories take precedence over P3M (#1901)", {
 
 })
 
-test_that("P3M is used as a final available-package fallback", {
+test_that("P3M is preferred over later available-package fallbacks", {
 
   renv_tests_scope()
   renv_scope_options(
-    renv.config.crandb.enabled = FALSE,
-    renv.install.allowArchivedPackages = FALSE
+    renv.config.crandb.enabled = TRUE,
+    renv.install.allowArchivedPackages = TRUE
   )
 
   enabled_type <- NULL
+  crandb_called <- FALSE
+  archive_called <- FALSE
   local_mocked_bindings(
     renv_available_packages_latest_repos = function(...) NULL,
     renv_p3m_enabled = function(type = NULL) {
@@ -588,6 +590,19 @@ test_that("P3M is used as a final available-package fallback", {
         ),
         type = "binary"
       )
+    },
+    renv_available_packages_latest_crandb = function(...) {
+      crandb_called <<- TRUE
+      NULL
+    },
+    renv_available_packages_latest_archive = function(package, ...) {
+      archive_called <<- TRUE
+      list(
+        Package    = package,
+        Version    = "8.8.8",
+        Source     = "Repository",
+        Repository = "CRAN"
+      )
     }
   )
 
@@ -596,6 +611,8 @@ test_that("P3M is used as a final available-package fallback", {
   expect_identical(enabled_type, "binary")
   expect_equal(record$Version, "9.9.9")
   expect_identical(attr(record, "type", exact = TRUE), "binary")
+  expect_false(crandb_called)
+  expect_false(archive_called)
 
 })
 

--- a/tests/testthat/test-available-packages.R
+++ b/tests/testthat/test-available-packages.R
@@ -532,20 +532,15 @@ test_that("the repositories short-circuit the later lookup methods", {
 
 })
 
-test_that("P3M is not consulted when picking a latest version (#1901)", {
+test_that("configured repositories take precedence over P3M (#1901)", {
 
   renv_tests_scope()
   renv_scope_options(renv.config.crandb.enabled = FALSE)
 
-  # P3M ignores the configured repositories entirely, so letting it name a
-  # version means renv can prefer a P3M binary over the pinned repository
-  # snapshot the user actually asked for
-  # force the conditions under which P3M would be eligible, so this actually
-  # asserts something on platforms where the test scope leaves it disabled
   enabled_called <- FALSE
   latest_called <- FALSE
   local_mocked_bindings(
-    renv_p3m_enabled = function() {
+    renv_p3m_enabled = function(type = NULL) {
       enabled_called <<- TRUE
       TRUE
     },
@@ -562,9 +557,86 @@ test_that("P3M is not consulted when picking a latest version (#1901)", {
 
   record <- renv_available_packages_latest("bread")
 
-  expect_false(enabled_called)
+  expect_true(enabled_called)
   expect_false(latest_called)
   expect_equal(record$Version, "1.0.0")
+
+})
+
+test_that("P3M is used as a final available-package fallback", {
+
+  renv_tests_scope()
+  renv_scope_options(
+    renv.config.crandb.enabled = FALSE,
+    renv.install.allowArchivedPackages = FALSE
+  )
+
+  enabled_type <- NULL
+  local_mocked_bindings(
+    renv_available_packages_latest_repos = function(...) NULL,
+    renv_p3m_enabled = function(type = NULL) {
+      enabled_type <<- type
+      TRUE
+    },
+    renv_available_packages_latest_p3m = function(package, ...) {
+      structure(
+        list(
+          Package    = package,
+          Version    = "9.9.9",
+          Source     = "Repository",
+          Repository = "P3M"
+        ),
+        type = "binary"
+      )
+    }
+  )
+
+  record <- renv_available_packages_latest("bread", type = "binary")
+
+  expect_identical(enabled_type, "binary")
+  expect_equal(record$Version, "9.9.9")
+  expect_identical(attr(record, "type", exact = TRUE), "binary")
+
+})
+
+test_that("P3M eligibility respects the requested package type", {
+
+  renv_tests_scope()
+  renv_scope_options(
+    pkgType = "source",
+    renv.config.ppm.enabled = TRUE
+  )
+
+  expect_false(renv_p3m_enabled())
+  expect_false(renv_p3m_enabled("source"))
+  expect_true(renv_p3m_enabled("binary"))
+
+})
+
+test_that("ordinary P3M misses are quiet", {
+
+  renv_tests_scope()
+
+  refreshed <- FALSE
+  database <- new.env(parent = emptyenv())
+  local_mocked_bindings(
+    renv_p3m_database_refresh = function(...) refreshed <<- TRUE,
+    renv_p3m_database_load = function(...) database
+  )
+
+  expect_null(renv_available_packages_latest_p3m("bread", type = "binary"))
+  expect_true(refreshed)
+
+  suffix <- contrib.url("", type = "binary")
+  entry <- new.env(parent = emptyenv())
+  attr(entry, "keys") <- "breakfast 1.0.0"
+  database[[suffix]] <- entry
+
+  expect_null(renv_available_packages_latest_p3m("bread", type = "binary"))
+
+  refreshed <- FALSE
+  expect_null(renv_available_packages_latest_p3m("bread", type = "source"))
+  expect_false(refreshed)
 
 })
 


### PR DESCRIPTION
## Summary

- restore P3M historical binaries as the first fallback after configured repositories
- prefer a concrete P3M binary over crandb version hints and enabled source archives
- preserve configured-repository precedence so P3M cannot override pinned repository candidates
- skip P3M for source-only requests and treat missing database records as ordinary misses
- add regression coverage for repository precedence, fallback ordering, package type handling, and quiet misses

## Tests

- focused available-packages test suite
- full test suite (existing warnings and skips only)
- git diff --check