### PR TITLE
sync p3m database for R 4.5 and 4.6

### DIFF
--- a/R/p3m.R
+++ b/R/p3m.R
@@ -108,8 +108,10 @@ renv_p3m_database_dates <- function(version, all = TRUE) {
     "4.2" = "2022-04-22",
     "4.3" = "2023-04-21",
     "4.4" = "2024-04-24",
-    "4.5" = "2025-05-18",  # a guess
-    "4.6" = "2026-05-18",  # a guess
+    "4.5" = "2025-04-11",
+    "4.6" = "2026-04-24",
+    "4.7" = "2027-04-24",  # a guess
+    "4.8" = "2028-04-24",  # a guess
     NULL
   )
 
@@ -322,7 +324,10 @@ renv_p3m_database_sync_all <- function() {
 renv_p3m_database_sync_all_impl <- function() {
 
   # NOTE: this needs to be manually updated since the binary URL for
-  # packages can change from version to version, especially on macOS
+  # packages can change from version to version, especially on macOS.
+  # the keys are looked up via contrib.url(), so they must match the
+  # layout of https://cran.r-project.org/bin/macosx/ exactly -- p3m
+  # serves other spellings too, but no R installation asks for them.
 
 #  # R 3.2
 #  renv_p3m_database_sync("windows", "3.2")
@@ -360,12 +365,22 @@ renv_p3m_database_sync_all_impl <- function() {
 
   # R 4.3
   renv_p3m_database_sync("windows", "4.3")
-  renv_p3m_database_sync("macosx", "4.3")
+  renv_p3m_database_sync("macosx/big-sur-x86_64", "4.3")
   renv_p3m_database_sync("macosx/big-sur-arm64", "4.3")
-  
+
   # R 4.4
   renv_p3m_database_sync("windows", "4.4")
-  renv_p3m_database_sync("macosx", "4.4")
+  renv_p3m_database_sync("macosx/big-sur-x86_64", "4.4")
   renv_p3m_database_sync("macosx/big-sur-arm64", "4.4")
+
+  # R 4.5
+  renv_p3m_database_sync("windows", "4.5")
+  renv_p3m_database_sync("macosx/big-sur-x86_64", "4.5")
+  renv_p3m_database_sync("macosx/big-sur-arm64", "4.5")
+
+  # R 4.6
+  renv_p3m_database_sync("windows", "4.6")
+  renv_p3m_database_sync("macosx/big-sur-x86_64", "4.6")
+  renv_p3m_database_sync("macosx/sonoma-arm64", "4.6")
 
 }


### PR DESCRIPTION
The P3M package database tops out at R 4.4. The published `packages.rds` (downloaded fresh today) has no entries for 4.5 or 4.6:

```
                                   key     n    maxdate
 /bin/macosx/big-sur-arm64/contrib/4.1 12724 2023-04-21
 /bin/macosx/big-sur-arm64/contrib/4.2 27678 2024-05-18
 /bin/macosx/big-sur-arm64/contrib/4.3 38917 2025-05-18
 /bin/macosx/big-sur-arm64/contrib/4.4 44354 2026-05-18
               /bin/macosx/contrib/4.1 12975 2023-04-21
               ... (4.2, 4.3, 4.4)
              /bin/windows/contrib/4.1 43496 2023-04-21
               ... (4.2, 4.3, 4.4)
```

`renv_retrieve_repos_p3m()` looks the entry up by `contrib.url("", type = "binary")` and returns `FALSE` when it's `NULL`, so on R 4.5 and 4.6 historical binary retrieval from P3M is currently a silent no-op.

### Changes

**Add 4.5 and 4.6 to `renv_p3m_database_sync_all_impl()`.**

**Correct the guessed release dates and add placeholders two releases ahead.** Per CRAN's `src/base/R-4/`, R 4.5.0 shipped 2025-04-11 (table said 2025-05-18) and R 4.6.0 shipped 2026-04-24 (table said 2026-05-18). `renv_p3m_database_dates()` reads `releases[[index + 2L]]` to compute its end date, so with the table ending at 4.6 both new versions errored outright:

```
4.4 : 2024-04-24 .. 2026-05-18
4.5 : subscript out of bounds
4.6 : subscript out of bounds
```

Adding 4.7/4.8 placeholders fixes that.

**Use `macosx/big-sur-x86_64` instead of `macosx` for R 4.3 and 4.4.** CRAN's actual layout under `bin/macosx/`:

| contrib dir | R versions served |
|---|---|
| `macosx/contrib` | 4.0, 4.1, 4.2 |
| `macosx/big-sur-x86_64/contrib` | 4.3, 4.4, 4.5, 4.6 |
| `macosx/big-sur-arm64/contrib` | 4.2, 4.3, 4.4, 4.5 |
| `macosx/sonoma-arm64/contrib` | 4.6 |

Intel macOS asks for `big-sur-x86_64` from 4.3 onward, so the existing `macosx/contrib/4.3` and `macosx/contrib/4.4` keys are dead weight -- no R installation ever looks them up. P3M serves both spellings, which is why this went unnoticed. arm64 likewise moves from `big-sur-arm64` to `sonoma-arm64` at 4.6.

The `NOTE` comment above the sync list now records this, since it's the part that keeps drifting.

### Verification

All six versions resolve, with 4.5/4.6 correctly clamped to today:

```
4.1  2021-05-18 .. 2023-04-21  (704 days)
4.2  2022-04-22 .. 2024-04-24  (734 days)
4.3  2023-04-21 .. 2025-04-11  (722 days)
4.4  2024-04-24 .. 2026-04-24  (731 days)
4.5  2025-04-11 .. 2026-08-25  (502 days)
4.6  2026-04-24 .. 2026-08-25  (124 days)
```

A single-date smoke test (2026-08-20) against a throwaway `RENV_PATHS_ROOT` confirms every new or changed combo fetches and parses:

```
  /bin/macosx/big-sur-arm64/contrib/4.5 21832
 /bin/macosx/big-sur-x86_64/contrib/4.3 21526
 /bin/macosx/big-sur-x86_64/contrib/4.4 21756
 /bin/macosx/big-sur-x86_64/contrib/4.5 21967
 /bin/macosx/big-sur-x86_64/contrib/4.6 21352
   /bin/macosx/sonoma-arm64/contrib/4.6 21752
               /bin/windows/contrib/4.5 24043
               /bin/windows/contrib/4.6 24583
```

That `sonoma-arm64/contrib/4.6` key is exactly what `contrib.url("", type = "binary")` returns on R 4.6.1 arm64, so the retrieval lookup will now hit.

### Notes

- The corrected dates end 4.3 and 4.4 earlier than the published database is already synced to (2025-05-18 / 2026-05-18). `renv_p3m_database_sync()` returns early when `last >= now`, so those become no-ops rather than errors -- but they also won't be re-synced.
- This only fixes the code that generates the database. The database itself still needs `renv_p3m_database_sync_all()` run and the result uploaded to `rstudio-buildtools.s3.amazonaws.com/renv/package-manager/packages.rds`. Adding four platform/version combos will grow the current 868 KB file appreciably.
- No NEWS entry, matching the precedent of 071513bf9 ("prepare database updates").
