### PR TITLE
Avoid encoding warnings in R script header checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # renv (development version)
 
+* `renv::dependencies()` no longer emits encoding warnings when checking R
+  script headers containing non-ASCII text in a different encoding from the
+  current locale. This also avoids failures when warnings are treated as
+  errors. (#2362)
+
 * Fixed an issue where renv computed the wrong Posit Package Manager binary
   URL on some Enterprise Linux distributions. CentOS Stream 9 and 10 were
   mapped to the non-existent `centos9` and `centos1` platforms rather than

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1216,7 +1216,9 @@ renv_dependencies_discover_r <- function(path  = NULL,
   # https://github.com/rstudio/renv/issues/2023
   if (is.character(text) || is.character(path)) {
     text <- text %||% readLines(path, n = 1L, warn = FALSE)
-    if (length(text) && grepl("^\\s*#'\\s*[-]{3}\\s*$", text[[1L]], perl = TRUE))
+    # Match bytes so comments in other encodings do not cause warnings.
+    pattern <- "^\\s*#'\\s*[-]{3}\\s*$"
+    if (length(text) && grepl(pattern, text[[1L]], perl = TRUE, useBytes = TRUE))
       packages <- union(c("knitr", "rmarkdown"), packages)
   }
 

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -785,6 +785,23 @@ test_that("R scripts that appear destined for knitr::spin() are detected", {
   expect_contains(result$Package, c("knitr", "rmarkdown"))
 })
 
+test_that("R script header checks tolerate non-native encodings", {
+
+  # https://github.com/rstudio/renv/issues/2362
+  comment <- paste("#", intToUtf8(c(0x4e2d, 0x6587, 0x6d4b, 0x8bd5)))
+  text <- c(comment, "library(dplyr)")
+
+  for (encoding in c("UTF-8", "GBK")) {
+    file <- renv_scope_tempfile(fileext = ".R")
+    encoded <- iconv(text, from = "UTF-8", to = encoding)
+    writeLines(encoded, file, useBytes = TRUE)
+
+    expect_no_warning(deps <- dependencies(file, quiet = TRUE))
+    expect_equal(deps$Package, "dplyr")
+  }
+
+})
+
 test_that("renv infers a dev. dependency on lintr", {
   project <- renv_tests_scope()
   file.create(".lintr")


### PR DESCRIPTION
Dependency discovery can emit encoding warnings when a UTF-8 R script is read in a GBK locale, and fail when warnings are treated as errors. The script parses successfully, but the subsequent `knitr::spin()` header check interprets its first line using the native encoding.

Match the ASCII header pattern with `useBytes = TRUE`. This handles both UTF-8 and native-encoded files; forcing the second read to UTF-8 would introduce warnings for valid GBK files. Includes a regression test and NEWS entry.

Fixes #2362.

Validation:

- Confirmed the regression test fails before the fix.
- Dependency and parser tests passed, with two existing empty tests skipped.
- UTF-8 files, GBK files, and UTF-8 text input passed in a GBK locale with `options(warn = 2)` on macOS with R 4.6.1. The original Windows environment was not tested locally.
