### PR TITLE
avoid forking the R session in Positron

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # renv (development version)
 
+* `renv::update()` no longer tries to fork the R session when checking
+  packages installed from non-CRAN remotes within Positron, whose R kernel
+  forbids forking. Such checks now run sequentially there, as they already do
+  on Windows. (#2364)
+
 * `renv::dependencies()` no longer emits encoding warnings when checking R
   script headers containing non-ASCII text in a different encoding from the
   current locale. This also avoids failures when warnings are treated as

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -1,7 +1,9 @@
 
 renv_parallel_cores <- function() {
 
-  if (renv_platform_windows())
+  # forking is unsupported on Windows, and Positron's ark kernel blocks it
+  # outright (posit-dev/positron#3817), so run sequentially in both cases
+  if (renv_platform_windows() || renv_platform_positron())
     return(1L)
 
   parallel <- config$updates.parallel()

--- a/R/platform.R
+++ b/R/platform.R
@@ -37,6 +37,10 @@ renv_platform_windows <- function() {
   .Platform$OS.type == "windows"
 }
 
+renv_platform_positron <- function() {
+  Sys.getenv("POSITRON") == "1"
+}
+
 renv_platform_macos <- function() {
   the$sysinfo[["sysname"]] == "Darwin"
 }

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -141,6 +141,16 @@ test_that("we guard against invalid mc.cores values", {
 
 })
 
+test_that("we don't fork in Positron", {
+
+  skip_on_windows()
+  renv_scope_options(renv.config.updates.parallel = TRUE, mc.cores = 4L)
+  renv_scope_envvars(POSITRON = "1")
+
+  expect_equal(renv_parallel_cores(), 1L)
+
+})
+
 test_that("update() ignores packages in other libraries by default", {
 
   skip_on_cran()


### PR DESCRIPTION
Fixes #2364.

Positron 2026.08+ ships a fork guard in ark that replaces `parallel:::mcfork()` with a stub that errors (posit-dev/positron#3817). renv's `renv_parallel_exec()` uses `parallel::mclapply()` when checking non-CRAN remotes for updates, and the default `updates.parallel = 2` meant any project with two or more GitHub packages failed with:

```
Error:
! Can't fork the R session in Positron.
```

Forking will never work there, so this treats Positron like Windows in `renv_parallel_cores()` and runs the checks sequentially. Positron is detected via the `POSITRON=1` environment variable, the same check devtools, usethis, and testthat use.

Verified by simulating ark's `mcfork` shim locally: `renv_parallel_exec()` on two elements fails on `main` and succeeds with this change when `POSITRON=1` is set.